### PR TITLE
bug: Fixed bug with draw mode icon being out of sync

### DIFF
--- a/map-sketching/README.md
+++ b/map-sketching/README.md
@@ -18,7 +18,7 @@ This sample demonstrates how you can sketch graphics on a SketchGraphicsOverlay.
   1. Tap the point icon in the bottom left.
   2. Single tap on the map. A red placement symbol will be drawn on the map.
   3. Optionally, tap again or drag the placement symbol to reposition the point.
-  4. Long press to finish the point, which will change to a blue placed symbol.
+  4. Long press or tap point icon to finish the point, which will change to a blue placed symbol.
 
 #### Sketch Polyline
 
@@ -26,7 +26,7 @@ This sample demonstrates how you can sketch graphics on a SketchGraphicsOverlay.
   2. Single tap on the map. A red placement symbol will be drawn on the map.
   3. All additional single taps will add a new point, change the symbol of the previous point to the polyline vertex symbol and add a midpoint to the new line segment.
   4. Optionally, any vertex or midpoint can be single tapped to select it, and then dragged to reposition it.
-  5. Long press to finish the polyline, which will change the final working point to the polyline vertex symbol, remove all midpoints, and change the line color to blue.
+  5. Long press or tap polyline icon to finish the polyline, which will change the final working point to the polyline vertex symbol, remove all midpoints, and change the line color to blue.
 
 #### Sketch Polygon
 
@@ -34,7 +34,7 @@ This sample demonstrates how you can sketch graphics on a SketchGraphicsOverlay.
   2. Single tap on the map. A red placement symbol will be drawn on the map.
   3. All additional single taps will add a new point, change the symbol of the previous point to the polyline vertex symbol and add a midpoint to the new line segment. Once three or more points are sketched, the polygon will be drawn within the polyline.
   4. Optionally, any vertex or midpoint can be single tapped to select it, and then dragged to reposition it.
-  5. Long press to finish the polygon, which will change the final working point to the polyline vertex symbol, remove all midpoints, and change the line color to blue.
+  5. Long press or tap polygon icon to finish the polygon, which will change the final working point to the polyline vertex symbol, remove all midpoints, and change the line color to blue.
 
 #### Undo
 

--- a/map-sketching/src/main/java/com/esri/arcgisruntime/sample/mapsketching/MainActivity.java
+++ b/map-sketching/src/main/java/com/esri/arcgisruntime/sample/mapsketching/MainActivity.java
@@ -90,8 +90,12 @@ public class MainActivity extends AppCompatActivity {
    * @param v the button view
    */
   public void pointClick(View v) {
-    v.setSelected(true);
-    mSketchGraphicsOverlay.setDrawingMode(SketchGraphicsOverlay.DrawingMode.POINT);
+    if (!v.isSelected()) {
+      v.setSelected(true);
+      mSketchGraphicsOverlay.setDrawingMode(SketchGraphicsOverlay.DrawingMode.POINT);
+    } else {
+      mSketchGraphicsOverlay.setDrawingMode(SketchGraphicsOverlay.DrawingMode.NONE);
+    }
   }
 
   /**
@@ -100,8 +104,12 @@ public class MainActivity extends AppCompatActivity {
    * @param v the button view
    */
   public void polylineClick(View v) {
-    v.setSelected(true);
-    mSketchGraphicsOverlay.setDrawingMode(SketchGraphicsOverlay.DrawingMode.POLYLINE);
+    if (!v.isSelected()) {
+      v.setSelected(true);
+      mSketchGraphicsOverlay.setDrawingMode(SketchGraphicsOverlay.DrawingMode.POLYLINE);
+    } else {
+      mSketchGraphicsOverlay.setDrawingMode(SketchGraphicsOverlay.DrawingMode.NONE);
+    }
   }
 
   /**
@@ -110,8 +118,12 @@ public class MainActivity extends AppCompatActivity {
    * @param v the button view
    */
   public void polygonClick(View v) {
-    v.setSelected(true);
-    mSketchGraphicsOverlay.setDrawingMode(SketchGraphicsOverlay.DrawingMode.POLYGON);
+    if (!v.isAccessibilityFocused()) {
+      v.setSelected(true);
+      mSketchGraphicsOverlay.setDrawingMode(SketchGraphicsOverlay.DrawingMode.POLYGON);
+    } else {
+      mSketchGraphicsOverlay.setDrawingMode(SketchGraphicsOverlay.DrawingMode.NONE);
+    }
   }
 
   /**


### PR DESCRIPTION
When drawing, if the user clicked the icon again (rather than long press) the drawing would complete, but then the next time the icon was pressed it would not enter the 'selected' state and would therefore be unclear to the user whether they were actually able to draw or not.

This was addressed by setting the draw mode to 'NONE' explicitly when unselected a draw mode icon

#78 