### PR TITLE
Adding ':app' to include

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
-include ':add-graphics-renderer',
+include ':app',
+        ':add-graphics-renderer',
         ':add-graphics-symbols',
         ':arcgis-map-imagelayer-url',
         ':arcgis-tiledlayer-url',


### PR DESCRIPTION
I had to add this in order to be able to access the environment variables using Android Studio, if not it doesn't compile & sync.