### PR TITLE
Updated onStatusChanged listener to use new API for errors

### DIFF
--- a/display-device-location/src/main/java/com/esri/arcgisruntime/sample/displaydevicelocation/MainActivity.java
+++ b/display-device-location/src/main/java/com/esri/arcgisruntime/sample/displaydevicelocation/MainActivity.java
@@ -74,7 +74,7 @@ public class MainActivity extends AppCompatActivity {
           return;
 
         // No error is reported, then continue.
-        if (dataSourceStatusChangedEvent.getSource().getLocationDataSource().getError() == null)
+        if (dataSourceStatusChangedEvent.getError() == null)
           return;
 
         // If an error is found, handle the failure to start.


### PR DESCRIPTION
To find out if you've called startAsync on the LocationDisplay but it's failed, you can now check the error object on the event argument passed in (instead of getting this from the data source from the source object from the parameter).

This one-line change updates the sample to use this new API member.

@doneill - could you review this please?