### PR TITLE
Trev8939/blend renderer

### DIFF
--- a/blend-renderer/src/main/java/com/esri/arcgisruntime/sample/blendrenderer/MainActivity.java
+++ b/blend-renderer/src/main/java/com/esri/arcgisruntime/sample/blendrenderer/MainActivity.java
@@ -133,8 +133,8 @@ public class MainActivity extends AppCompatActivity implements ParametersDialogF
   private void updateRenderer() {
     ColorRamp colorRamp = mColorRampType != ColorRamp.PresetType.NONE ? new ColorRamp(mColorRampType, 800) : null;
     // if color ramp is not NONE, color the hillshade elevation raster instead of using satellite imagery raster color
-    RasterLayer mRasterLayer = colorRamp != null ? new RasterLayer(mElevationRaster) : new RasterLayer(mImageryRaster);
-    mMapView.getMap().setBasemap(new Basemap(mRasterLayer));
+    RasterLayer rasterLayer = colorRamp != null ? new RasterLayer(mElevationRaster) : new RasterLayer(mImageryRaster);
+    mMapView.getMap().setBasemap(new Basemap(rasterLayer));
     // create blend renderer
     BlendRenderer blendRenderer = new BlendRenderer(
         mElevationRaster,
@@ -152,7 +152,7 @@ public class MainActivity extends AppCompatActivity implements ParametersDialogF
         mPixelSizeFactor,
         mPixelSizePower,
         mOutputBitDepth);
-    mRasterLayer.setRasterRenderer(blendRenderer);
+    rasterLayer.setRasterRenderer(blendRenderer);
   }
 
   /**

--- a/blend-renderer/src/main/java/com/esri/arcgisruntime/sample/blendrenderer/MainActivity.java
+++ b/blend-renderer/src/main/java/com/esri/arcgisruntime/sample/blendrenderer/MainActivity.java
@@ -33,10 +33,6 @@ public class MainActivity extends AppCompatActivity implements ParametersDialogF
 
   private File mElevationFile;
 
-  private Raster mImageryRaster;
-
-  private Raster mElevationRaster;
-
   private int mAltitude;
 
   private int mAzimuth;
@@ -136,14 +132,14 @@ public class MainActivity extends AppCompatActivity implements ParametersDialogF
     // if color ramp type is not None, create a new ColorRamp
     ColorRamp colorRamp = mColorRampType != ColorRamp.PresetType.NONE ? new ColorRamp(mColorRampType, 800) : null;
     // create rasters
-    mImageryRaster = new Raster(mImageFile.getAbsolutePath());
-    mElevationRaster = new Raster(mElevationFile.getAbsolutePath());
+    Raster imageryRaster = new Raster(mImageFile.getAbsolutePath());
+    Raster elevationRaster = new Raster(mElevationFile.getAbsolutePath());
     // if color ramp is not NONE, color the hillshade elevation raster instead of using satellite imagery raster color
-    RasterLayer rasterLayer = colorRamp != null ? new RasterLayer(mElevationRaster) : new RasterLayer(mImageryRaster);
+    RasterLayer rasterLayer = colorRamp != null ? new RasterLayer(elevationRaster) : new RasterLayer(imageryRaster);
     mMapView.getMap().setBasemap(new Basemap(rasterLayer));
     // create blend renderer
     BlendRenderer blendRenderer = new BlendRenderer(
-        mElevationRaster,
+        elevationRaster,
         Collections.singletonList(9.0),
         Collections.singletonList(255.0),
         null,

--- a/blend-renderer/src/main/java/com/esri/arcgisruntime/sample/blendrenderer/MainActivity.java
+++ b/blend-renderer/src/main/java/com/esri/arcgisruntime/sample/blendrenderer/MainActivity.java
@@ -29,6 +29,10 @@ public class MainActivity extends AppCompatActivity implements ParametersDialogF
 
   private MapView mMapView;
 
+  private File mImageFile;
+
+  private File mElevationFile;
+
   private Raster mImageryRaster;
 
   private Raster mElevationRaster;
@@ -111,15 +115,13 @@ public class MainActivity extends AppCompatActivity implements ParametersDialogF
   }
 
   /**
-   * Creates new imagery and elevation rasters based on a given path, creates an ArcGISMap, sets it to a MapView and
+   * Creates new imagery and elevation files based on a given path, creates an ArcGISMap, sets it to a MapView and
    * calls updateRenderer().
    */
   private void blendRenderer() {
-    // create rasters
-    mImageryRaster = new Raster(
-        new File(buildRasterPath(this.getString(R.string.imagery_raster_name))).getAbsolutePath());
-    mElevationRaster = new Raster(
-        new File(buildRasterPath(this.getString(R.string.elevation_raster_name))).getAbsolutePath());
+    // create raster files
+    mImageFile = new File(buildRasterPath(this.getString(R.string.imagery_raster_name)));
+    mElevationFile = new File(buildRasterPath(this.getString(R.string.elevation_raster_name)));
     // create a map
     ArcGISMap map = new ArcGISMap();
     // add the map to a map view
@@ -131,7 +133,11 @@ public class MainActivity extends AppCompatActivity implements ParametersDialogF
    * Creates ColorRamp and BlendRenderer according to the chosen property values.
    */
   private void updateRenderer() {
+    // if color ramp type is not None, create a new ColorRamp
     ColorRamp colorRamp = mColorRampType != ColorRamp.PresetType.NONE ? new ColorRamp(mColorRampType, 800) : null;
+    // create rasters
+    mImageryRaster = new Raster(mImageFile.getAbsolutePath());
+    mElevationRaster = new Raster(mElevationFile.getAbsolutePath());
     // if color ramp is not NONE, color the hillshade elevation raster instead of using satellite imagery raster color
     RasterLayer rasterLayer = colorRamp != null ? new RasterLayer(mElevationRaster) : new RasterLayer(mImageryRaster);
     mMapView.getMap().setBasemap(new Basemap(rasterLayer));

--- a/blend-renderer/src/main/java/com/esri/arcgisruntime/sample/blendrenderer/MainActivity.java
+++ b/blend-renderer/src/main/java/com/esri/arcgisruntime/sample/blendrenderer/MainActivity.java
@@ -16,8 +16,6 @@
 
 package com.esri.arcgisruntime.sample.blendrenderer;
 
-import java.io.File;
-import java.util.Collections;
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -31,7 +29,6 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.Toast;
-
 import com.esri.arcgisruntime.layers.RasterLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.Basemap;
@@ -41,28 +38,22 @@ import com.esri.arcgisruntime.raster.ColorRamp;
 import com.esri.arcgisruntime.raster.Raster;
 import com.esri.arcgisruntime.raster.SlopeType;
 
+import java.io.File;
+import java.util.Collections;
+
 public class MainActivity extends AppCompatActivity implements ParametersDialogFragment.ParametersListener {
 
   private MapView mMapView;
-
   private File mImageFile;
-
   private File mElevationFile;
 
   private int mAltitude;
-
   private int mAzimuth;
-
   private double mZFactor;
-
   private SlopeType mSlopeType;
-
   private ColorRamp.PresetType mColorRampType;
-
   private double mPixelSizeFactor;
-
   private double mPixelSizePower;
-
   private int mOutputBitDepth;
 
   private FragmentManager mFragmentManager;

--- a/blend-renderer/src/main/java/com/esri/arcgisruntime/sample/blendrenderer/ParametersDialogFragment.java
+++ b/blend-renderer/src/main/java/com/esri/arcgisruntime/sample/blendrenderer/ParametersDialogFragment.java
@@ -16,8 +16,6 @@
 
 package com.esri.arcgisruntime.sample.blendrenderer;
 
-import java.util.ArrayList;
-import java.util.List;
 import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.Context;
@@ -28,39 +26,25 @@ import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
-import android.widget.SeekBar;
-import android.widget.Spinner;
-import android.widget.TextView;
-
+import android.widget.*;
 import com.esri.arcgisruntime.raster.ColorRamp;
 import com.esri.arcgisruntime.raster.SlopeType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Class which handles the blend renderer parameters dialog.
  */
 
-public class
-ParametersDialogFragment extends DialogFragment {
-
-  /**
-   * Interface for passing dialog parameters back to MainActivity.
-   */
-  public interface ParametersListener {
-    void returnParameters(int altitude, int azimuth, SlopeType slopeType, ColorRamp.PresetType colorRampType);
-  }
+public class ParametersDialogFragment extends DialogFragment {
 
   private Integer mAltitude;
-
   private Integer mAzimuth;
-
   private SlopeType mSlopeType;
-
   private ColorRamp.PresetType mColorRampType;
 
   private TextView mCurrAltitudeTextView;
-
   private TextView mCurrAzimuthTextView;
 
   /**
@@ -235,5 +219,12 @@ ParametersDialogFragment extends DialogFragment {
   private void updateAzimuthSeekBar(SeekBar azimuthSeekBar) {
     azimuthSeekBar.setProgress(mAzimuth);
     mCurrAzimuthTextView.setText(mAzimuth.toString());
+  }
+
+  /**
+   * Interface for passing dialog parameters back to MainActivity.
+   */
+  public interface ParametersListener {
+    void returnParameters(int altitude, int azimuth, SlopeType slopeType, ColorRamp.PresetType colorRampType);
   }
 }


### PR DESCRIPTION
Next release of the SDK will no longer allow creating a new `RasterLayer`s from a `Raster` which is already used to create an existing `RasterLayer`.  Fix creates new `RasterLayer`s when updating the renderer. 