### PR TITLE
Trev8939/map view dispose

### DIFF
--- a/java/add-graphics-renderer/src/main/AndroidManifest.xml
+++ b/java/add-graphics-renderer/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/add-graphics-renderer/src/main/java/com/esri/arcgisruntime/sample/addgraphicsrenderer/MainActivity.java
+++ b/java/add-graphics-renderer/src/main/java/com/esri/arcgisruntime/sample/addgraphicsrenderer/MainActivity.java
@@ -36,91 +36,97 @@ import com.esri.arcgisruntime.symbology.SimpleRenderer;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // create MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the Basemap Type topographic
-        ArcGISMap mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 15.169193, 16.333479, 2);
-        // add graphics overlay
-        addGraphicsOverlay();
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
-    }
+    // create MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the Basemap Type topographic
+    ArcGISMap mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 15.169193, 16.333479, 2);
+    // add graphics overlay
+    addGraphicsOverlay();
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
+  }
 
-    private void addGraphicsOverlay(){
-        // point graphic
-        Point pointGeometry = new Point(40e5, 40e5, SpatialReferences.getWebMercator());
-        // red diamond point symbol
-        SimpleMarkerSymbol pointSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.DIAMOND, Color.RED, 10);
-        // create graphic for point
-        Graphic pointGraphic = new Graphic(pointGeometry);
-        // create a graphic overlay for the point
-        GraphicsOverlay pointGraphicOverlay = new GraphicsOverlay();
-        // create simple renderer
-        SimpleRenderer pointRenderer = new SimpleRenderer(pointSymbol);
-        pointGraphicOverlay.setRenderer(pointRenderer);
-        // add graphic to overlay
-        pointGraphicOverlay.getGraphics().add(pointGraphic);
-        // add graphics overlay to the MapView
-        mMapView.getGraphicsOverlays().add(pointGraphicOverlay);
+  private void addGraphicsOverlay() {
+    // point graphic
+    Point pointGeometry = new Point(40e5, 40e5, SpatialReferences.getWebMercator());
+    // red diamond point symbol
+    SimpleMarkerSymbol pointSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.DIAMOND, Color.RED, 10);
+    // create graphic for point
+    Graphic pointGraphic = new Graphic(pointGeometry);
+    // create a graphic overlay for the point
+    GraphicsOverlay pointGraphicOverlay = new GraphicsOverlay();
+    // create simple renderer
+    SimpleRenderer pointRenderer = new SimpleRenderer(pointSymbol);
+    pointGraphicOverlay.setRenderer(pointRenderer);
+    // add graphic to overlay
+    pointGraphicOverlay.getGraphics().add(pointGraphic);
+    // add graphics overlay to the MapView
+    mMapView.getGraphicsOverlays().add(pointGraphicOverlay);
 
-        // line graphic
-        PolylineBuilder lineGeometry = new PolylineBuilder(SpatialReferences.getWebMercator());
-        lineGeometry.addPoint(-10e5, 40e5);
-        lineGeometry.addPoint(20e5, 50e5);
-        // solid blue line symbol
-        SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.BLUE, 5);
-        // create graphic for polyline
-        Graphic lineGraphic = new Graphic(lineGeometry.toGeometry());
-        // create graphic overlay for polyline
-        GraphicsOverlay lineGraphicOverlay = new GraphicsOverlay();
-        // create simple renderer
-        SimpleRenderer lineRenderer = new SimpleRenderer(lineSymbol);
-        // add graphic to overlay
-        lineGraphicOverlay.setRenderer(lineRenderer);
-        // add graphic to overlay
-        lineGraphicOverlay.getGraphics().add(lineGraphic);
-        // add graphics overlay to the MapView
-        mMapView.getGraphicsOverlays().add(lineGraphicOverlay);
+    // line graphic
+    PolylineBuilder lineGeometry = new PolylineBuilder(SpatialReferences.getWebMercator());
+    lineGeometry.addPoint(-10e5, 40e5);
+    lineGeometry.addPoint(20e5, 50e5);
+    // solid blue line symbol
+    SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.BLUE, 5);
+    // create graphic for polyline
+    Graphic lineGraphic = new Graphic(lineGeometry.toGeometry());
+    // create graphic overlay for polyline
+    GraphicsOverlay lineGraphicOverlay = new GraphicsOverlay();
+    // create simple renderer
+    SimpleRenderer lineRenderer = new SimpleRenderer(lineSymbol);
+    // add graphic to overlay
+    lineGraphicOverlay.setRenderer(lineRenderer);
+    // add graphic to overlay
+    lineGraphicOverlay.getGraphics().add(lineGraphic);
+    // add graphics overlay to the MapView
+    mMapView.getGraphicsOverlays().add(lineGraphicOverlay);
 
-        //polygon graphic
-        PolygonBuilder polygonGeometry = new PolygonBuilder(SpatialReferences.getWebMercator());
-        polygonGeometry.addPoint(-20e5, 20e5);
-        polygonGeometry.addPoint(20e5, 20e5);
-        polygonGeometry.addPoint(20e5, -20e5);
-        polygonGeometry.addPoint(-20e5, -20e5);
-        // solid yellow polygon symbol
-        SimpleFillSymbol polygonSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, Color.YELLOW, null);
-        // create graphic for polygon
-        Graphic polygonGraphic = new Graphic(polygonGeometry.toGeometry());
-        // create graphic overlay for polygon
-        GraphicsOverlay polygonGraphicOverlay = new GraphicsOverlay();
-        // create simple renderer
-        SimpleRenderer polygonRenderer = new SimpleRenderer(polygonSymbol);
-        // add graphic to overlay
-        polygonGraphicOverlay.setRenderer(polygonRenderer);
-        // add graphic to overlay
-        polygonGraphicOverlay.getGraphics().add(polygonGraphic);
-        // add graphics overlay to MapView
-        mMapView.getGraphicsOverlays().add(polygonGraphicOverlay);
+    //polygon graphic
+    PolygonBuilder polygonGeometry = new PolygonBuilder(SpatialReferences.getWebMercator());
+    polygonGeometry.addPoint(-20e5, 20e5);
+    polygonGeometry.addPoint(20e5, 20e5);
+    polygonGeometry.addPoint(20e5, -20e5);
+    polygonGeometry.addPoint(-20e5, -20e5);
+    // solid yellow polygon symbol
+    SimpleFillSymbol polygonSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, Color.YELLOW, null);
+    // create graphic for polygon
+    Graphic polygonGraphic = new Graphic(polygonGeometry.toGeometry());
+    // create graphic overlay for polygon
+    GraphicsOverlay polygonGraphicOverlay = new GraphicsOverlay();
+    // create simple renderer
+    SimpleRenderer polygonRenderer = new SimpleRenderer(polygonSymbol);
+    // add graphic to overlay
+    polygonGraphicOverlay.setRenderer(polygonRenderer);
+    // add graphic to overlay
+    polygonGraphicOverlay.getGraphics().add(polygonGraphic);
+    // add graphics overlay to MapView
+    mMapView.getGraphicsOverlays().add(polygonGraphicOverlay);
 
-    }
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/add-graphics-symbols/src/main/AndroidManifest.xml
+++ b/java/add-graphics-symbols/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/add-graphics-symbols/src/main/java/com/esri/arcgisruntime/sample/addgraphicssymbols/MainActivity.java
+++ b/java/add-graphics-symbols/src/main/java/com/esri/arcgisruntime/sample/addgraphicssymbols/MainActivity.java
@@ -37,215 +37,222 @@ import com.esri.arcgisruntime.symbology.TextSymbol;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
-    private final SpatialReference wgs84 = SpatialReference.create(4326);
+  private final SpatialReference wgs84 = SpatialReference.create(4326);
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the BasemapType topographic
-        ArcGISMap map = new ArcGISMap(Basemap.Type.OCEANS, 56.075844, -2.681572, 11);
-        // set the map to be displayed in this view
-        mMapView.setMap(map);
-        // add graphics overlay to MapView.
-        GraphicsOverlay graphicsOverlay = addGraphicsOverlay(mMapView);
-        //add some buoy positions to the graphics overlay
-        addBuoyPoints(graphicsOverlay);
-        //add boat trip polyline to graphics overlay
-        addBoatTrip(graphicsOverlay);
-        //add nesting ground polygon to graphics overlay
-        addNestingGround(graphicsOverlay);
-        //add text symbols and points to graphics overlay
-        addText(graphicsOverlay);
-    }
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the BasemapType topographic
+    ArcGISMap map = new ArcGISMap(Basemap.Type.OCEANS, 56.075844, -2.681572, 11);
+    // set the map to be displayed in this view
+    mMapView.setMap(map);
+    // add graphics overlay to MapView.
+    GraphicsOverlay graphicsOverlay = addGraphicsOverlay(mMapView);
+    //add some buoy positions to the graphics overlay
+    addBuoyPoints(graphicsOverlay);
+    //add boat trip polyline to graphics overlay
+    addBoatTrip(graphicsOverlay);
+    //add nesting ground polygon to graphics overlay
+    addNestingGround(graphicsOverlay);
+    //add text symbols and points to graphics overlay
+    addText(graphicsOverlay);
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
 
-    private GraphicsOverlay addGraphicsOverlay(MapView mapView) {
-        //create the graphics overlay
-        GraphicsOverlay graphicsOverlay = new GraphicsOverlay();
-        //add the overlay to the map view
-        mapView.getGraphicsOverlays().add(graphicsOverlay);
-        return graphicsOverlay;
-    }
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 
-    private void addBuoyPoints(GraphicsOverlay graphicOverlay) {
-        //define the buoy locations
-        Point buoy1Loc = new Point(-2.712642647560347, 56.062812566811544, wgs84);
-        Point buoy2Loc = new Point(-2.6908416959572303, 56.06444173689877, wgs84);
-        Point buoy3Loc = new Point(-2.6697273884990937, 56.064250073402874, wgs84);
-        Point buoy4Loc = new Point(-2.6395150461199726, 56.06127916736989, wgs84);
-        //create a marker symbol
-        SimpleMarkerSymbol buoyMarker = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.CIRCLE, Color.RED, 10);
-        //create graphics
-        Graphic buoyGraphic1 = new Graphic(buoy1Loc, buoyMarker);
-        Graphic buoyGraphic2 = new Graphic(buoy2Loc, buoyMarker);
-        Graphic buoyGraphic3 = new Graphic(buoy3Loc, buoyMarker);
-        Graphic buoyGraphic4 = new Graphic(buoy4Loc, buoyMarker);
-        //add the graphics to the graphics overlay
-        graphicOverlay.getGraphics().add(buoyGraphic1);
-        graphicOverlay.getGraphics().add(buoyGraphic2);
-        graphicOverlay.getGraphics().add(buoyGraphic3);
-        graphicOverlay.getGraphics().add(buoyGraphic4);
-    }
+  private GraphicsOverlay addGraphicsOverlay(MapView mapView) {
+    //create the graphics overlay
+    GraphicsOverlay graphicsOverlay = new GraphicsOverlay();
+    //add the overlay to the map view
+    mapView.getGraphicsOverlays().add(graphicsOverlay);
+    return graphicsOverlay;
+  }
 
-    private void addText(GraphicsOverlay graphicOverlay) {
-        //create a point geometry
-        Point bassLocation = new Point(-2.640631, 56.078083,wgs84);
-        Point craigleithLocation = new Point (-2.720324, 56.073569,wgs84);
+  private void addBuoyPoints(GraphicsOverlay graphicOverlay) {
+    //define the buoy locations
+    Point buoy1Loc = new Point(-2.712642647560347, 56.062812566811544, wgs84);
+    Point buoy2Loc = new Point(-2.6908416959572303, 56.06444173689877, wgs84);
+    Point buoy3Loc = new Point(-2.6697273884990937, 56.064250073402874, wgs84);
+    Point buoy4Loc = new Point(-2.6395150461199726, 56.06127916736989, wgs84);
+    //create a marker symbol
+    SimpleMarkerSymbol buoyMarker = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.CIRCLE, Color.RED, 10);
+    //create graphics
+    Graphic buoyGraphic1 = new Graphic(buoy1Loc, buoyMarker);
+    Graphic buoyGraphic2 = new Graphic(buoy2Loc, buoyMarker);
+    Graphic buoyGraphic3 = new Graphic(buoy3Loc, buoyMarker);
+    Graphic buoyGraphic4 = new Graphic(buoy4Loc, buoyMarker);
+    //add the graphics to the graphics overlay
+    graphicOverlay.getGraphics().add(buoyGraphic1);
+    graphicOverlay.getGraphics().add(buoyGraphic2);
+    graphicOverlay.getGraphics().add(buoyGraphic3);
+    graphicOverlay.getGraphics().add(buoyGraphic4);
+  }
 
-        //create text symbols
-        TextSymbol bassRockSymbol =
-                new TextSymbol(10, "Bass Rock", Color.rgb(0, 0, 230),
-                        TextSymbol.HorizontalAlignment.LEFT, TextSymbol.VerticalAlignment.BOTTOM);
-        TextSymbol craigleithSymbol = new TextSymbol(10, "Craigleith", Color.rgb(0, 0, 230),
-                        TextSymbol.HorizontalAlignment.RIGHT, TextSymbol.VerticalAlignment.TOP);
+  private void addText(GraphicsOverlay graphicOverlay) {
+    //create a point geometry
+    Point bassLocation = new Point(-2.640631, 56.078083, wgs84);
+    Point craigleithLocation = new Point(-2.720324, 56.073569, wgs84);
 
-        //define a graphic from the geometry and symbol
-        Graphic bassRockGraphic = new Graphic(bassLocation, bassRockSymbol);
-        Graphic craigleithGraphic = new Graphic(craigleithLocation, craigleithSymbol);
-        //add the text to the graphics overlay
-        graphicOverlay.getGraphics().add(bassRockGraphic);
-        graphicOverlay.getGraphics().add(craigleithGraphic);
-    }
+    //create text symbols
+    TextSymbol bassRockSymbol =
+        new TextSymbol(10, "Bass Rock", Color.rgb(0, 0, 230),
+            TextSymbol.HorizontalAlignment.LEFT, TextSymbol.VerticalAlignment.BOTTOM);
+    TextSymbol craigleithSymbol = new TextSymbol(10, "Craigleith", Color.rgb(0, 0, 230),
+        TextSymbol.HorizontalAlignment.RIGHT, TextSymbol.VerticalAlignment.TOP);
 
-    private void addBoatTrip(GraphicsOverlay graphicOverlay) {
-        //define a polyline for the boat trip
-        Polyline boatRoute = getBoatTripGeometry();
-        //define a line symbol
-        SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.DASH, Color.rgb(128, 0, 128), 4);
-        //create the graphic
-        Graphic boatTripGraphic = new Graphic(boatRoute, lineSymbol);
-        //add to the graphic overlay
-        graphicOverlay.getGraphics().add(boatTripGraphic);
-    }
+    //define a graphic from the geometry and symbol
+    Graphic bassRockGraphic = new Graphic(bassLocation, bassRockSymbol);
+    Graphic craigleithGraphic = new Graphic(craigleithLocation, craigleithSymbol);
+    //add the text to the graphics overlay
+    graphicOverlay.getGraphics().add(bassRockGraphic);
+    graphicOverlay.getGraphics().add(craigleithGraphic);
+  }
 
-    private void addNestingGround(GraphicsOverlay graphicOverlay) {
-        //define the polygon for the nesting ground
-        Polygon nestingGround = getNestingGroundGeometry();
-        //define the fill symbol and outline
-        SimpleLineSymbol outlineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.DASH, Color.rgb(0, 0, 128), 1);
-        SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.DIAGONAL_CROSS, Color.rgb(0, 80, 0), outlineSymbol);
-        //define graphic
-        Graphic nestingGraphic = new Graphic(nestingGround,fillSymbol);
-        //add to graphics overlay
-        graphicOverlay.getGraphics().add(nestingGraphic);
-    }
+  private void addBoatTrip(GraphicsOverlay graphicOverlay) {
+    //define a polyline for the boat trip
+    Polyline boatRoute = getBoatTripGeometry();
+    //define a line symbol
+    SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.DASH, Color.rgb(128, 0, 128), 4);
+    //create the graphic
+    Graphic boatTripGraphic = new Graphic(boatRoute, lineSymbol);
+    //add to the graphic overlay
+    graphicOverlay.getGraphics().add(boatTripGraphic);
+  }
 
-    private Polyline getBoatTripGeometry() {
-        //a new point collection to make up the polyline
-        PointCollection boatPositions = new PointCollection(wgs84);
-        //add positions to the point collection
-        boatPositions.add(new Point(-2.7184791227926772,56.06147084563517));
-        boatPositions.add(new Point(-2.7196807500463924,56.06147084563517));
-        boatPositions.add(new Point(-2.722084004553823,56.062141712059706));
-        boatPositions.add(new Point(-2.726375530459948,56.06386674355254));
-        boatPositions.add(new Point(-2.726890513568683,56.0660708381432));
-        boatPositions.add(new Point(-2.7270621746049275,56.06779569383808));
-        boatPositions.add(new Point(-2.7255172252787228,56.068753913653914));
-        boatPositions.add(new Point(-2.723113970771293,56.069424653352335));
-        boatPositions.add(new Point(-2.719165766937657,56.07028701581465));
-        boatPositions.add(new Point(-2.713672613777817,56.070574465681325));
-        boatPositions.add(new Point(-2.7093810878716917,56.07095772883556));
-        boatPositions.add(new Point(-2.7044029178205866,56.07153261642126));
-        boatPositions.add(new Point(-2.698223120515766,56.072394931722265));
-        boatPositions.add(new Point(-2.6923866452834355,56.07325722773041));
-        boatPositions.add(new Point(-2.68672183108735,56.07335303720707));
-        boatPositions.add(new Point(-2.6812286779275096,56.07354465544585));
-        boatPositions.add(new Point(-2.6764221689126497,56.074215311778964));
-        boatPositions.add(new Point(-2.6698990495353394,56.07488595644139));
-        boatPositions.add(new Point(-2.6647492184479886,56.075748196715914));
-        boatPositions.add(new Point(-2.659427726324393,56.076131408423215));
-        boatPositions.add(new Point(-2.654792878345778,56.07622721075461));
-        boatPositions.add(new Point(-2.651359657620878,56.076514616319784));
-        boatPositions.add(new Point(-2.6477547758597324,56.07708942101955));
-        boatPositions.add(new Point(-2.6450081992798125,56.07814320736718));
-        boatPositions.add(new Point(-2.6432915889173625,56.08025069360931));
-        boatPositions.add(new Point(-2.638656740938747,56.08044227755186));
-        boatPositions.add(new Point(-2.636940130576297,56.078813783674946));
-        boatPositions.add(new Point(-2.636425147467562,56.07728102068079));
-        boatPositions.add(new Point(-2.637798435757522,56.076610417698504));
-        boatPositions.add(new Point(-2.638656740938747,56.07507756705851));
-        boatPositions.add(new Point(-2.641231656482422,56.07479015077557));
-        boatPositions.add(new Point(-2.6427766058086277,56.075748196715914));
-        boatPositions.add(new Point(-2.6456948434247924,56.07546078543464));
-        boatPositions.add(new Point(-2.647239792750997,56.074598538729404));
-        boatPositions.add(new Point(-2.6492997251859376,56.072682365868616));
-        boatPositions.add(new Point(-2.6530762679833284,56.0718200569986));
-        boatPositions.add(new Point(-2.655479522490758,56.070861913404286));
-        boatPositions.add(new Point(-2.6587410821794135,56.07047864929729));
-        boatPositions.add(new Point(-2.6633759301580286,56.07028701581465));
-        boatPositions.add(new Point(-2.666637489846684,56.07009538137926));
-        boatPositions.add(new Point(-2.670070710571584,56.06990374599109));
-        boatPositions.add(new Point(-2.6741905754414645,56.069137194910745));
-        boatPositions.add(new Point(-2.678310440311345,56.06808316228391));
-        boatPositions.add(new Point(-2.682086983108735,56.06789151689155));
-        boatPositions.add(new Point(-2.6868934921235956,56.06760404701653));
-        boatPositions.add(new Point(-2.6911850180297208,56.06722075051504));
-        boatPositions.add(new Point(-2.695133221863356,56.06702910083509));
-        boatPositions.add(new Point(-2.698223120515766,56.066837450202335));
-        boatPositions.add(new Point(-2.7016563412406667,56.06645414607839));
-        boatPositions.add(new Point(-2.7061195281830366,56.0660708381432));
-        boatPositions.add(new Point(-2.7100677320166717,56.065591697864576));
-        boatPositions.add(new Point(-2.713329291705327,56.06520838135397));
-        boatPositions.add(new Point(-2.7167625124302273,56.06453756828941));
-        boatPositions.add(new Point(-2.718307461756433,56.06348340989081));
-        boatPositions.add(new Point(-2.719165766937657,56.062812566811544));
-        boatPositions.add(new Point(-2.7198524110826376,56.06204587471371));
-        boatPositions.add(new Point(-2.719165766937657,56.06166252294756));
-        boatPositions.add(new Point(-2.718307461756433,56.06147084563517));
+  private void addNestingGround(GraphicsOverlay graphicOverlay) {
+    //define the polygon for the nesting ground
+    Polygon nestingGround = getNestingGroundGeometry();
+    //define the fill symbol and outline
+    SimpleLineSymbol outlineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.DASH, Color.rgb(0, 0, 128), 1);
+    SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.DIAGONAL_CROSS, Color.rgb(0, 80, 0),
+        outlineSymbol);
+    //define graphic
+    Graphic nestingGraphic = new Graphic(nestingGround, fillSymbol);
+    //add to graphics overlay
+    graphicOverlay.getGraphics().add(nestingGraphic);
+  }
 
-        //create the polyline from the point collection
-        return new Polyline(boatPositions);
-    }
+  private Polyline getBoatTripGeometry() {
+    //a new point collection to make up the polyline
+    PointCollection boatPositions = new PointCollection(wgs84);
+    //add positions to the point collection
+    boatPositions.add(new Point(-2.7184791227926772, 56.06147084563517));
+    boatPositions.add(new Point(-2.7196807500463924, 56.06147084563517));
+    boatPositions.add(new Point(-2.722084004553823, 56.062141712059706));
+    boatPositions.add(new Point(-2.726375530459948, 56.06386674355254));
+    boatPositions.add(new Point(-2.726890513568683, 56.0660708381432));
+    boatPositions.add(new Point(-2.7270621746049275, 56.06779569383808));
+    boatPositions.add(new Point(-2.7255172252787228, 56.068753913653914));
+    boatPositions.add(new Point(-2.723113970771293, 56.069424653352335));
+    boatPositions.add(new Point(-2.719165766937657, 56.07028701581465));
+    boatPositions.add(new Point(-2.713672613777817, 56.070574465681325));
+    boatPositions.add(new Point(-2.7093810878716917, 56.07095772883556));
+    boatPositions.add(new Point(-2.7044029178205866, 56.07153261642126));
+    boatPositions.add(new Point(-2.698223120515766, 56.072394931722265));
+    boatPositions.add(new Point(-2.6923866452834355, 56.07325722773041));
+    boatPositions.add(new Point(-2.68672183108735, 56.07335303720707));
+    boatPositions.add(new Point(-2.6812286779275096, 56.07354465544585));
+    boatPositions.add(new Point(-2.6764221689126497, 56.074215311778964));
+    boatPositions.add(new Point(-2.6698990495353394, 56.07488595644139));
+    boatPositions.add(new Point(-2.6647492184479886, 56.075748196715914));
+    boatPositions.add(new Point(-2.659427726324393, 56.076131408423215));
+    boatPositions.add(new Point(-2.654792878345778, 56.07622721075461));
+    boatPositions.add(new Point(-2.651359657620878, 56.076514616319784));
+    boatPositions.add(new Point(-2.6477547758597324, 56.07708942101955));
+    boatPositions.add(new Point(-2.6450081992798125, 56.07814320736718));
+    boatPositions.add(new Point(-2.6432915889173625, 56.08025069360931));
+    boatPositions.add(new Point(-2.638656740938747, 56.08044227755186));
+    boatPositions.add(new Point(-2.636940130576297, 56.078813783674946));
+    boatPositions.add(new Point(-2.636425147467562, 56.07728102068079));
+    boatPositions.add(new Point(-2.637798435757522, 56.076610417698504));
+    boatPositions.add(new Point(-2.638656740938747, 56.07507756705851));
+    boatPositions.add(new Point(-2.641231656482422, 56.07479015077557));
+    boatPositions.add(new Point(-2.6427766058086277, 56.075748196715914));
+    boatPositions.add(new Point(-2.6456948434247924, 56.07546078543464));
+    boatPositions.add(new Point(-2.647239792750997, 56.074598538729404));
+    boatPositions.add(new Point(-2.6492997251859376, 56.072682365868616));
+    boatPositions.add(new Point(-2.6530762679833284, 56.0718200569986));
+    boatPositions.add(new Point(-2.655479522490758, 56.070861913404286));
+    boatPositions.add(new Point(-2.6587410821794135, 56.07047864929729));
+    boatPositions.add(new Point(-2.6633759301580286, 56.07028701581465));
+    boatPositions.add(new Point(-2.666637489846684, 56.07009538137926));
+    boatPositions.add(new Point(-2.670070710571584, 56.06990374599109));
+    boatPositions.add(new Point(-2.6741905754414645, 56.069137194910745));
+    boatPositions.add(new Point(-2.678310440311345, 56.06808316228391));
+    boatPositions.add(new Point(-2.682086983108735, 56.06789151689155));
+    boatPositions.add(new Point(-2.6868934921235956, 56.06760404701653));
+    boatPositions.add(new Point(-2.6911850180297208, 56.06722075051504));
+    boatPositions.add(new Point(-2.695133221863356, 56.06702910083509));
+    boatPositions.add(new Point(-2.698223120515766, 56.066837450202335));
+    boatPositions.add(new Point(-2.7016563412406667, 56.06645414607839));
+    boatPositions.add(new Point(-2.7061195281830366, 56.0660708381432));
+    boatPositions.add(new Point(-2.7100677320166717, 56.065591697864576));
+    boatPositions.add(new Point(-2.713329291705327, 56.06520838135397));
+    boatPositions.add(new Point(-2.7167625124302273, 56.06453756828941));
+    boatPositions.add(new Point(-2.718307461756433, 56.06348340989081));
+    boatPositions.add(new Point(-2.719165766937657, 56.062812566811544));
+    boatPositions.add(new Point(-2.7198524110826376, 56.06204587471371));
+    boatPositions.add(new Point(-2.719165766937657, 56.06166252294756));
+    boatPositions.add(new Point(-2.718307461756433, 56.06147084563517));
 
-    private Polygon getNestingGroundGeometry() {
+    //create the polyline from the point collection
+    return new Polyline(boatPositions);
+  }
 
-        //a new point collection to make up the polygon
-        PointCollection points = new PointCollection(wgs84);
+  private Polygon getNestingGroundGeometry() {
 
-        //add points to the point collection
-        points.add(new Point(-2.643077012566659,56.077125346044475));
-        points.add(new Point(-2.6428195210159444,56.07717324600376));
-        points.add(new Point(-2.6425405718360033,56.07774804087097));
-        points.add(new Point(-2.6427122328698127,56.077927662508635));
-        points.add(new Point(-2.642454741319098,56.07829887790651));
-        points.add(new Point(-2.641853927700763,56.078526395253725));
-        points.add(new Point(-2.6409741649024867,56.078801809192434));
-        points.add(new Point(-2.6399871139580795,56.07881378366685));
-        points.add(new Point(-2.6394077579689705,56.07908919555142));
-        points.add(new Point(-2.638764029092183,56.07917301616904));
-        points.add(new Point(-2.638485079912242,56.07896945149566));
-        points.add(new Point(-2.638570910429147,56.078203080726844));
-        points.add(new Point(-2.63878548672141,56.077568418396));
-        points.add(new Point(-2.6391931816767085,56.077197195961084));
-        points.add(new Point(-2.6399441986996273,56.07675411934114));
-        points.add(new Point(-2.6406523004640934,56.076730169108444));
-        points.add(new Point(-2.6406737580933193,56.07632301287509));
-        points.add(new Point(-2.6401802326211157,56.075999679860494));
-        points.add(new Point(-2.6402446055087943,56.075844000034046));
-        points.add(new Point(-2.640416266542604,56.07578412301025));
-        points.add(new Point(-2.6408883343855822,56.075808073830935));
-        points.add(new Point(-2.6417680971838577,56.076239186057734));
-        points.add(new Point(-2.642197249768383,56.076251161328514));
-        points.add(new Point(-2.6428409786451708,56.07661041772168));
-        points.add(new Point(-2.643077012566659,56.077125346044475));
+    //a new point collection to make up the polygon
+    PointCollection points = new PointCollection(wgs84);
 
-        //create a polygon from the point collection
-        return new Polygon(points);
-    }
+    //add points to the point collection
+    points.add(new Point(-2.643077012566659, 56.077125346044475));
+    points.add(new Point(-2.6428195210159444, 56.07717324600376));
+    points.add(new Point(-2.6425405718360033, 56.07774804087097));
+    points.add(new Point(-2.6427122328698127, 56.077927662508635));
+    points.add(new Point(-2.642454741319098, 56.07829887790651));
+    points.add(new Point(-2.641853927700763, 56.078526395253725));
+    points.add(new Point(-2.6409741649024867, 56.078801809192434));
+    points.add(new Point(-2.6399871139580795, 56.07881378366685));
+    points.add(new Point(-2.6394077579689705, 56.07908919555142));
+    points.add(new Point(-2.638764029092183, 56.07917301616904));
+    points.add(new Point(-2.638485079912242, 56.07896945149566));
+    points.add(new Point(-2.638570910429147, 56.078203080726844));
+    points.add(new Point(-2.63878548672141, 56.077568418396));
+    points.add(new Point(-2.6391931816767085, 56.077197195961084));
+    points.add(new Point(-2.6399441986996273, 56.07675411934114));
+    points.add(new Point(-2.6406523004640934, 56.076730169108444));
+    points.add(new Point(-2.6406737580933193, 56.07632301287509));
+    points.add(new Point(-2.6401802326211157, 56.075999679860494));
+    points.add(new Point(-2.6402446055087943, 56.075844000034046));
+    points.add(new Point(-2.640416266542604, 56.07578412301025));
+    points.add(new Point(-2.6408883343855822, 56.075808073830935));
+    points.add(new Point(-2.6417680971838577, 56.076239186057734));
+    points.add(new Point(-2.642197249768383, 56.076251161328514));
+    points.add(new Point(-2.6428409786451708, 56.07661041772168));
+    points.add(new Point(-2.643077012566659, 56.077125346044475));
+
+    //create a polygon from the point collection
+    return new Polygon(points);
+  }
 }

--- a/java/analyze-hotspots/src/main/AndroidManifest.xml
+++ b/java/analyze-hotspots/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/analyze-hotspots/src/main/java/com/esri/arcgisruntime/sample/analyzehotspots/MainActivity.java
+++ b/java/analyze-hotspots/src/main/java/com/esri/arcgisruntime/sample/analyzehotspots/MainActivity.java
@@ -322,4 +322,10 @@ public class MainActivity extends AppCompatActivity {
     super.onResume();
     mMapView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/arcgis-map-imagelayer-url/src/main/AndroidManifest.xml
+++ b/java/arcgis-map-imagelayer-url/src/main/AndroidManifest.xml
@@ -12,8 +12,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme"
-        android:configChanges="orientation|screenSize|uiMode">
+        android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name" >

--- a/java/arcgis-map-imagelayer-url/src/main/java/com/esri/arcgisruntime/sample/mapimagelayer/MainActivity.java
+++ b/java/arcgis-map-imagelayer-url/src/main/java/com/esri/arcgisruntime/sample/mapimagelayer/MainActivity.java
@@ -57,4 +57,9 @@ public class MainActivity extends AppCompatActivity {
         mMapView.resume();
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        mMapView.dispose();
+    }
 }

--- a/java/arcgis-tiledlayer-url/src/main/AndroidManifest.xml
+++ b/java/arcgis-tiledlayer-url/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/arcgis-tiledlayer-url/src/main/java/com/esri/arcgisruntime/sample/tiledlayerfromurl/MainActivity.java
+++ b/java/arcgis-tiledlayer-url/src/main/java/com/esri/arcgisruntime/sample/tiledlayerfromurl/MainActivity.java
@@ -26,34 +26,40 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapViewLayout);
-        // create new Tiled Layer from service url
-        ArcGISTiledLayer tiledLayerBaseMap = new ArcGISTiledLayer(getResources().getString(R.string.world_topo_service));
-        // set tiled layer as basemap
-        Basemap basemap = new Basemap(tiledLayerBaseMap);
-        // create a map with the basemap
-        ArcGISMap map = new ArcGISMap(basemap);
-        // set the map to be displayed in this view
-        mMapView.setMap(map);
-    }
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapViewLayout);
+    // create new Tiled Layer from service url
+    ArcGISTiledLayer tiledLayerBaseMap = new ArcGISTiledLayer(getResources().getString(R.string.world_topo_service));
+    // set tiled layer as basemap
+    Basemap basemap = new Basemap(tiledLayerBaseMap);
+    // create a map with the basemap
+    ArcGISMap map = new ArcGISMap(basemap);
+    // set the map to be displayed in this view
+    mMapView.setMap(map);
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/arcgis-vectortiledlayer-url/src/main/AndroidManifest.xml
+++ b/java/arcgis-vectortiledlayer-url/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
             android:theme="@style/AppTheme"
             android:supportsRtl="true">
         <activity android:name="com.esri.arcgisruntime.sample.arcgisvectortiledlayerurl.MainActivity"
-                  android:label="@string/app_name"
-                  android:configChanges="orientation|screenSize|uiMode">
+                  android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/java/arcgis-vectortiledlayer-url/src/main/java/com/esri/arcgisruntime/sample/arcgisvectortiledlayerurl/MainActivity.java
+++ b/java/arcgis-vectortiledlayer-url/src/main/java/com/esri/arcgisruntime/sample/arcgisvectortiledlayerurl/MainActivity.java
@@ -101,6 +101,12 @@ public class MainActivity extends AppCompatActivity {
     mMapView.resume();
   }
 
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
+
   /**
    * The click listener for ListView in the navigation drawer
    */

--- a/java/blend-renderer/src/main/java/com/esri/arcgisruntime/sample/blendrenderer/MainActivity.java
+++ b/java/blend-renderer/src/main/java/com/esri/arcgisruntime/sample/blendrenderer/MainActivity.java
@@ -16,6 +16,9 @@
 
 package com.esri.arcgisruntime.sample.blendrenderer;
 
+import java.io.File;
+import java.util.Collections;
+
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -29,6 +32,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.Toast;
+
 import com.esri.arcgisruntime.layers.RasterLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.Basemap;
@@ -37,9 +41,6 @@ import com.esri.arcgisruntime.raster.BlendRenderer;
 import com.esri.arcgisruntime.raster.ColorRamp;
 import com.esri.arcgisruntime.raster.Raster;
 import com.esri.arcgisruntime.raster.SlopeType;
-
-import java.io.File;
-import java.util.Collections;
 
 public class MainActivity extends AppCompatActivity implements ParametersDialogFragment.ParametersListener {
 
@@ -211,5 +212,11 @@ public class MainActivity extends AppCompatActivity implements ParametersDialogF
   protected void onResume() {
     super.onResume();
     mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
   }
 }

--- a/java/change-basemaps/src/main/AndroidManifest.xml
+++ b/java/change-basemaps/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/change-basemaps/src/main/java/com/esri/arcgisruntime/sample/switchbasemaps/MainActivity.java
+++ b/java/change-basemaps/src/main/java/com/esri/arcgisruntime/sample/switchbasemaps/MainActivity.java
@@ -33,153 +33,160 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
-    private ArcGISMap mMap;
+  private MapView mMapView;
+  private ArcGISMap mMap;
 
-    private String[] mNavigationDrawerItemTitles;
+  private String[] mNavigationDrawerItemTitles;
 
-    private ListView mDrawerList;
+  private ListView mDrawerList;
 
-    private ActionBarDrawerToggle mDrawerToggle;
-    private DrawerLayout mDrawerLayout;
-    private String mActivityTitle;
+  private ActionBarDrawerToggle mDrawerToggle;
+  private DrawerLayout mDrawerLayout;
+  private String mActivityTitle;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate navigation drawer
-        mNavigationDrawerItemTitles = getResources().getStringArray(R.array.vector_tiled_types);
-        mDrawerList = (ListView)findViewById(R.id.navList);
-        mDrawerLayout = (DrawerLayout)findViewById(R.id.drawer_layout);
-        // get app title
-        mActivityTitle = getTitle().toString();
+    // inflate navigation drawer
+    mNavigationDrawerItemTitles = getResources().getStringArray(R.array.vector_tiled_types);
+    mDrawerList = (ListView) findViewById(R.id.navList);
+    mDrawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+    // get app title
+    mActivityTitle = getTitle().toString();
 
-        addDrawerItems();
-        setupDrawer();
+    addDrawerItems();
+    setupDrawer();
 
-        if(getSupportActionBar() != null){
-            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-            getSupportActionBar().setHomeButtonEnabled(true);
-            // set opening basemap title to Topographic
-            getSupportActionBar().setTitle(mNavigationDrawerItemTitles[2]);
-        }
-
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with Topographic Basemap
-        mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 47.6047381, -122.3334255, 12);
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
+    if (getSupportActionBar() != null) {
+      getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+      getSupportActionBar().setHomeButtonEnabled(true);
+      // set opening basemap title to Topographic
+      getSupportActionBar().setTitle(mNavigationDrawerItemTitles[2]);
     }
 
-    /**
-     * Add navigation drawer items
-     */
-    private void addDrawerItems(){
-        ArrayAdapter<String> mAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, mNavigationDrawerItemTitles);
-        mDrawerList.setAdapter(mAdapter);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with Topographic Basemap
+    mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 47.6047381, -122.3334255, 12);
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
+  }
 
-        mDrawerList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> adapterView, View view, int position, long id) {
-                selectBasemap(position);
-            }
-        });
+  /**
+   * Add navigation drawer items
+   */
+  private void addDrawerItems() {
+    ArrayAdapter<String> mAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1,
+        mNavigationDrawerItemTitles);
+    mDrawerList.setAdapter(mAdapter);
+
+    mDrawerList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+      @Override
+      public void onItemClick(AdapterView<?> adapterView, View view, int position, long id) {
+        selectBasemap(position);
+      }
+    });
+  }
+
+  /**
+   * Set up the navigation drawer
+   */
+  private void setupDrawer() {
+
+    mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, R.string.drawer_open, R.string.drawer_close) {
+
+      /** Called when a drawer has settled in a completely open state. */
+      public void onDrawerOpened(View drawerView) {
+        super.onDrawerOpened(drawerView);
+        getSupportActionBar().setTitle(mActivityTitle);
+        invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
+      }
+
+      /** Called when a drawer has settled in a completely closed state. */
+      public void onDrawerClosed(View view) {
+        super.onDrawerClosed(view);
+        invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
+      }
+    };
+
+    mDrawerToggle.setDrawerIndicatorEnabled(true);
+    mDrawerLayout.addDrawerListener(mDrawerToggle);
+  }
+
+  /**
+   * Select the Basemap item based on position in the navigation drawer
+   *
+   * @param position order int in navigation drawer
+   */
+  private void selectBasemap(int position) {
+    // update selected item and title, then close the drawer
+    mDrawerList.setItemChecked(position, true);
+    mDrawerLayout.closeDrawer(mDrawerList);
+
+    // if-else is used because this sample is used elsewhere as a Library module
+    if (position == 0) {
+      // position 0 = Streets
+      mMap.setBasemap(Basemap.createStreets());
+      getSupportActionBar().setTitle(mNavigationDrawerItemTitles[position]);
+    } else if (position == 1) {
+      // position 1 = Navigation Vector
+      mMap.setBasemap(Basemap.createNavigationVector());
+      getSupportActionBar().setTitle(mNavigationDrawerItemTitles[position]);
+    } else if (position == 2) {
+      // position 2 = Topographic
+      mMap.setBasemap(Basemap.createTopographic());
+      getSupportActionBar().setTitle(mNavigationDrawerItemTitles[position]);
+    } else if (position == 3) {
+      // position 3 = Topographic Vector
+      mMap.setBasemap(Basemap.createTopographicVector());
+      getSupportActionBar().setTitle(mNavigationDrawerItemTitles[position]);
+    } else if (position == 4) {
+      // position 3 = Gray Canvas
+      mMap.setBasemap(Basemap.createLightGrayCanvas());
+      getSupportActionBar().setTitle(mNavigationDrawerItemTitles[position]);
+    } else if (position == 5) {
+      // position 3 = Gray Canvas Vector
+      mMap.setBasemap(Basemap.createLightGrayCanvasVector());
+      getSupportActionBar().setTitle(mNavigationDrawerItemTitles[position]);
     }
+  }
 
-    /**
-     * Set up the navigation drawer
-     */
-    private void setupDrawer(){
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    // Activate the navigation drawer toggle
+    return (mDrawerToggle.onOptionsItemSelected(item)) || super.onOptionsItemSelected(item);
+  }
 
-        mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, R.string.drawer_open, R.string.drawer_close){
+  @Override
+  protected void onPostCreate(Bundle savedInstanceState) {
+    super.onPostCreate(savedInstanceState);
+    mDrawerToggle.syncState();
+  }
 
-            /** Called when a drawer has settled in a completely open state. */
-            public void onDrawerOpened(View drawerView) {
-                super.onDrawerOpened(drawerView);
-                getSupportActionBar().setTitle(mActivityTitle);
-                invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
-            }
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    mDrawerToggle.onConfigurationChanged(newConfig);
+  }
 
-            /** Called when a drawer has settled in a completely closed state. */
-            public void onDrawerClosed(View view) {
-                super.onDrawerClosed(view);
-                invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
-            }
-        };
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
 
-        mDrawerToggle.setDrawerIndicatorEnabled(true);
-        mDrawerLayout.addDrawerListener(mDrawerToggle);
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
 
-    /**
-     * Select the Basemap item based on position in the navigation drawer
-     *
-     * @param position order int in navigation drawer
-     */
-    private void selectBasemap(int position){
-        // update selected item and title, then close the drawer
-        mDrawerList.setItemChecked(position, true);
-        mDrawerLayout.closeDrawer(mDrawerList);
+  }
 
-        // if-else is used because this sample is used elsewhere as a Library module
-        if(position == 0){
-            // position 0 = Streets
-            mMap.setBasemap(Basemap.createStreets());
-            getSupportActionBar().setTitle(mNavigationDrawerItemTitles[position]);
-        } else if(position == 1){
-            // position 1 = Navigation Vector
-            mMap.setBasemap(Basemap.createNavigationVector());
-            getSupportActionBar().setTitle(mNavigationDrawerItemTitles[position]);
-        } else if(position == 2){
-            // position 2 = Topographic
-            mMap.setBasemap(Basemap.createTopographic());
-            getSupportActionBar().setTitle(mNavigationDrawerItemTitles[position]);
-        } else if(position == 3){
-            // position 3 = Topographic Vector
-            mMap.setBasemap(Basemap.createTopographicVector());
-            getSupportActionBar().setTitle(mNavigationDrawerItemTitles[position]);
-        } else if (position == 4){
-            // position 3 = Gray Canvas
-            mMap.setBasemap(Basemap.createLightGrayCanvas());
-            getSupportActionBar().setTitle(mNavigationDrawerItemTitles[position]);
-        } else if (position == 5){
-            // position 3 = Gray Canvas Vector
-            mMap.setBasemap(Basemap.createLightGrayCanvasVector());
-            getSupportActionBar().setTitle(mNavigationDrawerItemTitles[position]);
-        }
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // Activate the navigation drawer toggle
-        return (mDrawerToggle.onOptionsItemSelected(item)) || super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    protected void onPostCreate(Bundle savedInstanceState) {
-        super.onPostCreate(savedInstanceState);
-        mDrawerToggle.syncState();
-    }
-
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-        mDrawerToggle.onConfigurationChanged(newConfig);
-    }
-
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
-
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-
-    }
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/change-feature-layer-renderer/src/main/AndroidManifest.xml
+++ b/java/change-feature-layer-renderer/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/change-feature-layer-renderer/src/main/java/com/esri/arcgisruntime/samples/changefeaturelayerrenderer/MainActivity.java
+++ b/java/change-feature-layer-renderer/src/main/java/com/esri/arcgisruntime/samples/changefeaturelayerrenderer/MainActivity.java
@@ -34,98 +34,107 @@ import com.esri.arcgisruntime.symbology.SimpleRenderer;
 
 public class MainActivity extends AppCompatActivity {
 
-    MapView mMapView;
-    FeatureLayer mFeatureLayer;
+  MapView mMapView;
+  FeatureLayer mFeatureLayer;
 
-    boolean overrideActive;
+  boolean overrideActive;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // set up the bottom toolbar
-        createBottomToolbar();
+    // set up the bottom toolbar
+    createBottomToolbar();
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // create a map with the topographic basemap
-        ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
-        //set an initial viewpoint
-        map.setInitialViewpoint(new Viewpoint(new Envelope(-1.30758164047166E7, 4014771.46954516, -1.30730056797177E7, 4016869.78617381, SpatialReferences.getWebMercator())));
+    // create a map with the topographic basemap
+    ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+    //set an initial viewpoint
+    map.setInitialViewpoint(new Viewpoint(
+        new Envelope(-1.30758164047166E7, 4014771.46954516, -1.30730056797177E7, 4016869.78617381,
+            SpatialReferences.getWebMercator())));
 
+    // create feature layer with its service feature table
+    ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(
+        getResources().getString(R.string.sample_service_url));
+    mFeatureLayer = new FeatureLayer(serviceFeatureTable);
 
-        // create feature layer with its service feature table
-        ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.sample_service_url));
-        mFeatureLayer = new FeatureLayer(serviceFeatureTable);
+    // add the layer to the map
+    map.getOperationalLayers().add(mFeatureLayer);
 
-        // add the layer to the map
-        map.getOperationalLayers().add(mFeatureLayer);
+    // set the map to be displayed in the mapview
+    mMapView.setMap(map);
 
-        // set the map to be displayed in the mapview
-        mMapView.setMap(map);
+  }
 
-    }
+  private void overrideRenderer() {
 
-    private void overrideRenderer() {
+    // create a new simple renderer for the line feature layer
+    SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.rgb(0, 0, 255), 2);
+    SimpleRenderer simpleRenderer = new SimpleRenderer(lineSymbol);
 
-        // create a new simple renderer for the line feature layer
-        SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.rgb(0, 0, 255), 2);
-        SimpleRenderer simpleRenderer = new SimpleRenderer(lineSymbol);
+    // override the current renderer with the new renderer defined above
+    mFeatureLayer.setRenderer(simpleRenderer);
+  }
 
-        // override the current renderer with the new renderer defined above
-        mFeatureLayer.setRenderer(simpleRenderer);
-    }
+  private void resetRenderer() {
 
-    private void resetRenderer() {
+    // reset the renderer back to the definition from the source (feature service) using the reset renderer method
+    mFeatureLayer.resetRenderer();
 
-        // reset the renderer back to the definition from the source (feature service) using the reset renderer method
-        mFeatureLayer.resetRenderer();
+  }
 
-    }
+  private void createBottomToolbar() {
 
-    private void createBottomToolbar() {
+    Toolbar bottomToolbar = (Toolbar) findViewById(R.id.bottomToolbar);
+    bottomToolbar.inflateMenu(R.menu.menu_main);
 
-        Toolbar bottomToolbar = (Toolbar) findViewById(R.id.bottomToolbar);
-        bottomToolbar.inflateMenu(R.menu.menu_main);
+    bottomToolbar.setOnMenuItemClickListener(new Toolbar.OnMenuItemClickListener() {
+      @Override
+      public boolean onMenuItemClick(MenuItem item) {
+        // Handle action bar item clicks
+        int itemId = item.getItemId();
+        //if statement is used because this sample is used elsewhere as a Library module
+        if (itemId == R.id.action_override_rend) {
+          // check the state of the menu item
+          if (!overrideActive) {
+            overrideRenderer();
+            // change the text to reset
+            overrideActive = true;
+            item.setTitle(R.string.action_reset);
+          } else {
+            resetRenderer();
+            // change the text to override
+            overrideActive = false;
+            item.setTitle(R.string.action_override_rend);
+          }
+        }
+        return true;
+      }
+    });
+  }
 
-        bottomToolbar.setOnMenuItemClickListener(new Toolbar.OnMenuItemClickListener() {
-            @Override
-            public boolean onMenuItemClick(MenuItem item) {
-                // Handle action bar item clicks
-                int itemId = item.getItemId();
-                //if statement is used because this sample is used elsewhere as a Library module
-                if(itemId == R.id.action_override_rend){
-                    // check the state of the menu item
-                    if (!overrideActive) {
-                        overrideRenderer();
-                        // change the text to reset
-                        overrideActive = true;
-                        item.setTitle(R.string.action_reset);
-                    } else {
-                        resetRenderer();
-                        // change the text to override
-                        overrideActive = false;
-                        item.setTitle(R.string.action_override_rend);
-                    }
-                }
-                return true;
-            }
-        });
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
-    }
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
 }

--- a/java/change-sublayer-visibility/src/main/AndroidManifest.xml
+++ b/java/change-sublayer-visibility/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/change-sublayer-visibility/src/main/java/com/esri/arcgisruntime/sample/mapimagelayersublayervisibility/MainActivity.java
+++ b/java/change-sublayer-visibility/src/main/java/com/esri/arcgisruntime/sample/mapimagelayersublayervisibility/MainActivity.java
@@ -29,107 +29,113 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
-    private ArcGISMapImageLayer mMapImageLayer;
-    private SublayerList mLayers;
+  private MapView mMapView;
+  private ArcGISMapImageLayer mMapImageLayer;
+  private SublayerList mLayers;
 
-    // The layer on/off menu items.
-    private MenuItem mCities = null;
-    private MenuItem mContinent = null;
-    private MenuItem mWorld = null;
+  // The layer on/off menu items.
+  private MenuItem mCities = null;
+  private MenuItem mContinent = null;
+  private MenuItem mWorld = null;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the Basemap Type topographic
-        ArcGISMap map = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 48.354406, -99.998267, 2);
-        // create a MapImageLayer with dynamically generated map images
-        mMapImageLayer = new ArcGISMapImageLayer(getResources().getString(R.string.world_cities_service));
-        mMapImageLayer.setOpacity(0.5f);
-        // add world cities layers as map operational layer
-        map.getOperationalLayers().add(mMapImageLayer);
-        // set the map to be displayed in this view
-        mMapView.setMap(map);
-        // get the layers from the map image layer
-        mLayers = mMapImageLayer.getSublayers();
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the Basemap Type topographic
+    ArcGISMap map = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 48.354406, -99.998267, 2);
+    // create a MapImageLayer with dynamically generated map images
+    mMapImageLayer = new ArcGISMapImageLayer(getResources().getString(R.string.world_cities_service));
+    mMapImageLayer.setOpacity(0.5f);
+    // add world cities layers as map operational layer
+    map.getOperationalLayers().add(mMapImageLayer);
+    // set the map to be displayed in this view
+    mMapView.setMap(map);
+    // get the layers from the map image layer
+    mLayers = mMapImageLayer.getSublayers();
 
-    }
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_main, menu);
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 
-        // Get the sub layer switching menu items.
-        mCities = menu.getItem(0);
-        mContinent = menu.getItem(1);
-        mWorld = menu.getItem(2);
+  @Override
+  public boolean onCreateOptionsMenu(Menu menu) {
+    // Inflate the menu; this adds items to the action bar if it is present.
+    getMenuInflater().inflate(R.menu.menu_main, menu);
 
-        // set all layers on by default
+    // Get the sub layer switching menu items.
+    mCities = menu.getItem(0);
+    mContinent = menu.getItem(1);
+    mWorld = menu.getItem(2);
+
+    // set all layers on by default
+    mCities.setChecked(true);
+    mContinent.setChecked(true);
+    mWorld.setChecked(true);
+
+    return true;
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    // handle menu item selection
+    //if-else is used because this sample is used elsewhere as a Library module
+    int itemId = item.getItemId();
+    if (itemId == R.id.Cities) {
+      if (mLayers.get(0).isVisible() && mCities.isChecked()) {
+        // cities layer is on and menu item checked
+        mLayers.get(0).setVisible(false);
+        mCities.setChecked(false);
+      } else if (!mLayers.get(0).isVisible() && !mCities.isChecked()) {
+        // cities layer is off and menu item unchecked
+        mLayers.get(0).setVisible(true);
         mCities.setChecked(true);
+      }
+      return true;
+    } else if (itemId == R.id.Continents) {
+      if (mLayers.get(1).isVisible() && mContinent.isChecked()) {
+        // continent layer is on and menu item checked
+        mLayers.get(1).setVisible(false);
+        mContinent.setChecked(false);
+      } else if (!mLayers.get(1).isVisible() && !mContinent.isChecked()) {
+        // continent layer is off and menu item unchecked
+        mLayers.get(1).setVisible(true);
         mContinent.setChecked(true);
+      }
+      return true;
+    } else if (itemId == R.id.World) {
+      if (mLayers.get(2).isVisible() && mWorld.isChecked()) {
+        // world layer is on and menu item checked
+        mLayers.get(2).setVisible(false);
+        mWorld.setChecked(false);
+      } else if (!mLayers.get(2).isVisible() && !mWorld.isChecked()) {
+        // world layer is off and menu item unchecked
+        mLayers.get(2).setVisible(true);
         mWorld.setChecked(true);
-
-        return true;
+      }
+      return true;
+    } else {
+      return super.onOptionsItemSelected(item);
     }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // handle menu item selection
-        //if-else is used because this sample is used elsewhere as a Library module
-        int itemId = item.getItemId();
-        if(itemId == R.id.Cities){
-            if(mLayers.get(0).isVisible() && mCities.isChecked()){
-                // cities layer is on and menu item checked
-                mLayers.get(0).setVisible(false);
-                mCities.setChecked(false);
-            }else if(!mLayers.get(0).isVisible() && !mCities.isChecked()){
-                // cities layer is off and menu item unchecked
-                mLayers.get(0).setVisible(true);
-                mCities.setChecked(true);
-            }
-            return true;
-        }else if(itemId == R.id.Continents){
-            if(mLayers.get(1).isVisible() && mContinent.isChecked()){
-                // continent layer is on and menu item checked
-                mLayers.get(1).setVisible(false);
-                mContinent.setChecked(false);
-            }else if(!mLayers.get(1).isVisible() && !mContinent.isChecked()){
-                // continent layer is off and menu item unchecked
-                mLayers.get(1).setVisible(true);
-                mContinent.setChecked(true);
-            }
-            return true;
-        }else if(itemId == R.id.World){
-            if(mLayers.get(2).isVisible() && mWorld.isChecked()){
-                // world layer is on and menu item checked
-                mLayers.get(2).setVisible(false);
-                mWorld.setChecked(false);
-            }else if(!mLayers.get(2).isVisible() && !mWorld.isChecked()){
-                // world layer is off and menu item unchecked
-                mLayers.get(2).setVisible(true);
-                mWorld.setChecked(true);
-            }
-            return true;
-        }else{
-                return super.onOptionsItemSelected(item);
-            }
-    }
+  }
 
 }

--- a/java/change-viewpoint/src/main/java/com/esri/arcgisruntime/sample/changeviewpoint/MainActivity.java
+++ b/java/change-viewpoint/src/main/java/com/esri/arcgisruntime/sample/changeviewpoint/MainActivity.java
@@ -20,6 +20,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
@@ -41,131 +42,139 @@ import com.esri.arcgisruntime.symbology.SimpleFillSymbol;
 
 public class MainActivity extends AppCompatActivity {
 
-    private static final int SCALE = 7000;
-    private static final String TAG = "ChangeViewPoint";
-    ArcGISMap mMap;
-    private MapView mMapView;
-    private SpatialReference spatialReference;
-    private Button mGeometryButton, mCenterScaleButton, mAnimateButton;
-    private int mDuration = 10;
-    private boolean isGeometryButtonClicked = false;
+  private static final int SCALE = 7000;
+  private static final String TAG = "ChangeViewPoint";
+  ArcGISMap mMap;
+  private MapView mMapView;
+  private SpatialReference spatialReference;
+  private Button mGeometryButton, mCenterScaleButton, mAnimateButton;
+  private int mDuration = 10;
+  private boolean isGeometryButtonClicked = false;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the BasemapType topographic
-        mMap = new ArcGISMap(Basemap.createImageryWithLabels());
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
-        // create spatial reference for all points
-        spatialReference = SpatialReference.create(2229);
-        // create point for starting location - London
-        Point startPoint = new Point(28677947.756181,22987445.6186465, spatialReference);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the BasemapType topographic
+    mMap = new ArcGISMap(Basemap.createImageryWithLabels());
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
+    // create spatial reference for all points
+    spatialReference = SpatialReference.create(2229);
+    // create point for starting location - London
+    Point startPoint = new Point(28677947.756181, 22987445.6186465, spatialReference);
 
-        //set viewpoint of map view to starting point and scaled
-        mMapView.setViewpointCenterAsync(startPoint, SCALE);
+    //set viewpoint of map view to starting point and scaled
+    mMapView.setViewpointCenterAsync(startPoint, SCALE);
 
-        // inflate the Buttons from the layout
-        mGeometryButton = (Button) findViewById(R.id.geometryButton);
-        mCenterScaleButton = (Button) findViewById(R.id.centerScaleButton);
-        mAnimateButton = (Button) findViewById(R.id.animateButton);
+    // inflate the Buttons from the layout
+    mGeometryButton = (Button) findViewById(R.id.geometryButton);
+    mCenterScaleButton = (Button) findViewById(R.id.centerScaleButton);
+    mAnimateButton = (Button) findViewById(R.id.animateButton);
 
-        // create geometry of Griffith Park from JSON raw file, add graphics and set viewpoint of the map view to Griffith Park
-        mGeometryButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                // create an input stream for the raw text file containing JSON of Griffith Park
-                InputStream ins = getResources().openRawResource(
-                        getResources().getIdentifier("griffithparkjson",
-                                "raw", getPackageName()));
+    // create geometry of Griffith Park from JSON raw file, add graphics and set viewpoint of the map view to
+    // Griffith Park
+    mGeometryButton.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        // create an input stream for the raw text file containing JSON of Griffith Park
+        InputStream ins = getResources().openRawResource(
+            getResources().getIdentifier("griffithparkjson",
+                "raw", getPackageName()));
 
-                InputStreamReader inputReader = new InputStreamReader(ins);
+        InputStreamReader inputReader = new InputStreamReader(ins);
 
-                BufferedReader bufferReader = new BufferedReader(inputReader);
-                String line;
-                StringBuilder text = new StringBuilder();
+        BufferedReader bufferReader = new BufferedReader(inputReader);
+        String line;
+        StringBuilder text = new StringBuilder();
 
-                // read the text file
-                try {
-                    while (( line = bufferReader.readLine()) != null) {
-                        text.append(line);
-                    }
-                } catch (IOException e) {
-                    Log.d(TAG, e.toString());
-                }
-                String JsonString = text.toString();
+        // read the text file
+        try {
+          while ((line = bufferReader.readLine()) != null) {
+            text.append(line);
+          }
+        } catch (IOException e) {
+          Log.d(TAG, e.toString());
+        }
+        String JsonString = text.toString();
 
-                // create Geometry from JSON
-                Geometry geometry = Geometry.fromJson(JsonString, spatialReference);
-                GraphicsOverlay overlay = new GraphicsOverlay();
-                // add graphics overlay on map view
-                mMapView.getGraphicsOverlays().add(overlay);
-                SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.DIAGONAL_CROSS, Color.GREEN, null);
-                // add graphic of Griffith Park
-                overlay.getGraphics().add(new Graphic(geometry, fillSymbol));
+        // create Geometry from JSON
+        Geometry geometry = Geometry.fromJson(JsonString, spatialReference);
+        GraphicsOverlay overlay = new GraphicsOverlay();
+        // add graphics overlay on map view
+        mMapView.getGraphicsOverlays().add(overlay);
+        SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.DIAGONAL_CROSS, Color.GREEN, null);
+        // add graphic of Griffith Park
+        overlay.getGraphics().add(new Graphic(geometry, fillSymbol));
 
-                // set viewpoint of map view to Geometry - Griffith Park
-                mMapView.setViewpointGeometryAsync(geometry);
+        // set viewpoint of map view to Geometry - Griffith Park
+        mMapView.setViewpointGeometryAsync(geometry);
 
-                mGeometryButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimaryDark));
-                mAnimateButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
-                mCenterScaleButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
+        mGeometryButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimaryDark));
+        mAnimateButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
+        mCenterScaleButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
 
-                isGeometryButtonClicked = true;
-            }
-        });
+        isGeometryButtonClicked = true;
+      }
+    });
 
-        mAnimateButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                int scale;
-                if(isGeometryButtonClicked) {
-                    scale = SCALE * SCALE;
-                    isGeometryButtonClicked = false;
-                } else {
-                    scale = SCALE;
-                }
-                // create the London location point
-                Point londonPoint = new Point(28677947.756181,22987445.6186465, spatialReference);
-                // create the viewpoint with the London point and scale
-                Viewpoint viewpoint = new Viewpoint(londonPoint, scale);
-                // set the map views's viewpoint to London with a ten second duration
-                mMapView.setViewpointAsync(viewpoint, mDuration);
+    mAnimateButton.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        int scale;
+        if (isGeometryButtonClicked) {
+          scale = SCALE * SCALE;
+          isGeometryButtonClicked = false;
+        } else {
+          scale = SCALE;
+        }
+        // create the London location point
+        Point londonPoint = new Point(28677947.756181, 22987445.6186465, spatialReference);
+        // create the viewpoint with the London point and scale
+        Viewpoint viewpoint = new Viewpoint(londonPoint, scale);
+        // set the map views's viewpoint to London with a ten second duration
+        mMapView.setViewpointAsync(viewpoint, mDuration);
 
-                mGeometryButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
-                mAnimateButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimaryDark));
-                mCenterScaleButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
-            }
-        });
+        mGeometryButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
+        mAnimateButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimaryDark));
+        mCenterScaleButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
+      }
+    });
 
-        mCenterScaleButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                // create the Waterloo location point
-                Point waterlooPoint = new Point(28681235.9843606, 22990575.7224154, spatialReference);
-                // set the map views's viewpoint centered on Waterloo and scaled
-                mMapView.setViewpointCenterAsync(waterlooPoint, SCALE);
+    mCenterScaleButton.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        // create the Waterloo location point
+        Point waterlooPoint = new Point(28681235.9843606, 22990575.7224154, spatialReference);
+        // set the map views's viewpoint centered on Waterloo and scaled
+        mMapView.setViewpointCenterAsync(waterlooPoint, SCALE);
 
-                mGeometryButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
-                mAnimateButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
-                mCenterScaleButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimaryDark));
-            }
-        });
-    }
+        mGeometryButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
+        mAnimateButton.setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimary));
+        mCenterScaleButton
+            .setBackgroundColor(ContextCompat.getColor(getApplicationContext(), R.color.colorPrimaryDark));
+      }
+    });
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/colormap-renderer/src/main/java/com/esri/arcgisruntime/sample/colormaprenderer/MainActivity.java
+++ b/java/colormap-renderer/src/main/java/com/esri/arcgisruntime/sample/colormaprenderer/MainActivity.java
@@ -16,6 +16,10 @@
 
 package com.esri.arcgisruntime.sample.colormaprenderer;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
@@ -25,22 +29,23 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.widget.Toast;
+
 import com.esri.arcgisruntime.layers.RasterLayer;
+import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.Basemap;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.raster.ColormapRenderer;
 import com.esri.arcgisruntime.raster.Raster;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * A sample class which demonstrates the ColorMapRenderer.
  */
 public class MainActivity extends AppCompatActivity {
+
+  private final static String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
 
@@ -118,7 +123,13 @@ public class MainActivity extends AppCompatActivity {
     rasterLayer.addDoneLoadingListener(new Runnable() {
       @Override
       public void run() {
-        mMapView.setViewpointGeometryAsync(rasterLayer.getFullExtent(), 50);
+        if (rasterLayer.getLoadStatus() == LoadStatus.LOADED) {
+          mMapView.setViewpointGeometryAsync(rasterLayer.getFullExtent(), 50);
+        } else {
+          String error = "RasterLayer failed to load: " + rasterLayer.getLoadError().getMessage();
+          Log.e(TAG, error);
+          Toast.makeText(MainActivity.this, error, Toast.LENGTH_LONG).show();
+        }
       }
     });
   }
@@ -149,5 +160,11 @@ public class MainActivity extends AppCompatActivity {
   protected void onResume() {
     super.onResume();
     mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
   }
 }

--- a/java/colormap-renderer/src/main/res/values/strings.xml
+++ b/java/colormap-renderer/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Colormap Renderer</string>
     <string name="location_permission_denied">Colormap Renderer could not open the raster because WRITE permission was denied.</string>
-    <string name="config_data_sdcard_offline_dir">/ArcGIS/samples/raster</string>
+    <string name="config_data_sdcard_offline_dir">ArcGIS/samples/raster</string>
     <string name="config_raster_name">ShastaBW</string>
 </resources>

--- a/java/create-geometries/src/main/java/com/esri/arcgisruntime/sample/creategeometries/MainActivity.java
+++ b/java/create-geometries/src/main/java/com/esri/arcgisruntime/sample/creategeometries/MainActivity.java
@@ -43,6 +43,40 @@ import com.esri.arcgisruntime.symbology.SimpleMarkerSymbol;
  */
 public class MainActivity extends AppCompatActivity {
 
+  private MapView mMapView;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+
+    // get MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+
+    // create a map with the BasemapType topographic
+    final ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+
+    // set the map to be displayed in this view
+    mMapView.setMap(map);
+
+    // create color and symbols for drawing graphics
+    SimpleMarkerSymbol markerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.TRIANGLE, Color.BLUE, 14);
+    SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.CROSS, Color.BLUE, null);
+    SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.BLUE, 3);
+
+    // add a graphic of point, multipoint, polyline and polygon.
+    GraphicsOverlay overlay = new GraphicsOverlay();
+    mMapView.getGraphicsOverlays().add(overlay);
+    overlay.getGraphics().add(new Graphic(createPolygon(), fillSymbol));
+    overlay.getGraphics().add(new Graphic(createPolyline(), lineSymbol));
+    overlay.getGraphics().add(new Graphic(createMultipoint(), markerSymbol));
+    overlay.getGraphics().add(new Graphic(createPoint(), markerSymbol));
+
+    // use the envelope to set the map viewpoint
+    mMapView.setViewpointGeometryAsync(createEnvelope(), getResources().getDimension(R.dimen.viewpoint_padding));
+
+  }
+
   private Envelope createEnvelope() {
 
     //[DocRef: Name=Create Envelope, Category=Fundamentals, Topic=Geometries]
@@ -103,37 +137,21 @@ public class MainActivity extends AppCompatActivity {
     return polygon;
   }
 
-
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    setContentView(R.layout.activity_main);
-
-    // get MapView from layout
-    MapView mMapView = (MapView) findViewById(R.id.mapView);
-
-    // create a map with the BasemapType topographic
-    final ArcGISMap mMap = new ArcGISMap(Basemap.createTopographic());
-
-    // set the map to be displayed in this view
-    mMapView.setMap(mMap);
-
-    // create color and symbols for drawing graphics
-    SimpleMarkerSymbol markerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.TRIANGLE, Color.BLUE, 14);
-    SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.CROSS, Color.BLUE, null);
-    SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.BLUE, 3);
-
-    // add a graphic of point, multipoint, polyline and polygon.
-    GraphicsOverlay overlay = new GraphicsOverlay();
-    mMapView.getGraphicsOverlays().add(overlay);
-    overlay.getGraphics().add(new Graphic(createPolygon(), fillSymbol));
-    overlay.getGraphics().add(new Graphic(createPolyline(), lineSymbol));
-    overlay.getGraphics().add(new Graphic(createMultipoint(), markerSymbol));
-    overlay.getGraphics().add(new Graphic(createPoint(), markerSymbol));
-
-    // use the envelope to set the map viewpoint
-    mMapView.setViewpointGeometryAsync(createEnvelope(), getResources().getDimension(R.dimen.viewpoint_padding));
-
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
   }
 
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/create-geometries/src/main/java/com/esri/arcgisruntime/sample/creategeometries/MainActivity.java
+++ b/java/create-geometries/src/main/java/com/esri/arcgisruntime/sample/creategeometries/MainActivity.java
@@ -45,38 +45,6 @@ public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
 
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    setContentView(R.layout.activity_main);
-
-    // get MapView from layout
-    mMapView = (MapView) findViewById(R.id.mapView);
-
-    // create a map with the BasemapType topographic
-    final ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
-
-    // set the map to be displayed in this view
-    mMapView.setMap(map);
-
-    // create color and symbols for drawing graphics
-    SimpleMarkerSymbol markerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.TRIANGLE, Color.BLUE, 14);
-    SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.CROSS, Color.BLUE, null);
-    SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.BLUE, 3);
-
-    // add a graphic of point, multipoint, polyline and polygon.
-    GraphicsOverlay overlay = new GraphicsOverlay();
-    mMapView.getGraphicsOverlays().add(overlay);
-    overlay.getGraphics().add(new Graphic(createPolygon(), fillSymbol));
-    overlay.getGraphics().add(new Graphic(createPolyline(), lineSymbol));
-    overlay.getGraphics().add(new Graphic(createMultipoint(), markerSymbol));
-    overlay.getGraphics().add(new Graphic(createPoint(), markerSymbol));
-
-    // use the envelope to set the map viewpoint
-    mMapView.setViewpointGeometryAsync(createEnvelope(), getResources().getDimension(R.dimen.viewpoint_padding));
-
-  }
-
   private Envelope createEnvelope() {
 
     //[DocRef: Name=Create Envelope, Category=Fundamentals, Topic=Geometries]
@@ -135,6 +103,39 @@ public class MainActivity extends AppCompatActivity {
     //[DocRef: END]
 
     return polygon;
+  }
+
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+
+    // get MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+
+    // create a map with the BasemapType topographic
+    final ArcGISMap mMap = new ArcGISMap(Basemap.createTopographic());
+
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
+
+    // create color and symbols for drawing graphics
+    SimpleMarkerSymbol markerSymbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.TRIANGLE, Color.BLUE, 14);
+    SimpleFillSymbol fillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.CROSS, Color.BLUE, null);
+    SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.BLUE, 3);
+
+    // add a graphic of point, multipoint, polyline and polygon.
+    GraphicsOverlay overlay = new GraphicsOverlay();
+    mMapView.getGraphicsOverlays().add(overlay);
+    overlay.getGraphics().add(new Graphic(createPolygon(), fillSymbol));
+    overlay.getGraphics().add(new Graphic(createPolyline(), lineSymbol));
+    overlay.getGraphics().add(new Graphic(createMultipoint(), markerSymbol));
+    overlay.getGraphics().add(new Graphic(createPoint(), markerSymbol));
+
+    // use the envelope to set the map viewpoint
+    mMapView.setViewpointGeometryAsync(createEnvelope(), getResources().getDimension(R.dimen.viewpoint_padding));
+
   }
 
   @Override

--- a/java/create-save-map/src/main/java/com/esri/arcgisruntime/sample/createsavemap/MainActivity.java
+++ b/java/create-save-map/src/main/java/com/esri/arcgisruntime/sample/createsavemap/MainActivity.java
@@ -303,4 +303,21 @@ public class MainActivity extends AppCompatActivity {
     }
   }
 
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/display-device-location/src/main/AndroidManifest.xml
+++ b/java/display-device-location/src/main/AndroidManifest.xml
@@ -17,7 +17,6 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:configChanges="orientation|screenSize|uiMode"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/java/display-device-location/src/main/java/com/esri/arcgisruntime/sample/displaydevicelocation/MainActivity.java
+++ b/java/display-device-location/src/main/java/com/esri/arcgisruntime/sample/displaydevicelocation/MainActivity.java
@@ -16,6 +16,8 @@
 
 package com.esri.arcgisruntime.sample.displaydevicelocation;
 
+import java.util.ArrayList;
+
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -34,8 +36,6 @@ import com.esri.arcgisruntime.mapping.view.LocationDisplay;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.sample.spinner.ItemData;
 import com.esri.arcgisruntime.sample.spinner.SpinnerAdapter;
-
-import java.util.ArrayList;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -191,4 +191,9 @@ public class MainActivity extends AppCompatActivity {
     mMapView.resume();
   }
 
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/display-drawing-status/src/main/AndroidManifest.xml
+++ b/java/display-drawing-status/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/display-drawing-status/src/main/java/com/esri/arcgisruntime/sample/displaydrawingstatus/MainActivity.java
+++ b/java/display-drawing-status/src/main/java/com/esri/arcgisruntime/sample/displaydrawingstatus/MainActivity.java
@@ -36,60 +36,68 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        final ProgressBar progressBar = (ProgressBar) findViewById(R.id.progressBar);
+    final ProgressBar progressBar = (ProgressBar) findViewById(R.id.progressBar);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the Basemap Type topographic
-        ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
-        // create an envelope
-        Envelope targetExtent = new Envelope(-13639984.0, 4537387.0, -13606734.0, 4558866.0, SpatialReferences.getWebMercator());
-        // use envelope to set initial viewpoint
-        Viewpoint initViewpoint = new Viewpoint(targetExtent);
-        // set the initial viewpoint in the map
-        map.setInitialViewpoint(initViewpoint);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the Basemap Type topographic
+    ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+    // create an envelope
+    Envelope targetExtent = new Envelope(-13639984.0, 4537387.0, -13606734.0, 4558866.0,
+        SpatialReferences.getWebMercator());
+    // use envelope to set initial viewpoint
+    Viewpoint initViewpoint = new Viewpoint(targetExtent);
+    // set the initial viewpoint in the map
+    map.setInitialViewpoint(initViewpoint);
 
-        // create a feature table from a service url
-        ServiceFeatureTable svcFeaturetable = new ServiceFeatureTable(getResources().getString(R.string.service_feature_table_url));
-        // create a feature layer
-        FeatureLayer featureLayer = new FeatureLayer(svcFeaturetable);
-        // add feature layer to map
-        map.getOperationalLayers().add(featureLayer);
+    // create a feature table from a service url
+    ServiceFeatureTable svcFeaturetable = new ServiceFeatureTable(
+        getResources().getString(R.string.service_feature_table_url));
+    // create a feature layer
+    FeatureLayer featureLayer = new FeatureLayer(svcFeaturetable);
+    // add feature layer to map
+    map.getOperationalLayers().add(featureLayer);
 
-        // set the map to be displayed in this view
-        mMapView.setMap(map);
+    // set the map to be displayed in this view
+    mMapView.setMap(map);
 
-        //[DocRef: Name=Monitor map drawing, Category=Work with maps, Topic=Display a map]
-        mMapView.addDrawStatusChangedListener(new DrawStatusChangedListener() {
-            @Override
-            public void drawStatusChanged(DrawStatusChangedEvent drawStatusChangedEvent) {
-                if(drawStatusChangedEvent.getDrawStatus() == DrawStatus.IN_PROGRESS){
-                    progressBar.setVisibility(View.VISIBLE);
-                    Log.d("drawStatusChanged", "spinner visible");
-                }else if (drawStatusChangedEvent.getDrawStatus() == DrawStatus.COMPLETED){
-                    progressBar.setVisibility(View.INVISIBLE);
-                }
-            }
-        });
-        //[DocRef: END]
-    }
+    //[DocRef: Name=Monitor map drawing, Category=Work with maps, Topic=Display a map]
+    mMapView.addDrawStatusChangedListener(new DrawStatusChangedListener() {
+      @Override
+      public void drawStatusChanged(DrawStatusChangedEvent drawStatusChangedEvent) {
+        if (drawStatusChangedEvent.getDrawStatus() == DrawStatus.IN_PROGRESS) {
+          progressBar.setVisibility(View.VISIBLE);
+          Log.d("drawStatusChanged", "spinner visible");
+        } else if (drawStatusChangedEvent.getDrawStatus() == DrawStatus.COMPLETED) {
+          progressBar.setVisibility(View.INVISIBLE);
+        }
+      }
+    });
+    //[DocRef: END]
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/display-layer-view-state/src/main/java/com/esri/arcgisruntime/sample/displaylayerviewstate/MainActivity.java
+++ b/java/display-layer-view-state/src/main/java/com/esri/arcgisruntime/sample/displaylayerviewstate/MainActivity.java
@@ -36,119 +36,133 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private static final int MIN_SCALE = 40000000;
-    private static final int TILED_LAYER = 0;
-    private static final int IMAGE_LAYER = 1;
-    private static final int FEATURE_LAYER = 2;
-    private MapView mMapView;
-    private TextView timeZoneTextView;
-    private TextView worldCensusTextView;
-    private TextView recreationTextView;
+  private static final int MIN_SCALE = 40000000;
+  private static final int TILED_LAYER = 0;
+  private static final int IMAGE_LAYER = 1;
+  private static final int FEATURE_LAYER = 2;
+  private MapView mMapView;
+  private TextView timeZoneTextView;
+  private TextView worldCensusTextView;
+  private TextView recreationTextView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // create three layers to add to the map
-        final ArcGISTiledLayer tiledLayer = new ArcGISTiledLayer(getApplication().getString(R.string.world_timezone_service_URL));
-        tiledLayer.setMinScale(4E8);
+    // create three layers to add to the map
+    final ArcGISTiledLayer tiledLayer = new ArcGISTiledLayer(
+        getApplication().getString(R.string.world_timezone_service_URL));
+    tiledLayer.setMinScale(4E8);
 
-        final ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer(getApplication().getString(R.string.world_census_service_URL));
-        // setting the scales at which this layer can be viewed
-        imageLayer.setMinScale(MIN_SCALE);
-        imageLayer.setMaxScale(MIN_SCALE / 10);
+    final ArcGISMapImageLayer imageLayer = new ArcGISMapImageLayer(
+        getApplication().getString(R.string.world_census_service_URL));
+    // setting the scales at which this layer can be viewed
+    imageLayer.setMinScale(MIN_SCALE);
+    imageLayer.setMaxScale(MIN_SCALE / 10);
 
-        // creating a layer from a service feature table
-        final ServiceFeatureTable featureTable = new ServiceFeatureTable(getApplication().getString(R.string.world_facilities_service_URL));
-        final FeatureLayer featureLayer = new FeatureLayer(featureTable);
+    // creating a layer from a service feature table
+    final ServiceFeatureTable featureTable = new ServiceFeatureTable(
+        getApplication().getString(R.string.world_facilities_service_URL));
+    final FeatureLayer featureLayer = new FeatureLayer(featureTable);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the BasemapType topographic
-        final ArcGISMap mMap = new ArcGISMap(Basemap.createTopographic());
-        // add the layers on the map
-        mMap.getOperationalLayers().add(tiledLayer);
-        mMap.getOperationalLayers().add(imageLayer);
-        mMap.getOperationalLayers().add(featureLayer);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the BasemapType topographic
+    final ArcGISMap mMap = new ArcGISMap(Basemap.createTopographic());
+    // add the layers on the map
+    mMap.getOperationalLayers().add(tiledLayer);
+    mMap.getOperationalLayers().add(imageLayer);
+    mMap.getOperationalLayers().add(featureLayer);
 
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
 
-        // inflate TextViews from the layout
-        timeZoneTextView = (TextView) findViewById(R.id.worldTimeZoneStatusView);
-        worldCensusTextView = (TextView) findViewById(R.id.censusStatusView);
-        recreationTextView = (TextView) findViewById(R.id.facilitiesStatusView);
+    // inflate TextViews from the layout
+    timeZoneTextView = (TextView) findViewById(R.id.worldTimeZoneStatusView);
+    worldCensusTextView = (TextView) findViewById(R.id.censusStatusView);
+    recreationTextView = (TextView) findViewById(R.id.facilitiesStatusView);
 
-        // zoom to custom ViewPoint
-        mMapView.setViewpoint(new Viewpoint(
-                new Point(-11e6, 45e5, SpatialReferences.getWebMercator()), MIN_SCALE));
+    // zoom to custom ViewPoint
+    mMapView.setViewpoint(new Viewpoint(
+        new Point(-11e6, 45e5, SpatialReferences.getWebMercator()), MIN_SCALE));
 
-        // Listen to changes in the status of the Layer
-        mMapView.addLayerViewStateChangedListener(new LayerViewStateChangedListener() {
-            @Override
-            public void layerViewStateChanged(LayerViewStateChangedEvent layerViewStateChangedEvent) {
+    // Listen to changes in the status of the Layer
+    mMapView.addLayerViewStateChangedListener(new LayerViewStateChangedListener() {
+      @Override
+      public void layerViewStateChanged(LayerViewStateChangedEvent layerViewStateChangedEvent) {
 
-                // get the layer which changed it's state
-                Layer layer = layerViewStateChangedEvent.getLayer();
+        // get the layer which changed it's state
+        Layer layer = layerViewStateChangedEvent.getLayer();
 
-                // get the View Status of the layer
-                // View status will be either of ACTIVE, ERROR, LOADING, NOT_VISIBLE, OUT_OF_SCALE, UNKNOWN
-                String viewStatus = layerViewStateChangedEvent.getLayerViewStatus().iterator().next().toString();
+        // get the View Status of the layer
+        // View status will be either of ACTIVE, ERROR, LOADING, NOT_VISIBLE, OUT_OF_SCALE, UNKNOWN
+        String viewStatus = layerViewStateChangedEvent.getLayerViewStatus().iterator().next().toString();
 
-                final int layerIndex = mMap.getOperationalLayers().indexOf(layer);
+        final int layerIndex = mMap.getOperationalLayers().indexOf(layer);
 
-                // finding and updating status of the layer
-                switch (layerIndex) {
-                    case TILED_LAYER:
-                        timeZoneTextView.setText(viewStatusString(viewStatus));
-                        break;
-                    case IMAGE_LAYER:
-                        worldCensusTextView.setText(viewStatusString(viewStatus));
-                        break;
-                    case FEATURE_LAYER:
-                        recreationTextView.setText(viewStatusString(viewStatus));
-                        break;
-                }
-
-            }
-        });
-    }
-
-    /**
-     * The method looks up the view status of the layer and returns a string which is displayed
-     *
-     * @param status View Status of the layer
-     * @return String equivalent of the status
-     */
-    private String viewStatusString (String status) {
-
-        switch(status) {
-            case "ACTIVE": return getApplication().getString(R.string.active);
-
-            case "ERROR": return getApplication().getString(R.string.error);
-
-            case "LOADING": return getApplication().getString(R.string.loading);
-
-            case "NOT_VISIBLE": return getApplication().getString(R.string.notVisible);
-
-            case "OUT_OF_SCALE": return getApplication().getString(R.string.outOfScale);
-
+        // finding and updating status of the layer
+        switch (layerIndex) {
+          case TILED_LAYER:
+            timeZoneTextView.setText(viewStatusString(viewStatus));
+            break;
+          case IMAGE_LAYER:
+            worldCensusTextView.setText(viewStatusString(viewStatus));
+            break;
+          case FEATURE_LAYER:
+            recreationTextView.setText(viewStatusString(viewStatus));
+            break;
         }
 
-        return getApplication().getString(R.string.unknown);
+      }
+    });
+  }
+
+  /**
+   * The method looks up the view status of the layer and returns a string which is displayed
+   *
+   * @param status View Status of the layer
+   * @return String equivalent of the status
+   */
+  private String viewStatusString(String status) {
+
+    switch (status) {
+      case "ACTIVE":
+        return getApplication().getString(R.string.active);
+
+      case "ERROR":
+        return getApplication().getString(R.string.error);
+
+      case "LOADING":
+        return getApplication().getString(R.string.loading);
+
+      case "NOT_VISIBLE":
+        return getApplication().getString(R.string.notVisible);
+
+      case "OUT_OF_SCALE":
+        return getApplication().getString(R.string.outOfScale);
 
     }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+    return getApplication().getString(R.string.unknown);
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/display-map/src/main/AndroidManifest.xml
+++ b/java/display-map/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/display-map/src/main/java/com/esri/arcgisruntime/sample/displaymap/MainActivity.java
+++ b/java/display-map/src/main/java/com/esri/arcgisruntime/sample/displaymap/MainActivity.java
@@ -25,30 +25,36 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the BasemapType topographic
-        ArcGISMap map = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 16);
-        // set the map to be displayed in this view
-        mMapView.setMap(map);
-    }
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the BasemapType topographic
+    ArcGISMap map = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 16);
+    // set the map to be displayed in this view
+    mMapView.setMap(map);
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/display-scene/src/main/AndroidManifest.xml
+++ b/java/display-scene/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize">
+        <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/display-scene/src/main/java/com/esri/arcgisruntime/sample/displayscene/MainActivity.java
+++ b/java/display-scene/src/main/java/com/esri/arcgisruntime/sample/displayscene/MainActivity.java
@@ -27,48 +27,54 @@ import com.esri.arcgisruntime.mapping.view.SceneView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private SceneView mSceneView;
+  private SceneView mSceneView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // create a scene and add a basemap to it
-        ArcGISScene scene = new ArcGISScene();
-        scene.setBasemap(Basemap.createImagery());
+    // create a scene and add a basemap to it
+    ArcGISScene scene = new ArcGISScene();
+    scene.setBasemap(Basemap.createImagery());
 
-        //[DocRef: Name=Display Scene-android, Category=Work with 3D, Topic=Display a scene]
-        // create SceneView from layout
-        mSceneView = (SceneView) findViewById(R.id.sceneView);
-        mSceneView.setScene(scene);
-        //[DocRef: END]
+    //[DocRef: Name=Display Scene-android, Category=Work with 3D, Topic=Display a scene]
+    // create SceneView from layout
+    mSceneView = (SceneView) findViewById(R.id.sceneView);
+    mSceneView.setScene(scene);
+    //[DocRef: END]
 
-        //[DocRef: Name=Add elevation to base surface-android, Category=Work with 3D, Topic=Display a scene,
-        // RemoveChars=getResources().getString(R.string.elevation_image_service),
-        // ReplaceChars=http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer]
-        // create an elevation source, and add this to the base surface of the scene
-        ArcGISTiledElevationSource elevationSource = new ArcGISTiledElevationSource(
-                getResources().getString(R.string.elevation_image_service));
-        scene.getBaseSurface().getElevationSources().add(elevationSource);
-        //[DocRef: END]
+    //[DocRef: Name=Add elevation to base surface-android, Category=Work with 3D, Topic=Display a scene,
+    // RemoveChars=getResources().getString(R.string.elevation_image_service),
+    // ReplaceChars=http://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer]
+    // create an elevation source, and add this to the base surface of the scene
+    ArcGISTiledElevationSource elevationSource = new ArcGISTiledElevationSource(
+        getResources().getString(R.string.elevation_image_service));
+    scene.getBaseSurface().getElevationSources().add(elevationSource);
+    //[DocRef: END]
 
-        // add a camera and initial camera position
-        Camera camera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 0.0);
-        mSceneView.setViewpointCamera(camera);
-    }
+    // add a camera and initial camera position
+    Camera camera = new Camera(28.4, 83.9, 10010.0, 10.0, 80.0, 0.0);
+    mSceneView.setViewpointCamera(camera);
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause SceneView
-        mSceneView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause SceneView
+    mSceneView.pause();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // resume SceneView
-        mSceneView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume SceneView
+    mSceneView.resume();
+  }
+
+  @Override protected void onDestroy() {
+    super.onDestroy();
+    // dispose SceneView
+    mSceneView.dispose();
+  }
 }

--- a/java/edit-and-sync-features/src/main/AndroidManifest.xml
+++ b/java/edit-and-sync-features/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/edit-and-sync-features/src/main/java/com/esri/arcgisruntime/sample/editandsyncfeatures/MainActivity.java
+++ b/java/edit-and-sync-features/src/main/java/com/esri/arcgisruntime/sample/editandsyncfeatures/MainActivity.java
@@ -394,6 +394,11 @@ public class MainActivity extends AppCompatActivity {
     mMapView.resume();
   }
 
+  @Override protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
+
   @Override
   public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
     if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {

--- a/java/edit-feature-attachments/src/main/java/com/esri/arcgisruntime/sample/editfeatureattachments/MainActivity.java
+++ b/java/edit-feature-attachments/src/main/java/com/esri/arcgisruntime/sample/editfeatureattachments/MainActivity.java
@@ -55,6 +55,7 @@ public class MainActivity extends AppCompatActivity {
   private FeatureLayer mFeatureLayer;
   private ArcGISFeature mSelectedArcGISFeature;
   private android.graphics.Point mClickPoint;
+  private MapView mMapView;
   private List<Attachment> attachments;
   private String mSelectedArcGISFeatureAttributeValue;
   private String mAttributeID;
@@ -64,18 +65,18 @@ public class MainActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
     // inflate MapView from layout
-    MapView mapView = (MapView) findViewById(R.id.mapView);
+    mMapView = (MapView) findViewById(R.id.mapView);
     // create a map with the streets basemap
     ArcGISMap map = new ArcGISMap(Basemap.Type.STREETS, 44.354388, -119.998245, 5);
     // set the map to be displayed in the mapview
-    mapView.setMap(map);
+    mMapView.setMap(map);
 
     progressDialog = new ProgressDialog(this);
     progressDialog.setTitle(getApplication().getString(R.string.fetching_no_attachments));
     progressDialog.setMessage(getApplication().getString(R.string.wait));
     createCallout();
     // get callout, set content and show
-    mCallout = mapView.getCallout();
+    mCallout = mMapView.getCallout();
     // create feature layer with its service feature table
     // create the service feature table
     ServiceFeatureTable mServiceFeatureTable = new ServiceFeatureTable(
@@ -92,7 +93,7 @@ public class MainActivity extends AppCompatActivity {
     // add the layer to the map
     map.getOperationalLayers().add(mFeatureLayer);
 
-    mapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mapView) {
+    mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView) {
       @Override
       public boolean onSingleTapConfirmed(MotionEvent e) {
 
@@ -253,6 +254,24 @@ public class MainActivity extends AppCompatActivity {
       startActivityForResult(myIntent, REQUEST_CODE, bundle);
 
     }
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
   }
 
 }

--- a/java/export-tiles/src/main/AndroidManifest.xml
+++ b/java/export-tiles/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/export-tiles/src/main/java/com/esri/arcgisruntime/sample/exporttiles/MainActivity.java
+++ b/java/export-tiles/src/main/java/com/esri/arcgisruntime/sample/exporttiles/MainActivity.java
@@ -317,4 +317,11 @@ public class MainActivity extends AppCompatActivity {
     mMapView.resume();
     mTileCachePreview.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+    mTileCachePreview.dispose();
+  }
 }

--- a/java/feature-collection-layer-query/src/main/AndroidManifest.xml
+++ b/java/feature-collection-layer-query/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/feature-collection-layer-query/src/main/java/com/esri/arcgisruntime/sample/featurecollectionlayerquery/MainActivity.java
+++ b/java/feature-collection-layer-query/src/main/java/com/esri/arcgisruntime/sample/featurecollectionlayerquery/MainActivity.java
@@ -99,4 +99,10 @@ public class MainActivity extends AppCompatActivity {
     super.onResume();
     mMapView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/feature-layer-definition-expression/src/main/java/com/esri/arcgisruntime/samples/featurelayerdefinitionexpression/MainActivity.java
+++ b/java/feature-layer-definition-expression/src/main/java/com/esri/arcgisruntime/samples/featurelayerdefinitionexpression/MainActivity.java
@@ -28,95 +28,102 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    MapView mMapView;
-    FeatureLayer mFeatureLayer;
+  MapView mMapView;
+  FeatureLayer mFeatureLayer;
 
-    boolean applyActive;
+  boolean applyActive;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // set up the bottom toolbar
-        createBottomToolbar();
+    // set up the bottom toolbar
+    createBottomToolbar();
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // create a map with the topographic basemap
-        ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+    // create a map with the topographic basemap
+    ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
 
-        // create feature layer with its service feature table
-        // create the service feature table
-        ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.sample_service_url));
+    // create feature layer with its service feature table
+    // create the service feature table
+    ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(
+        getResources().getString(R.string.sample_service_url));
 
-        // create the feature layer using the service feature table
-        mFeatureLayer = new FeatureLayer(serviceFeatureTable);
+    // create the feature layer using the service feature table
+    mFeatureLayer = new FeatureLayer(serviceFeatureTable);
 
-        // add the layer to the map
-        map.getOperationalLayers().add(mFeatureLayer);
+    // add the layer to the map
+    map.getOperationalLayers().add(mFeatureLayer);
 
-        // set the map to be displayed in the mapview
-        mMapView.setMap(map);
+    // set the map to be displayed in the mapview
+    mMapView.setMap(map);
 
-        // zoom to a view point of the USA
-        mMapView.setViewpointCenterAsync(new Point(-13630845, 4544861, SpatialReferences.getWebMercator()), 600000);
+    // zoom to a view point of the USA
+    mMapView.setViewpointCenterAsync(new Point(-13630845, 4544861, SpatialReferences.getWebMercator()), 600000);
 
-    }
+  }
 
-    private void applyDefinitionExpression() {
-        // apply a definition expression on the feature layer
-        // if this is called before the layer is loaded, it will be applied to the loaded layer
-        mFeatureLayer.setDefinitionExpression("req_Type = 'Tree Maintenance or Damage'");
-    }
+  private void applyDefinitionExpression() {
+    // apply a definition expression on the feature layer
+    // if this is called before the layer is loaded, it will be applied to the loaded layer
+    mFeatureLayer.setDefinitionExpression("req_Type = 'Tree Maintenance or Damage'");
+  }
 
-    private void resetDefinitionExpression() {
-        // set the definition expression to nothing (empty string, null also works)
-        mFeatureLayer.setDefinitionExpression("");
-    }
+  private void resetDefinitionExpression() {
+    // set the definition expression to nothing (empty string, null also works)
+    mFeatureLayer.setDefinitionExpression("");
+  }
 
-    private void createBottomToolbar() {
+  private void createBottomToolbar() {
 
-        Toolbar bottomToolbar = (Toolbar) findViewById(R.id.bottomToolbar);
-        bottomToolbar.inflateMenu(R.menu.menu_main);
+    Toolbar bottomToolbar = (Toolbar) findViewById(R.id.bottomToolbar);
+    bottomToolbar.inflateMenu(R.menu.menu_main);
 
-        bottomToolbar.setOnMenuItemClickListener(new Toolbar.OnMenuItemClickListener() {
-            @Override
-            public boolean onMenuItemClick(MenuItem item) {
-                // Handle action bar item clicks
-                int itemId = item.getItemId();
-                //if statement is used because this sample is used elsewhere as a Library module
-                if(itemId == R.id.action_def_exp){
-                    // check the state of the menu item
-                    if (!applyActive) {
-                        applyDefinitionExpression();
-                        // change the text to reset
-                        applyActive = true;
-                        item.setTitle(R.string.action_reset);
-                    } else {
-                        resetDefinitionExpression();
-                        // change the text to apply
-                        applyActive = false;
-                        item.setTitle(R.string.action_def_exp);
-                    }
-                }
-                return true;
-            }
-        });
-    }
+    bottomToolbar.setOnMenuItemClickListener(new Toolbar.OnMenuItemClickListener() {
+      @Override
+      public boolean onMenuItemClick(MenuItem item) {
+        // handle action bar item clicks
+        int itemId = item.getItemId();
+        // if statement is used because this sample is used elsewhere as a Library module
+        if (itemId == R.id.action_def_exp) {
+          // check the state of the menu item
+          if (!applyActive) {
+            applyDefinitionExpression();
+            // change the text to reset
+            applyActive = true;
+            item.setTitle(R.string.action_reset);
+          } else {
+            resetDefinitionExpression();
+            // change the text to apply
+            applyActive = false;
+            item.setTitle(R.string.action_def_exp);
+          }
+        }
+        return true;
+      }
+    });
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/feature-layer-extrusion/src/main/AndroidManifest.xml
+++ b/java/feature-layer-extrusion/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize">
+        <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/feature-layer-extrusion/src/main/java/com/esri/arcgisruntime/sample/featurelayerextrusion/MainActivity.java
+++ b/java/feature-layer-extrusion/src/main/java/com/esri/arcgisruntime/sample/featurelayerextrusion/MainActivity.java
@@ -38,6 +38,8 @@ import com.esri.arcgisruntime.symbology.SimpleRenderer;
 
 public class MainActivity extends AppCompatActivity {
 
+  private SceneView mSceneView;
+
   private boolean showTotalPopulation;
 
   @Override
@@ -62,8 +64,8 @@ public class MainActivity extends AppCompatActivity {
 
     // create a scene and add it to the scene view
     ArcGISScene scene = new ArcGISScene(Basemap.createImagery());
-    SceneView sceneView = findViewById(R.id.sceneView);
-    sceneView.setScene(scene);
+    mSceneView = findViewById(R.id.sceneView);
+    mSceneView.setScene(scene);
 
     // add the feature layer to the scene
     scene.getOperationalLayers().add(statesFeatureLayer);
@@ -82,8 +84,8 @@ public class MainActivity extends AppCompatActivity {
     // add a camera and set it to orbit the look at point
     Camera camera = new Camera(lookAtPoint, 20000000, 0, 55, 0);
     OrbitLocationCameraController orbitCamera = new OrbitLocationCameraController(lookAtPoint, 20000000);
-    sceneView.setCameraController(orbitCamera);
-    sceneView.setViewpointCamera(camera);
+    mSceneView.setCameraController(orbitCamera);
+    mSceneView.setViewpointCamera(camera);
 
     // set button listener
     togglePopButton.setOnClickListener(new View.OnClickListener() {
@@ -106,5 +108,22 @@ public class MainActivity extends AppCompatActivity {
     });
     // click to set initial state
     togglePopButton.performClick();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mSceneView.pause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mSceneView.resume();
+  }
+
+  @Override protected void onDestroy() {
+    super.onDestroy();
+    mSceneView.dispose();
   }
 }

--- a/java/feature-layer-feature-service/src/main/java/com/esri/arcgisruntime/samples/featurelayerfeatureservice/MainActivity.java
+++ b/java/feature-layer-feature-service/src/main/java/com/esri/arcgisruntime/samples/featurelayerfeatureservice/MainActivity.java
@@ -15,8 +15,6 @@ package com.esri.arcgisruntime.samples.featurelayerfeatureservice;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.view.Menu;
-import android.view.MenuItem;
 
 import com.esri.arcgisruntime.data.ServiceFeatureTable;
 import com.esri.arcgisruntime.geometry.Point;
@@ -27,73 +25,54 @@ import com.esri.arcgisruntime.mapping.Basemap;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
-
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // create a map with the terrain with labels basemap
-        ArcGISMap map = new ArcGISMap(Basemap.createTerrainWithLabels());
-        //set an initial viewpointf
-        map.setInitialViewpoint(new Viewpoint(new Point(-13176752, 4090404, SpatialReferences.getWebMercator()), 500000));
+    // create a map with the terrain with labels basemap
+    ArcGISMap map = new ArcGISMap(Basemap.createTerrainWithLabels());
+    //set an initial viewpointf
+    map.setInitialViewpoint(new Viewpoint(new Point(-13176752, 4090404, SpatialReferences.getWebMercator()), 500000));
 
+    // create feature layer with its service feature table
+    // create the service feature table
+    ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(
+        getResources().getString(R.string.sample_service_url));
 
-        // create feature layer with its service feature table
-        // create the service feature table
-        ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.sample_service_url));
+    // create the feature layer using the service feature table
+    FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
 
-        // create the feature layer using the service feature table
-        FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
+    // add the layer to the map
+    map.getOperationalLayers().add(featureLayer);
 
-        // add the layer to the map
-        map.getOperationalLayers().add(featureLayer);
+    // set the map to be displayed in the mapview
+    mMapView.setMap(map);
 
-        // set the map to be displayed in the mapview
-        mMapView.setMap(map);
+  }
 
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_main, menu);
-        return true;
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // Handle action bar item clicks here. The action bar will
-        // automatically handle clicks on the Home/Up button, so long
-        // as you specify a parent activity in AndroidManifest.xml.
-        int id = item.getItemId();
-
-        //noinspection SimplifiableIfStatement
-        if (id == R.id.action_settings) {
-            return true;
-        }
-
-        return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
-    }
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/feature-layer-feature-service/src/main/res/menu/menu_main.xml
+++ b/java/feature-layer-feature-service/src/main/res/menu/menu_main.xml
@@ -1,6 +1,0 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools" tools:context=".MainActivity">
-    <item android:id="@+id/action_settings" android:title="@string/action_settings"
-        android:orderInCategory="100" app:showAsAction="never" />
-</menu>

--- a/java/feature-layer-geodatabase/src/main/AndroidManifest.xml
+++ b/java/feature-layer-geodatabase/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme"
-        android:configChanges="orientation|screenSize|uiMode">
+        android:theme="@style/AppTheme">
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/java/feature-layer-geodatabase/src/main/java/com/esri/arcgisruntime/sample/featurelayergeodatabase/MainActivity.java
+++ b/java/feature-layer-geodatabase/src/main/java/com/esri/arcgisruntime/sample/featurelayergeodatabase/MainActivity.java
@@ -131,4 +131,10 @@ public class MainActivity extends AppCompatActivity {
     super.onResume();
     mMapView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/feature-layer-geopackage/src/main/AndroidManifest.xml
+++ b/java/feature-layer-geopackage/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/feature-layer-geopackage/src/main/java/com/esri/arcgisruntime/sample/featurelayergeopackage/MainActivity.java
+++ b/java/feature-layer-geopackage/src/main/java/com/esri/arcgisruntime/sample/featurelayergeopackage/MainActivity.java
@@ -137,4 +137,10 @@ public class MainActivity extends AppCompatActivity {
     super.onResume();
     mMapView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/feature-layer-rendering-mode-map/src/main/AndroidManifest.xml
+++ b/java/feature-layer-rendering-mode-map/src/main/AndroidManifest.xml
@@ -1,26 +1,26 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.esri.arcgisruntime.sample.featurelayerrenderingmodemap">
+          package="com.esri.arcgisruntime.sample.featurelayerrenderingmodemap">
 
-    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <uses-feature
-        android:glEsVersion="0x00020000"
-        android:required="true" />
+            android:glEsVersion="0x00020000"
+            android:required="true"/>
 
     <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+            android:allowBackup="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme">
 
         <activity
-            android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+                android:name=".MainActivity"
+                android:label="@string/app_name"
+                android:configChanges="orientation|screenSize">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.MAIN"/>
 
-                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
     </application>

--- a/java/feature-layer-rendering-mode-map/src/main/AndroidManifest.xml
+++ b/java/feature-layer-rendering-mode-map/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
         <activity
                 android:name=".MainActivity"
-                android:label="@string/app_name"
-                android:configChanges="orientation|screenSize">
+                android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/java/feature-layer-rendering-mode-map/src/main/java/com/esri/arcgisruntime/sample/featurelayerrenderingmodemap/MainActivity.java
+++ b/java/feature-layer-rendering-mode-map/src/main/java/com/esri/arcgisruntime/sample/featurelayerrenderingmodemap/MainActivity.java
@@ -174,4 +174,11 @@ public class MainActivity extends AppCompatActivity {
     mMapViewTop.resume();
     mMapViewBottom.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapViewTop.dispose();
+    mMapViewBottom.dispose();
+  }
 }

--- a/java/feature-layer-rendering-mode-scene/src/main/AndroidManifest.xml
+++ b/java/feature-layer-rendering-mode-scene/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/feature-layer-rendering-mode-scene/src/main/AndroidManifest.xml
+++ b/java/feature-layer-rendering-mode-scene/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:configChanges="orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/feature-layer-rendering-mode-scene/src/main/java/com/esri/arcgisruntime/sample/featurelayerrenderingmodescene/MainActivity.java
+++ b/java/feature-layer-rendering-mode-scene/src/main/java/com/esri/arcgisruntime/sample/featurelayerrenderingmodescene/MainActivity.java
@@ -176,4 +176,11 @@ public class MainActivity extends AppCompatActivity {
     mSceneViewTop.resume();
     mSceneViewBottom.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mSceneViewTop.dispose();
+    mSceneViewBottom.dispose();
+  }
 }

--- a/java/feature-layer-selection/src/main/java/com/esri/arcgisruntime/samples/featurelayerselection/MainActivity.java
+++ b/java/feature-layer-selection/src/main/java/com/esri/arcgisruntime/samples/featurelayerselection/MainActivity.java
@@ -14,6 +14,7 @@
 package com.esri.arcgisruntime.samples.featurelayerselection;
 
 import java.util.Iterator;
+
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -38,86 +39,99 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // create a map with the streets basemap
-        final ArcGISMap map = new ArcGISMap(Basemap.createStreets());
-        //set an initial viewpoint
-        map.setInitialViewpoint(new Viewpoint(new Envelope(-1131596.019761, 3893114.069099, 3926705.982140, 7977912.461790, SpatialReferences.getWebMercator())));
-        // set the map to be displayed in the MapView
-        mMapView.setMap(map);
+    // create a map with the streets basemap
+    final ArcGISMap map = new ArcGISMap(Basemap.createStreets());
+    //set an initial viewpoint
+    map.setInitialViewpoint(new Viewpoint(new Envelope(-1131596.019761, 3893114.069099, 3926705.982140, 7977912.461790,
+        SpatialReferences.getWebMercator())));
+    // set the map to be displayed in the MapView
+    mMapView.setMap(map);
 
-        // create feature layer with its service feature table
-        // create the service feature table
-        final ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.sample_service_url));
-        // create the feature layer using the service feature table
-        final FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
-        featureLayer.setSelectionColor(Color.YELLOW);
-        featureLayer.setSelectionWidth(10);
-        // add the layer to the map
-        map.getOperationalLayers().add(featureLayer);
+    // create feature layer with its service feature table
+    // create the service feature table
+    final ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(
+        getResources().getString(R.string.sample_service_url));
+    // create the feature layer using the service feature table
+    final FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
+    featureLayer.setSelectionColor(Color.YELLOW);
+    featureLayer.setSelectionWidth(10);
+    // add the layer to the map
+    map.getOperationalLayers().add(featureLayer);
 
-        // set an on touch listener to listen for click events
-        mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView) {
-            @Override
-            public boolean onSingleTapConfirmed(MotionEvent e) {
-                // get the point that was clicked and convert it to a point in map coordinates
-                Point clickPoint = mMapView.screenToLocation(new android.graphics.Point(Math.round(e.getX()), Math.round(e.getY())));
-                int tolerance = 10;
-                double mapTolerance = tolerance * mMapView.getUnitsPerDensityIndependentPixel();
-                // create objects required to do a selection with a query
-                Envelope envelope = new Envelope(clickPoint.getX() - mapTolerance, clickPoint.getY() - mapTolerance, clickPoint.getX() + mapTolerance, clickPoint.getY() + mapTolerance, map.getSpatialReference());
-                QueryParameters query = new QueryParameters();
-                query.setGeometry(envelope);
-                // call select features
-                final ListenableFuture<FeatureQueryResult> future = featureLayer.selectFeaturesAsync(query, FeatureLayer.SelectionMode.NEW);
-                // add done loading listener to fire when the selection returns
-                future.addDoneListener(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            //call get on the future to get the result
-                            FeatureQueryResult result = future.get();
-                            // create an Iterator
-                            Iterator<Feature> iterator = result.iterator();
-                            Feature feature;
-                            // cycle through selections
-                            int counter = 0;
-                            while (iterator.hasNext()){
-                                feature = iterator.next();
-                                counter++;
-                                Log.d(getResources().getString(R.string.app_name), "Selection #: " + counter + " Table name: " + feature.getFeatureTable().getTableName());
-                            }
-                            Toast.makeText(getApplicationContext(), counter + " features selected", Toast.LENGTH_SHORT).show();
-                        } catch (Exception e) {
-                            Log.e(getResources().getString(R.string.app_name), "Select feature failed: " + e.getMessage());
-                        }
-                    }
-                });
-                return super.onSingleTapConfirmed(e);
+    // set an on touch listener to listen for click events
+    mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView) {
+      @Override
+      public boolean onSingleTapConfirmed(MotionEvent e) {
+        // get the point that was clicked and convert it to a point in map coordinates
+        Point clickPoint = mMapView
+            .screenToLocation(new android.graphics.Point(Math.round(e.getX()), Math.round(e.getY())));
+        int tolerance = 10;
+        double mapTolerance = tolerance * mMapView.getUnitsPerDensityIndependentPixel();
+        // create objects required to do a selection with a query
+        Envelope envelope = new Envelope(clickPoint.getX() - mapTolerance, clickPoint.getY() - mapTolerance,
+            clickPoint.getX() + mapTolerance, clickPoint.getY() + mapTolerance, map.getSpatialReference());
+        QueryParameters query = new QueryParameters();
+        query.setGeometry(envelope);
+        // call select features
+        final ListenableFuture<FeatureQueryResult> future = featureLayer
+            .selectFeaturesAsync(query, FeatureLayer.SelectionMode.NEW);
+        // add done loading listener to fire when the selection returns
+        future.addDoneListener(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              //call get on the future to get the result
+              FeatureQueryResult result = future.get();
+              // create an Iterator
+              Iterator<Feature> iterator = result.iterator();
+              Feature feature;
+              // cycle through selections
+              int counter = 0;
+              while (iterator.hasNext()) {
+                feature = iterator.next();
+                counter++;
+                Log.d(getResources().getString(R.string.app_name),
+                    "Selection #: " + counter + " Table name: " + feature.getFeatureTable().getTableName());
+              }
+              Toast.makeText(getApplicationContext(), counter + " features selected", Toast.LENGTH_SHORT).show();
+            } catch (Exception e) {
+              Log.e(getResources().getString(R.string.app_name), "Select feature failed: " + e.getMessage());
             }
+          }
         });
-    }
+        return super.onSingleTapConfirmed(e);
+      }
+    });
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
 }

--- a/java/feature-layer-shapefile/src/main/java/com/esri/arcgisruntime/sample/featurelayershapefile/MainActivity.java
+++ b/java/feature-layer-shapefile/src/main/java/com/esri/arcgisruntime/sample/featurelayershapefile/MainActivity.java
@@ -123,4 +123,10 @@ public class MainActivity extends AppCompatActivity {
     super.onResume();
     mMapView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/feature-layer-show-attributes/src/main/AndroidManifest.xml
+++ b/java/feature-layer-show-attributes/src/main/AndroidManifest.xml
@@ -12,8 +12,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme"
-        android:configChanges="orientation|screenSize|uiMode">
+        android:theme="@style/AppTheme">
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/java/feature-layer-show-attributes/src/main/java/com/esri/arcgisruntime/sample/featurelayershowattributes/MainActivity.java
+++ b/java/feature-layer-show-attributes/src/main/java/com/esri/arcgisruntime/sample/featurelayershowattributes/MainActivity.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -31,114 +32,123 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
-    private Callout mCallout;
+  private MapView mMapView;
+  private Callout mCallout;
 
-    private ServiceFeatureTable mServiceFeatureTable;
+  private ServiceFeatureTable mServiceFeatureTable;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create an ArcGISMap with BasemapType topo
-        final ArcGISMap map = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.057386, -117.191455, 14);
-        // set the ArcGISMap to the MapView
-        mMapView.setMap(map);
-        // get the callout that shows attributes
-        mCallout = mMapView.getCallout();
-        // create the service feature table
-        mServiceFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.sample_service_url));
-        // create the feature layer using the service feature table
-        final FeatureLayer featureLayer = new FeatureLayer(mServiceFeatureTable);
-        // add the layer to the map
-        map.getOperationalLayers().add(featureLayer);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create an ArcGISMap with BasemapType topo
+    final ArcGISMap map = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.057386, -117.191455, 14);
+    // set the ArcGISMap to the MapView
+    mMapView.setMap(map);
+    // get the callout that shows attributes
+    mCallout = mMapView.getCallout();
+    // create the service feature table
+    mServiceFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.sample_service_url));
+    // create the feature layer using the service feature table
+    final FeatureLayer featureLayer = new FeatureLayer(mServiceFeatureTable);
+    // add the layer to the map
+    map.getOperationalLayers().add(featureLayer);
 
-        // set an on touch listener to listen for click events
-        mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView) {
-            @Override
-            public boolean onSingleTapConfirmed(MotionEvent e) {
-                // remove any existing callouts
-                if(mCallout.isShowing()){
-                    mCallout.dismiss();
+    // set an on touch listener to listen for click events
+    mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView) {
+      @Override
+      public boolean onSingleTapConfirmed(MotionEvent e) {
+        // remove any existing callouts
+        if (mCallout.isShowing()) {
+          mCallout.dismiss();
+        }
+        // get the point that was clicked and convert it to a point in map coordinates
+        final Point clickPoint = mMapView
+            .screenToLocation(new android.graphics.Point(Math.round(e.getX()), Math.round(e.getY())));
+        // create a selection tolerance
+        int tolerance = 10;
+        double mapTolerance = tolerance * mMapView.getUnitsPerDensityIndependentPixel();
+        // use tolerance to create an envelope to query
+        Envelope envelope = new Envelope(clickPoint.getX() - mapTolerance, clickPoint.getY() - mapTolerance,
+            clickPoint.getX() + mapTolerance, clickPoint.getY() + mapTolerance, map.getSpatialReference());
+        QueryParameters query = new QueryParameters();
+        query.setGeometry(envelope);
+        // request all available attribute fields
+        final ListenableFuture<FeatureQueryResult> future = mServiceFeatureTable
+            .queryFeaturesAsync(query, ServiceFeatureTable.QueryFeatureFields.LOAD_ALL);
+        // add done loading listener to fire when the selection returns
+        future.addDoneListener(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              //call get on the future to get the result
+              FeatureQueryResult result = future.get();
+              // create an Iterator
+              Iterator<Feature> iterator = result.iterator();
+              // create a TextView to display field values
+              TextView calloutContent = new TextView(getApplicationContext());
+              calloutContent.setTextColor(Color.BLACK);
+              calloutContent.setSingleLine(false);
+              calloutContent.setVerticalScrollBarEnabled(true);
+              calloutContent.setScrollBarStyle(View.SCROLLBARS_INSIDE_INSET);
+              calloutContent.setMovementMethod(new ScrollingMovementMethod());
+              calloutContent.setLines(5);
+              // cycle through selections
+              int counter = 0;
+              Feature feature;
+              while (iterator.hasNext()) {
+                feature = iterator.next();
+                // create a Map of all available attributes as name value pairs
+                Map<String, Object> attr = feature.getAttributes();
+                Set<String> keys = attr.keySet();
+                for (String key : keys) {
+                  Object value = attr.get(key);
+                  // format observed field value as date
+                  if (value instanceof GregorianCalendar) {
+                    SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd-MMM-yyyy", Locale.US);
+                    value = simpleDateFormat.format(((GregorianCalendar) value).getTime());
+                  }
+                  // append name value pairs to TextView
+                  calloutContent.append(key + " | " + value + "\n");
                 }
-                // get the point that was clicked and convert it to a point in map coordinates
-                final Point clickPoint = mMapView.screenToLocation(new android.graphics.Point(Math.round(e.getX()), Math.round(e.getY())));
-                // create a selection tolerance
-                int tolerance = 10;
-                double mapTolerance = tolerance * mMapView.getUnitsPerDensityIndependentPixel();
-                // use tolerance to create an envelope to query
-                Envelope envelope = new Envelope(clickPoint.getX() - mapTolerance, clickPoint.getY() - mapTolerance, clickPoint.getX() + mapTolerance, clickPoint.getY() + mapTolerance, map.getSpatialReference());
-                QueryParameters query = new QueryParameters();
-                query.setGeometry(envelope);
-                // request all available attribute fields
-                final ListenableFuture<FeatureQueryResult> future = mServiceFeatureTable.queryFeaturesAsync(query, ServiceFeatureTable.QueryFeatureFields.LOAD_ALL);
-                // add done loading listener to fire when the selection returns
-                future.addDoneListener(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            //call get on the future to get the result
-                            FeatureQueryResult result = future.get();
-                            // create an Iterator
-                            Iterator<Feature> iterator = result.iterator();
-                            // create a TextView to display field values
-                            TextView calloutContent = new TextView(getApplicationContext());
-                            calloutContent.setTextColor(Color.BLACK);
-                            calloutContent.setSingleLine(false);
-                            calloutContent.setVerticalScrollBarEnabled(true);
-                            calloutContent.setScrollBarStyle(View.SCROLLBARS_INSIDE_INSET);
-                            calloutContent.setMovementMethod(new ScrollingMovementMethod());
-                            calloutContent.setLines(5);
-                            // cycle through selections
-                            int counter = 0;
-                            Feature feature;
-                            while (iterator.hasNext()){
-                                feature = iterator.next();
-                                // create a Map of all available attributes as name value pairs
-                                Map<String, Object> attr = feature.getAttributes();
-                                Set<String> keys = attr.keySet();
-                                for(String key:keys){
-                                    Object value = attr.get(key);
-                                    // format observed field value as date
-                                    if(value instanceof GregorianCalendar){
-                                        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd-MMM-yyyy", Locale.US);
-                                        value = simpleDateFormat.format(((GregorianCalendar) value).getTime());
-                                    }
-                                    // append name value pairs to TextView
-                                    calloutContent.append(key + " | " + value + "\n");
-                                }
-                                counter++;
-                                // center the mapview on selected feature
-                                Envelope envelope = feature.getGeometry().getExtent();
-                                mMapView.setViewpointGeometryAsync(envelope, 200);
-                                // show CallOut
-                                mCallout.setLocation(clickPoint);
-                                mCallout.setContent(calloutContent);
-                                mCallout.show();
-                            }
-                        } catch (Exception e) {
-                            Log.e(getResources().getString(R.string.app_name), "Select feature failed: " + e.getMessage());
-                        }
-                    }
-                });
-                return super.onSingleTapConfirmed(e);
+                counter++;
+                // center the mapview on selected feature
+                Envelope envelope = feature.getGeometry().getExtent();
+                mMapView.setViewpointGeometryAsync(envelope, 200);
+                // show CallOut
+                mCallout.setLocation(clickPoint);
+                mCallout.setContent(calloutContent);
+                mCallout.show();
+              }
+            } catch (Exception e) {
+              Log.e(getResources().getString(R.string.app_name), "Select feature failed: " + e.getMessage());
             }
+          }
         });
+        return super.onSingleTapConfirmed(e);
+      }
+    });
 
-    }
+  }
 
-    @Override
-    protected void onPause() {
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/feature-layer-update-attributes/src/main/res/values/strings.xml
+++ b/java/feature-layer-update-attributes/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">"feature-layer-update-attributes"</string>
+    <string name="app_name">Feature Layer Update Attributes</string>
     <string name="select_damage_Type">"Select new damage type"</string>
     <!-- Progress dialog messages -->
     <string name="progress_title">Updating attribute type</string>

--- a/java/feature-layer-update-geometry/src/main/AndroidManifest.xml
+++ b/java/feature-layer-update-geometry/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/java/feature-layer-update-geometry/src/main/java/com/esri/arcgisruntime/samples/featurelayerupdategeometry/MainActivity.java
+++ b/java/feature-layer-update-geometry/src/main/java/com/esri/arcgisruntime/samples/featurelayerupdategeometry/MainActivity.java
@@ -172,4 +172,10 @@ public class MainActivity extends AppCompatActivity {
     // resume MapView
     mMapView.resume();
   }
+
+  @Override protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
 }

--- a/java/find-address/src/main/AndroidManifest.xml
+++ b/java/find-address/src/main/AndroidManifest.xml
@@ -17,8 +17,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/find-address/src/main/java/com/esri/arcgisruntime/sample/findaddress/MainActivity.java
+++ b/java/find-address/src/main/java/com/esri/arcgisruntime/sample/findaddress/MainActivity.java
@@ -327,4 +327,10 @@ public class MainActivity extends AppCompatActivity {
     super.onResume();
     mMapView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/find-place/src/main/AndroidManifest.xml
+++ b/java/find-place/src/main/AndroidManifest.xml
@@ -17,8 +17,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/find-place/src/main/java/com/esri/arcgisruntime/sample/findplace/MainActivity.java
+++ b/java/find-place/src/main/java/com/esri/arcgisruntime/sample/findplace/MainActivity.java
@@ -128,8 +128,9 @@ public class MainActivity extends AppCompatActivity {
     try {
       mPinSourceSymbol = PictureMarkerSymbol.createAsync(pinDrawable).get();
     } catch (InterruptedException | ExecutionException e) {
-      Log.e(TAG, "Picture Marker Symbol error: " + e.getMessage());
-      Toast.makeText(getApplicationContext(), "Failed to load pin drawable.", Toast.LENGTH_LONG).show();
+      String error = "Error creating PictureMarkerSymbol: " + e.getMessage();
+      Log.e(TAG, error);
+      Toast.makeText(MainActivity.this, error, Toast.LENGTH_LONG).show();
     }
     // set pin to half of native size
     mPinSourceSymbol.setWidth(19f);
@@ -139,7 +140,7 @@ public class MainActivity extends AppCompatActivity {
     mProximitySearchViewEmpty = true;
 
     // create a LocatorTask from an online service
-    mLocatorTask = new LocatorTask("http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer");
+    mLocatorTask = new LocatorTask(getString(R.string.world_geocode_service));
 
     // inflate MapView from layout
     mMapView = (MapView) findViewById(R.id.mapView);
@@ -534,5 +535,23 @@ public class MainActivity extends AppCompatActivity {
       Toast.makeText(MainActivity.this, getResources().getString(R.string.location_permission_denied),
           Toast.LENGTH_SHORT).show();
     }
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
   }
 }

--- a/java/find-place/src/main/res/values/strings.xml
+++ b/java/find-place/src/main/res/values/strings.xml
@@ -7,5 +7,6 @@
     <string name="location_not_found">No location with that name: </string>
     <string name="searching_by_area">Searching by area...</string>
     <string name="redo_search_text">Redo search in this area</string>
+    <string name="world_geocode_service">http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer</string>
 
 </resources>

--- a/java/find-route/src/main/AndroidManifest.xml
+++ b/java/find-route/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:configChanges="orientation|screenSize|uiMode|keyboardHidden"
         android:theme="@style/AppTheme">
         <activity android:name="com.esri.arcgisruntime.sample.findroute.MainActivity">
             <intent-filter>

--- a/java/find-route/src/main/java/com/esri/arcgisruntime/sample/findroute/MainActivity.java
+++ b/java/find-route/src/main/java/com/esri/arcgisruntime/sample/findroute/MainActivity.java
@@ -19,6 +19,7 @@ package com.esri.arcgisruntime.sample.findroute;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+
 import android.app.ProgressDialog;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
@@ -61,287 +62,294 @@ import com.esri.arcgisruntime.tasks.networkanalysis.Stop;
 
 public class MainActivity extends AppCompatActivity {
 
-    private static final String TAG = "FindRouteSample";
-    private ProgressDialog mProgressDialog;
+  private static final String TAG = MainActivity.class.getSimpleName();
+  private ProgressDialog mProgressDialog;
 
-    private MapView mMapView;
-    private RouteTask mRouteTask;
-    private RouteParameters mRouteParams;
-    private Point mSourcePoint;
-    private Point mDestinationPoint;
-    private Route mRoute;
-    private SimpleLineSymbol mRouteSymbol;
-    private GraphicsOverlay mGraphicsOverlay;
+  private MapView mMapView;
+  private RouteTask mRouteTask;
+  private RouteParameters mRouteParams;
+  private Point mSourcePoint;
+  private Point mDestinationPoint;
+  private Route mRoute;
+  private SimpleLineSymbol mRouteSymbol;
+  private GraphicsOverlay mGraphicsOverlay;
 
-    private DrawerLayout mDrawerLayout;
-    private ListView mDrawerList;
-    private ActionBarDrawerToggle mDrawerToggle;
+  private DrawerLayout mDrawerLayout;
+  private ListView mDrawerList;
+  private ActionBarDrawerToggle mDrawerToggle;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_drawer);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_drawer);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create new Vector Tiled Layer from service url
-        ArcGISVectorTiledLayer mVectorTiledLayer = new ArcGISVectorTiledLayer(
-                getResources().getString(R.string.navigation_vector));
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create new Vector Tiled Layer from service url
+    ArcGISVectorTiledLayer mVectorTiledLayer = new ArcGISVectorTiledLayer(
+        getResources().getString(R.string.navigation_vector));
 
-        // set tiled layer as basemap
-        Basemap basemap = new Basemap(mVectorTiledLayer);
-        // create a map with the basemap
-        ArcGISMap mMap = new ArcGISMap(basemap);
-        // create a viewpoint from lat, long, scale
-        Viewpoint sanDiegoPoint = new Viewpoint(32.7157, -117.1611, 200000);
-        // set initial map extent
-        mMap.setInitialViewpoint(sanDiegoPoint);
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
+    // set tiled layer as basemap
+    Basemap basemap = new Basemap(mVectorTiledLayer);
+    // create a map with the basemap
+    ArcGISMap mMap = new ArcGISMap(basemap);
+    // create a viewpoint from lat, long, scale
+    Viewpoint sanDiegoPoint = new Viewpoint(32.7157, -117.1611, 200000);
+    // set initial map extent
+    mMap.setInitialViewpoint(sanDiegoPoint);
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
 
-        // inflate navigation drawer
-        mDrawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
-        mDrawerList = (ListView) findViewById(R.id.left_drawer);
+    // inflate navigation drawer
+    mDrawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+    mDrawerList = (ListView) findViewById(R.id.left_drawer);
 
-        FloatingActionButton mDirectionFab = (FloatingActionButton) findViewById(R.id.fab);
+    FloatingActionButton mDirectionFab = (FloatingActionButton) findViewById(R.id.fab);
 
-        // update UI when attribution view changes
-        final FrameLayout.LayoutParams params =  (FrameLayout.LayoutParams)mDirectionFab.getLayoutParams();
-        mMapView.addAttributionViewLayoutChangeListener(new View.OnLayoutChangeListener() {
-            @Override
-            public void onLayoutChange(
-                    View view, int left, int top, int right, int bottom,
-                    int oldLeft, int oldTop, int oldRight, int oldBottom) {
-                int heightDelta = (bottom - oldBottom);
-                params.bottomMargin += heightDelta;
-            }
-        });
+    // update UI when attribution view changes
+    final FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) mDirectionFab.getLayoutParams();
+    mMapView.addAttributionViewLayoutChangeListener(new View.OnLayoutChangeListener() {
+      @Override
+      public void onLayoutChange(
+          View view, int left, int top, int right, int bottom,
+          int oldLeft, int oldTop, int oldRight, int oldBottom) {
+        int heightDelta = (bottom - oldBottom);
+        params.bottomMargin += heightDelta;
+      }
+    });
 
-        setupDrawer();
-        setupSymbols();
+    setupDrawer();
+    setupSymbols();
 
-        mProgressDialog = new ProgressDialog(this);
-        mProgressDialog.setTitle(getString(R.string.progress_title));
-        mProgressDialog.setMessage(getString(R.string.progress_message));
+    mProgressDialog = new ProgressDialog(this);
+    mProgressDialog.setTitle(getString(R.string.progress_title));
+    mProgressDialog.setMessage(getString(R.string.progress_message));
 
+    mDirectionFab.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
 
-        mDirectionFab.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
+        mProgressDialog.show();
 
-                mProgressDialog.show();
+        if (getSupportActionBar() != null) {
+          getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+          getSupportActionBar().setHomeButtonEnabled(true);
+          setTitle(getString(R.string.app_name));
+        }
+        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
 
-                if(getSupportActionBar() != null) {
-                    getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-                    getSupportActionBar().setHomeButtonEnabled(true);
-                    setTitle(getString(R.string.app_name));
+        // create RouteTask instance
+        mRouteTask = new RouteTask(getApplicationContext(), getString(R.string.routing_service));
+
+        final ListenableFuture<RouteParameters> listenableFuture = mRouteTask.createDefaultParametersAsync();
+        listenableFuture.addDoneListener(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              if (listenableFuture.isDone()) {
+                int i = 0;
+                mRouteParams = listenableFuture.get();
+
+                // create stops
+                Stop stop1 = new Stop(new Point(-117.15083257944445, 32.741123367963446, SpatialReferences.getWgs84()));
+                Stop stop2 = new Stop(new Point(-117.15557279683529, 32.703360305883045, SpatialReferences.getWgs84()));
+
+                List<Stop> routeStops = new ArrayList<>();
+                // add stops
+                routeStops.add(stop1);
+                routeStops.add(stop2);
+                mRouteParams.setStops(routeStops);
+
+                // set return directions as true to return turn-by-turn directions in the result of
+                  // getDirectionManeuvers().
+                mRouteParams.setReturnDirections(true);
+
+                // solve
+                RouteResult result = mRouteTask.solveRouteAsync(mRouteParams).get();
+                final List routes = result.getRoutes();
+                mRoute = (Route) routes.get(0);
+                // create a mRouteSymbol graphic
+                Graphic routeGraphic = new Graphic(mRoute.getRouteGeometry(), mRouteSymbol);
+                // add mRouteSymbol graphic to the map
+                mGraphicsOverlay.getGraphics().add(routeGraphic);
+                // get directions
+                // NOTE: to get turn-by-turn directions Route Parameters should set returnDirection flag as true
+                final List<DirectionManeuver> directions = mRoute.getDirectionManeuvers();
+
+                String[] directionsArray = new String[directions.size()];
+
+                for (DirectionManeuver dm : directions) {
+                  directionsArray[i++] = dm.getDirectionText();
                 }
-                mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
+                Log.d(TAG, directions.get(0).getGeometry().getExtent().getXMin() + "");
+                Log.d(TAG, directions.get(0).getGeometry().getExtent().getYMin() + "");
 
-                // create RouteTask instance
-                mRouteTask = new RouteTask(getApplicationContext()  , getString(R.string.routing_service));
+                // Set the adapter for the list view
+                mDrawerList.setAdapter(new ArrayAdapter<>(getApplicationContext(),
+                    R.layout.drawer_layout_text, directionsArray));
 
-                final ListenableFuture<RouteParameters> listenableFuture = mRouteTask.createDefaultParametersAsync();
-                listenableFuture.addDoneListener(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            if (listenableFuture.isDone()) {
-                                int i = 0;
-                                mRouteParams = listenableFuture.get();
-
-                                // create stops
-                                Stop stop1 =  new Stop(new Point(-117.15083257944445, 32.741123367963446, SpatialReferences.getWgs84()));
-                                Stop stop2 = new Stop(new Point(-117.15557279683529, 32.703360305883045, SpatialReferences.getWgs84()));
-
-                                List<Stop> routeStops = new ArrayList<>();
-                                // add stops
-                                routeStops.add(stop1);
-                                routeStops.add(stop2);
-                                mRouteParams.setStops(routeStops);
-
-                                // set return directions as true to return turn-by-turn directions in the result of getDirectionManeuvers().
-                                mRouteParams.setReturnDirections(true);
-
-                                // solve
-                                RouteResult result = mRouteTask.solveRouteAsync(mRouteParams).get();
-                                final List routes = result.getRoutes();
-                                mRoute = (Route) routes.get(0);
-                                // create a mRouteSymbol graphic
-                                Graphic routeGraphic = new Graphic(mRoute.getRouteGeometry(), mRouteSymbol);
-                                // add mRouteSymbol graphic to the map
-                                mGraphicsOverlay.getGraphics().add(routeGraphic);
-                                // get directions
-                                // NOTE: to get turn-by-turn directions Route Parameters should set returnDirection flag as true
-                                final List<DirectionManeuver> directions = mRoute.getDirectionManeuvers();
-
-                                String[] directionsArray = new String[directions.size()];
-
-                                for (DirectionManeuver dm : directions) {
-                                    directionsArray[i++] = dm.getDirectionText();
-                                }
-                                Log.d(TAG,directions.get(0).getGeometry().getExtent().getXMin() + "");
-                                Log.d(TAG,directions.get(0).getGeometry().getExtent().getYMin() + "");
-
-                                // Set the adapter for the list view
-                                mDrawerList.setAdapter(new ArrayAdapter<>(getApplicationContext(),
-                                        R.layout.drawer_layout_text, directionsArray));
-
-                                if (mProgressDialog.isShowing()) {
-                                    mProgressDialog.dismiss();
-                                }
-                                mDrawerList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-                                    @Override
-                                    public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                                        if(mGraphicsOverlay.getGraphics().size() > 3) {
-                                            mGraphicsOverlay.getGraphics().remove(mGraphicsOverlay.getGraphics().size() - 1);
-                                        }
-                                        mDrawerLayout.closeDrawers();
-                                        DirectionManeuver dm = directions.get(position);
-                                        Geometry gm = dm.getGeometry();
-                                        Viewpoint vp = new Viewpoint(gm.getExtent(),20);
-                                        mMapView.setViewpointAsync(vp,3);
-                                        SimpleLineSymbol selectedRouteSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.GREEN, 5);
-                                        Graphic selectedRouteGraphic = new Graphic(directions.get(position).getGeometry(), selectedRouteSymbol);
-                                        mGraphicsOverlay.getGraphics().add(selectedRouteGraphic);
-                                    }
-                                });
-
-                            }
-                        } catch (Exception e) {
-                            Log.e(TAG, e.getMessage());
-                        }
+                if (mProgressDialog.isShowing()) {
+                  mProgressDialog.dismiss();
+                }
+                mDrawerList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+                  @Override
+                  public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                    if (mGraphicsOverlay.getGraphics().size() > 3) {
+                      mGraphicsOverlay.getGraphics().remove(mGraphicsOverlay.getGraphics().size() - 1);
                     }
+                    mDrawerLayout.closeDrawers();
+                    DirectionManeuver dm = directions.get(position);
+                    Geometry gm = dm.getGeometry();
+                    Viewpoint vp = new Viewpoint(gm.getExtent(), 20);
+                    mMapView.setViewpointAsync(vp, 3);
+                    SimpleLineSymbol selectedRouteSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID,
+                        Color.GREEN, 5);
+                    Graphic selectedRouteGraphic = new Graphic(directions.get(position).getGeometry(),
+                        selectedRouteSymbol);
+                    mGraphicsOverlay.getGraphics().add(selectedRouteGraphic);
+                  }
                 });
+
+              }
+            } catch (Exception e) {
+              Log.e(TAG, e.getMessage());
             }
+          }
         });
+      }
+    });
 
+  }
 
-    }
+  /**
+   * Set up the Source, Destination and mRouteSymbol graphics symbol
+   */
+  private void setupSymbols() {
 
-    /**
-     * Set up the Source, Destination and mRouteSymbol graphics symbol
-     */
-    private void setupSymbols() {
+    mGraphicsOverlay = new GraphicsOverlay();
 
-        mGraphicsOverlay = new GraphicsOverlay();
+    //add the overlay to the map view
+    mMapView.getGraphicsOverlays().add(mGraphicsOverlay);
 
-        //add the overlay to the map view
-        mMapView.getGraphicsOverlays().add(mGraphicsOverlay);
-
-        //[DocRef: Name=Picture Marker Symbol Drawable-android, Category=Fundamentals, Topic=Symbols and Renderers]
-        //Create a picture marker symbol from an app resource
-        BitmapDrawable startDrawable = (BitmapDrawable) ContextCompat.getDrawable(this, R.drawable.ic_source);
-        final PictureMarkerSymbol pinSourceSymbol;
-        try {
-            pinSourceSymbol = PictureMarkerSymbol.createAsync(startDrawable).get();
-            pinSourceSymbol.loadAsync();
-            pinSourceSymbol.addDoneLoadingListener(new Runnable() {
-                @Override
-                public void run() {
-                    //add a new graphic as start point
-                    mSourcePoint = new Point(-117.15083257944445, 32.741123367963446, SpatialReferences.getWgs84());
-                    Graphic pinSourceGraphic = new Graphic(mSourcePoint, pinSourceSymbol);
-                    mGraphicsOverlay.getGraphics().add(pinSourceGraphic);
-                }
-            });
-            pinSourceSymbol.setOffsetY(20);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        } catch (ExecutionException e) {
-            e.printStackTrace();
+    //[DocRef: Name=Picture Marker Symbol Drawable-android, Category=Fundamentals, Topic=Symbols and Renderers]
+    //Create a picture marker symbol from an app resource
+    BitmapDrawable startDrawable = (BitmapDrawable) ContextCompat.getDrawable(this, R.drawable.ic_source);
+    final PictureMarkerSymbol pinSourceSymbol;
+    try {
+      pinSourceSymbol = PictureMarkerSymbol.createAsync(startDrawable).get();
+      pinSourceSymbol.loadAsync();
+      pinSourceSymbol.addDoneLoadingListener(new Runnable() {
+        @Override
+        public void run() {
+          //add a new graphic as start point
+          mSourcePoint = new Point(-117.15083257944445, 32.741123367963446, SpatialReferences.getWgs84());
+          Graphic pinSourceGraphic = new Graphic(mSourcePoint, pinSourceSymbol);
+          mGraphicsOverlay.getGraphics().add(pinSourceGraphic);
         }
-        //[DocRef: END]
-        BitmapDrawable endDrawable = (BitmapDrawable) ContextCompat.getDrawable(this, R.drawable.ic_destination);
-        final PictureMarkerSymbol pinDestinationSymbol;
-        try {
-            pinDestinationSymbol = PictureMarkerSymbol.createAsync(endDrawable).get();
-            pinDestinationSymbol.loadAsync();
-            pinDestinationSymbol.addDoneLoadingListener(new Runnable() {
-                @Override
-                public void run() {
-                    //add a new graphic as end point
-                    mDestinationPoint = new Point(-117.15557279683529, 32.703360305883045, SpatialReferences.getWgs84());
-                    Graphic destinationGraphic = new Graphic(mDestinationPoint, pinDestinationSymbol);
-                    mGraphicsOverlay.getGraphics().add(destinationGraphic);
-                }
-            });
-            pinDestinationSymbol.setOffsetY(20);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        } catch (ExecutionException e) {
-            e.printStackTrace();
+      });
+      pinSourceSymbol.setOffsetY(20);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    //[DocRef: END]
+    BitmapDrawable endDrawable = (BitmapDrawable) ContextCompat.getDrawable(this, R.drawable.ic_destination);
+    final PictureMarkerSymbol pinDestinationSymbol;
+    try {
+      pinDestinationSymbol = PictureMarkerSymbol.createAsync(endDrawable).get();
+      pinDestinationSymbol.loadAsync();
+      pinDestinationSymbol.addDoneLoadingListener(new Runnable() {
+        @Override
+        public void run() {
+          //add a new graphic as end point
+          mDestinationPoint = new Point(-117.15557279683529, 32.703360305883045, SpatialReferences.getWgs84());
+          Graphic destinationGraphic = new Graphic(mDestinationPoint, pinDestinationSymbol);
+          mGraphicsOverlay.getGraphics().add(destinationGraphic);
         }
-        //[DocRef: END]
-        mRouteSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.BLUE, 5);
+      });
+      pinDestinationSymbol.setOffsetY(20);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } catch (ExecutionException e) {
+      e.printStackTrace();
     }
+    //[DocRef: END]
+    mRouteSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.BLUE, 5);
+  }
 
-    @Override
-    protected void onPause() {
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
 
-    /**
-     * set up the drawer
-     */
-    private void setupDrawer() {
-        mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, R.string.drawer_open, R.string.drawer_close) {
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 
-            /** Called when a drawer has settled in a completely open state. */
-            public void onDrawerOpened(View drawerView) {
-                super.onDrawerOpened(drawerView);
-                invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
-            }
+  /**
+   * set up the drawer
+   */
+  private void setupDrawer() {
+    mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, R.string.drawer_open, R.string.drawer_close) {
 
-            /** Called when a drawer has settled in a completely closed state. */
-            public void onDrawerClosed(View view) {
-                super.onDrawerClosed(view);
-                invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
-            }
-        };
+      /** Called when a drawer has settled in a completely open state. */
+      public void onDrawerOpened(View drawerView) {
+        super.onDrawerOpened(drawerView);
+        invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
+      }
 
-        mDrawerToggle.setDrawerIndicatorEnabled(true);
-        mDrawerLayout.addDrawerListener(mDrawerToggle);
+      /** Called when a drawer has settled in a completely closed state. */
+      public void onDrawerClosed(View view) {
+        super.onDrawerClosed(view);
+        invalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
+      }
+    };
 
-        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
-    }
+    mDrawerToggle.setDrawerIndicatorEnabled(true);
+    mDrawerLayout.addDrawerListener(mDrawerToggle);
 
-    @Override
-    protected void onPostCreate(Bundle savedInstanceState) {
-        super.onPostCreate(savedInstanceState);
-        // Sync the toggle state after onRestoreInstanceState has occurred.
-        mDrawerToggle.syncState();
-    }
+    mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
+  }
 
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-        super.onConfigurationChanged(newConfig);
+  @Override
+  protected void onPostCreate(Bundle savedInstanceState) {
+    super.onPostCreate(savedInstanceState);
+    // Sync the toggle state after onRestoreInstanceState has occurred.
+    mDrawerToggle.syncState();
+  }
 
-        mDrawerToggle.onConfigurationChanged(newConfig);
-    }
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+    super.onConfigurationChanged(newConfig);
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_main, menu);
-        return true;
-    }
+    mDrawerToggle.onConfigurationChanged(newConfig);
+  }
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // Handle action bar item clicks here. The action bar will
-        // automatically handle clicks on the Home/Up button, so long
-        // as you specify a parent activity in AndroidManifest.xml.
+  @Override
+  public boolean onCreateOptionsMenu(Menu menu) {
+    // Inflate the menu; this adds items to the action bar if it is present.
+    getMenuInflater().inflate(R.menu.menu_main, menu);
+    return true;
+  }
 
-        // Activate the navigation drawer toggle
-        return (mDrawerToggle.onOptionsItemSelected(item)) || super.onOptionsItemSelected(item);
-    }
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    // Handle action bar item clicks here. The action bar will
+    // automatically handle clicks on the Home/Up button, so long
+    // as you specify a parent activity in AndroidManifest.xml.
+
+    // Activate the navigation drawer toggle
+    return (mDrawerToggle.onOptionsItemSelected(item)) || super.onOptionsItemSelected(item);
+  }
 }

--- a/java/format-coordinates/src/main/java/com/esri/arcgisruntime/sample/formatcoordinates/MainActivity.java
+++ b/java/format-coordinates/src/main/java/com/esri/arcgisruntime/sample/formatcoordinates/MainActivity.java
@@ -255,4 +255,21 @@ public class MainActivity extends AppCompatActivity {
 
   }
 
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/generate-geodatabase/src/main/AndroidManifest.xml
+++ b/java/generate-geodatabase/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/generate-geodatabase/src/main/java/com/esri/arcgisruntime/sample/generategeodatabase/MainActivity.java
+++ b/java/generate-geodatabase/src/main/java/com/esri/arcgisruntime/sample/generategeodatabase/MainActivity.java
@@ -212,4 +212,10 @@ public class MainActivity extends AppCompatActivity {
     super.onResume();
     mMapView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/hillshade-renderer/src/main/java/com/esri/arcgisruntime/sample/hillshaderenderer/MainActivity.java
+++ b/java/hillshade-renderer/src/main/java/com/esri/arcgisruntime/sample/hillshaderenderer/MainActivity.java
@@ -16,6 +16,8 @@
 
 package com.esri.arcgisruntime.sample.hillshaderenderer;
 
+import java.io.File;
+
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -38,158 +40,163 @@ import com.esri.arcgisruntime.raster.HillshadeRenderer;
 import com.esri.arcgisruntime.raster.Raster;
 import com.esri.arcgisruntime.raster.SlopeType;
 
-import java.io.File;
-
 /**
  * A sample class which demonstrates how to use a HillshadeRenderer on a RasterLayer.
  */
 public class MainActivity extends AppCompatActivity
-        implements ParametersDialogFragment.ParametersListener {
+    implements ParametersDialogFragment.ParametersListener {
 
-    private MapView mMapView;
-    private RasterLayer mRasterLayer;
-    private int mAltitude;
-    private int mAzimuth;
-    private double mZFactor;
-    private SlopeType mSlopeType;
-    private double mPixelSizeFactor;
-    private double mPixelSizePower;
-    private int mOutputBitDepth;
-    private FragmentManager mFragmentManager;
+  private MapView mMapView;
+  private RasterLayer mRasterLayer;
+  private int mAltitude;
+  private int mAzimuth;
+  private double mZFactor;
+  private SlopeType mSlopeType;
+  private double mPixelSizeFactor;
+  private double mPixelSizePower;
+  private int mOutputBitDepth;
+  private FragmentManager mFragmentManager;
 
-    @Override
-    public void returnParameters(int altitude, int azimuth, SlopeType slopeType) {
-        //gets dialog box parameters and calls updateRenderer
-        mAltitude = altitude;
-        mAzimuth = azimuth;
-        mSlopeType = slopeType;
-        updateRenderer();
+  @Override
+  public void returnParameters(int altitude, int azimuth, SlopeType slopeType) {
+    //gets dialog box parameters and calls updateRenderer
+    mAltitude = altitude;
+    mAzimuth = azimuth;
+    mSlopeType = slopeType;
+    updateRenderer();
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+    //set default values for HillshadeRenderer parameters
+    mAltitude = 45;
+    mAzimuth = 315;
+    mZFactor = 0.000016;
+    mSlopeType = SlopeType.NONE;
+    mPixelSizeFactor = 1;
+    mPixelSizePower = 1;
+    mOutputBitDepth = 8;
+    // retrieve the MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    mFragmentManager = getSupportFragmentManager();
+    // define permission to request
+    String[] reqPermission = new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE };
+    int requestCode = 2;
+    // For API level 23+ request permission at runtime
+    if (ContextCompat.checkSelfPermission(MainActivity.this,
+        reqPermission[0]) == PackageManager.PERMISSION_GRANTED) {
+      hillshadeRenderer();
+    } else {
+      // request permission
+      ActivityCompat.requestPermissions(MainActivity.this, reqPermission, requestCode);
     }
+  }
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
-        //set default values for HillshadeRenderer parameters
-        mAltitude = 45;
-        mAzimuth = 315;
-        mZFactor = 0.000016;
-        mSlopeType = SlopeType.NONE;
-        mPixelSizeFactor = 1;
-        mPixelSizePower = 1;
-        mOutputBitDepth = 8;
-        // retrieve the MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        mFragmentManager = getSupportFragmentManager();
-        // define permission to request
-        String[] reqPermission = new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE};
-        int requestCode = 2;
-        // For API level 23+ request permission at runtime
-        if (ContextCompat.checkSelfPermission(MainActivity.this,
-                reqPermission[0]) == PackageManager.PERMISSION_GRANTED) {
-            hillshadeRenderer();
-        } else {
-            // request permission
-            ActivityCompat.requestPermissions(MainActivity.this, reqPermission, requestCode);
-        }
-    }
+  /**
+   * Using values stored in strings.xml, builds path to srtm.tif.
+   *
+   * @return the path to raster file
+   */
+  private String buildRasterPath() {
+    // get sdcard resource name
+    File extStorDir = Environment.getExternalStorageDirectory();
+    // get the directory
+    String extSDCardDirName =
+        this.getResources().getString(R.string.data_sdcard_offline_dir);
+    // get raster filename
+    String filename = this.getString(R.string.raster_name);
+    // create the full path to the raster file
+    return extStorDir.getAbsolutePath()
+        + File.separator
+        + extSDCardDirName
+        + File.separator
+        + filename
+        + ".tiff";
+  }
 
-    /**
-     * Using values stored in strings.xml, builds path to srtm.tif.
-     * @return the path to raster file
-     */
-    private String buildRasterPath() {
-        // get sdcard resource name
-        File extStorDir = Environment.getExternalStorageDirectory();
-        // get the directory
-        String extSDCardDirName =
-                this.getResources().getString(R.string.data_sdcard_offline_dir);
-        // get raster filename
-        String filename = this.getString(R.string.raster_name);
-        // create the full path to the raster file
-        return extStorDir.getAbsolutePath()
-                + File.separator
-                + extSDCardDirName
-                + File.separator
-                + filename
-                + ".tiff";
-    }
+  /**
+   * Creates a new Raster based on a given path and adds it to a RasterLayer which is added to an
+   * ArcGISMap as an operational layer.
+   */
+  private void hillshadeRenderer() {
+    // create raster
+    Raster raster = new Raster(
+        new File(buildRasterPath()).getAbsolutePath());
+    Log.d("Raster", raster.getPath());
+    // create a raster layer
+    mRasterLayer = new RasterLayer(raster);
+    // create a basemap from the raster layer
+    ArcGISMap map = new ArcGISMap();
+    // add the map to a map view
+    mMapView.setMap(map);
+    // add the raster as an operational layer
+    map.getOperationalLayers().add(mRasterLayer);
+    updateRenderer();
+  }
 
-    /**
-     * Creates a new Raster based on a given path and adds it to a RasterLayer which is added to an
-     * ArcGISMap as an operational layer.
-     */
-    private void hillshadeRenderer() {
-        // create raster
-        Raster raster = new Raster(
-                new File(buildRasterPath()).getAbsolutePath());
-        Log.d("Raster", raster.getPath());
-        // create a raster layer
-        mRasterLayer = new RasterLayer(raster);
-        // create a basemap from the raster layer
-        ArcGISMap map = new ArcGISMap();
-        // add the map to a map view
-        mMapView.setMap(map);
-        // add the raster as an operational layer
-        map.getOperationalLayers().add(mRasterLayer);
-        updateRenderer();
-    }
+  /**
+   * Creates a new HillshadeRenderer according to the chosen property values.
+   */
+  private void updateRenderer() {
+    // create blend renderer
+    HillshadeRenderer hillshadeRenderer = new HillshadeRenderer(mAltitude, mAzimuth,
+        mZFactor, mSlopeType, mPixelSizeFactor, mPixelSizePower, mOutputBitDepth);
+    mRasterLayer.setRasterRenderer(hillshadeRenderer);
+  }
 
-    /**
-     * Creates a new HillshadeRenderer according to the chosen property values.
-     */
-    private void updateRenderer() {
-        // create blend renderer
-        HillshadeRenderer hillshadeRenderer = new HillshadeRenderer(mAltitude, mAzimuth,
-                mZFactor, mSlopeType, mPixelSizeFactor, mPixelSizePower, mOutputBitDepth);
-        mRasterLayer.setRasterRenderer(hillshadeRenderer);
+  /**
+   * Handle the permissions request response.
+   */
+  public void onRequestPermissionsResult(int requestCode,
+      @NonNull String[] permissions,
+      @NonNull int[] grantResults) {
+    if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+      hillshadeRenderer();
+    } else {
+      // report to user that permission was denied
+      Toast.makeText(MainActivity.this,
+          getResources().getString(R.string.location_permission_denied),
+          Toast.LENGTH_SHORT).show();
     }
+  }
 
-    /**
-     * Handle the permissions request response.
-     */
-    public void onRequestPermissionsResult(int requestCode,
-                                           @NonNull String[] permissions,
-                                           @NonNull int[] grantResults) {
-        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            hillshadeRenderer();
-        } else {
-            // report to user that permission was denied
-            Toast.makeText(MainActivity.this,
-                    getResources().getString(R.string.location_permission_denied),
-                    Toast.LENGTH_SHORT).show();
-        }
-    }
+  @Override
+  public boolean onCreateOptionsMenu(Menu menu) {
+    MenuInflater inflater = getMenuInflater();
+    inflater.inflate(R.menu.hillshade_parameters, menu);
+    return super.onCreateOptionsMenu(menu);
+  }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        MenuInflater inflater = getMenuInflater();
-        inflater.inflate(R.menu.hillshade_parameters, menu);
-        return super.onCreateOptionsMenu(menu);
-    }
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    ParametersDialogFragment paramDialog = new ParametersDialogFragment();
+    Bundle hillshadeParameters = new Bundle();
+    //send parameters to fragment
+    hillshadeParameters.putInt("altitude", mAltitude);
+    hillshadeParameters.putInt("azimuth", mAzimuth);
+    hillshadeParameters.putSerializable("slope_type", mSlopeType);
+    paramDialog.setArguments(hillshadeParameters);
+    paramDialog.show(mFragmentManager, "param_dialog");
+    return super.onOptionsItemSelected(item);
+  }
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        ParametersDialogFragment paramDialog = new ParametersDialogFragment();
-        Bundle hillshadeParameters = new Bundle();
-        //send parameters to fragment
-        hillshadeParameters.putInt("altitude", mAltitude);
-        hillshadeParameters.putInt("azimuth", mAzimuth);
-        hillshadeParameters.putSerializable("slope_type", mSlopeType);
-        paramDialog.setArguments(hillshadeParameters);
-        paramDialog.show(mFragmentManager, "param_dialog");
-        return super.onOptionsItemSelected(item);
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onPause() {
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/identify-graphics-hittest/src/main/AndroidManifest.xml
+++ b/java/identify-graphics-hittest/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/identify-graphics-hittest/src/main/java/com/esri/arcgisruntime/sample/identifygraphicoverlay/MainActivity.java
+++ b/java/identify-graphics-hittest/src/main/java/com/esri/arcgisruntime/sample/identifygraphicoverlay/MainActivity.java
@@ -75,6 +75,12 @@ public class MainActivity extends AppCompatActivity {
         mMapView.resume();
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        mMapView.dispose();
+    }
+
     private void addGraphicsOverlay() {
         // create the polygon
         PolygonBuilder polygonGeometry = new PolygonBuilder(SpatialReferences.getWebMercator());

--- a/java/identify-layers/src/main/AndroidManifest.xml
+++ b/java/identify-layers/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/identify-layers/src/main/java/com/esri/arcgisruntime/sample/identifylayers/MainActivity.java
+++ b/java/identify-layers/src/main/java/com/esri/arcgisruntime/sample/identifylayers/MainActivity.java
@@ -222,4 +222,10 @@ public class MainActivity extends AppCompatActivity {
     super.onResume();
     mMapView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/list-related-features/src/main/AndroidManifest.xml
+++ b/java/list-related-features/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme"
-        android:configChanges="orientation|screenSize|uiMode">
+        android:theme="@style/AppTheme">
 
         <activity android:name=".MainActivity">
             <intent-filter>

--- a/java/list-related-features/src/main/java/com/esri/arcgisruntime/sample/listrelatedfeatures/MainActivity.java
+++ b/java/list-related-features/src/main/java/com/esri/arcgisruntime/sample/listrelatedfeatures/MainActivity.java
@@ -19,6 +19,7 @@ package com.esri.arcgisruntime.sample.listrelatedfeatures;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -50,199 +51,208 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private final String TAG = "RelatedFeatures";
+  private final String TAG = MainActivity.class.getSimpleName();
+  private final ArrayList<FeatureLayer> mOperationalLayers = new ArrayList<>();
+  private final List<String> mRelatedValues = new LinkedList<>();
+  private MapView mMapView;
+  private ArcGISMap mArcGISMap;
+  private BottomSheetBehavior mBottomSheetBehavior = null;
+  private ArrayAdapter<String> mArrayAdapter;
 
-    private MapView mMapView;
-    private ArcGISMap mArcGISMap;
-    private final ArrayList<FeatureLayer> mOperationalLayers = new ArrayList<>();
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-    private BottomSheetBehavior mBottomSheetBehavior = null;
-    private ArrayAdapter<String> mArrayAdapter;
-    private final List<String> mRelatedValues = new LinkedList<>();
+    // The View with the BottomSheetBehavior
+    mBottomSheetBehavior = BottomSheetBehavior.from(findViewById(R.id.bottom_sheet));
+    mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+    // get bottomsheet collapsed height in dp
+    DisplayMetrics displayMetrics = getResources().getDisplayMetrics();
+    final float dp =
+        mBottomSheetBehavior.getPeekHeight() / ((float) displayMetrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
 
-        // The View with the BottomSheetBehavior
-        mBottomSheetBehavior = BottomSheetBehavior.from(findViewById(R.id.bottom_sheet));
+    ListView tableList = (ListView) findViewById(R.id.related_list);
+    mArrayAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, mRelatedValues);
+    tableList.setAdapter(mArrayAdapter);
+
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a mArcGISMap a webmap
+    mArcGISMap = new ArcGISMap(getResources().getString(R.string.webmap_url));
+    // set the mArcGISMap to be displayed in this view
+    mMapView.setMap(mArcGISMap);
+    mArcGISMap.addDoneLoadingListener(new Runnable() {
+      @Override
+      public void run() {
+        if (mArcGISMap.getLoadStatus() == LoadStatus.LOADED) {
+          // create Features to use for listing related features
+          createFeatures(mArcGISMap);
+        }
+      }
+    });
+
+    mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView) {
+      @Override
+      public boolean onSingleTapConfirmed(MotionEvent e) {
+        // clear ListAdapter of previous results
+        mArrayAdapter.clear();
+        // hide the bottomsheet
         mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+        // get the point that was clicked and convert it to a point in mArcGISMap coordinates
+        Point clickPoint = mMapView.screenToLocation(new android.graphics.Point(
+            Math.round(e.getX()),
+            Math.round(e.getY())));
+        int tolerance = 10;
+        double mapTolerance = tolerance * mMapView.getUnitsPerDensityIndependentPixel();
+        // create objects required to do a selection with a query
+        Envelope envelope = new Envelope(
+            clickPoint.getX() - mapTolerance,
+            clickPoint.getY() - mapTolerance,
+            clickPoint.getX() + mapTolerance,
+            clickPoint.getY() + mapTolerance,
+            mArcGISMap.getSpatialReference());
+        QueryParameters queryParams = new QueryParameters();
+        queryParams.setGeometry(envelope);
+        // get the FeatureLayer to query
+        final FeatureLayer selectedLayer = mOperationalLayers.get(0);
+        // get a list of related features to display
+        queryRelatedFeatures(selectedLayer, queryParams);
+        // highlight selected layer
+        selectedLayer.setSelectionColor(Color.YELLOW);
+        selectedLayer.setSelectionWidth(5);
+        return super.onSingleTapConfirmed(e);
+      }
+    });
 
-        // get bottomsheet collapsed height in dp
-        DisplayMetrics displayMetrics = getResources().getDisplayMetrics();
-        final float dp = mBottomSheetBehavior.getPeekHeight()/((float)displayMetrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
+    // respond to bottom sheet interaction
+    mBottomSheetBehavior.setBottomSheetCallback(new BottomSheetBehavior.BottomSheetCallback() {
+      @Override
+      public void onStateChanged(@NonNull View bottomSheet, int newState) {
+        if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
+          // set attribution bar above bottom sheet when collapsed
+          mMapView.setViewInsets(0, 0, 0, dp);
+        } else {
+          // set attribution bar to bottom when bottom sheet hidden or sliding
+          mMapView.setViewInsets(0, 0, 0, 0);
+        }
+      }
 
-        ListView tableList = (ListView) findViewById(R.id.related_list);
-        mArrayAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, mRelatedValues);
-        tableList.setAdapter(mArrayAdapter);
+      @Override
+      public void onSlide(@NonNull View bottomSheet, float slideOffset) {
+        // bottom sheet sliding up or down
+      }
+    });
+  }
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a mArcGISMap a webmap
-        mArcGISMap = new ArcGISMap(getResources().getString(R.string.webmap_url));
-        // set the mArcGISMap to be displayed in this view
-        mMapView.setMap(mArcGISMap);
-        mArcGISMap.addDoneLoadingListener(new Runnable() {
-            @Override
-            public void run() {
-                if(mArcGISMap.getLoadStatus() == LoadStatus.LOADED){
-                    // create Features to use for listing related features
-                    createFeatures(mArcGISMap);
-                }
-            }
-        });
+  /**
+   * Uses the selected FeatureLayer to get FeatureTable RelationshipInfos used to
+   * QueryRelatedFeaturesAsync which returns a list of related features.
+   *
+   * @param featureLayer    Layer selected from the Map
+   * @param queryParameters Input parameters for query
+   */
+  private void queryRelatedFeatures(final FeatureLayer featureLayer, QueryParameters queryParameters) {
+    final ListenableFuture<FeatureQueryResult> future = featureLayer
+        .selectFeaturesAsync(queryParameters, FeatureLayer.SelectionMode.NEW);
+    // clear previously selected layers
+    featureLayer.clearSelection();
 
-        mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView){
-            @Override
-            public boolean onSingleTapConfirmed(MotionEvent e) {
-                // clear ListAdapter of previous results
-                mArrayAdapter.clear();
-                // hide the bottomsheet
-                mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
-                // get the point that was clicked and convert it to a point in mArcGISMap coordinates
-                Point clickPoint = mMapView.screenToLocation(new android.graphics.Point(
-                        Math.round(e.getX()),
-                        Math.round(e.getY())));
-                int tolerance = 10;
-                double mapTolerance = tolerance * mMapView.getUnitsPerDensityIndependentPixel();
-                // create objects required to do a selection with a query
-                Envelope envelope = new Envelope(
-                        clickPoint.getX() - mapTolerance,
-                        clickPoint.getY() - mapTolerance,
-                        clickPoint.getX() + mapTolerance,
-                        clickPoint.getY() + mapTolerance,
-                        mArcGISMap.getSpatialReference());
-                QueryParameters queryParams = new QueryParameters();
-                queryParams.setGeometry(envelope);
-                // get the FeatureLayer to query
-                final FeatureLayer selectedLayer = mOperationalLayers.get(0);
-                // get a list of related features to display
-                queryRelatedFeatures(selectedLayer, queryParams);
-                // highlight selected layer
-                selectedLayer.setSelectionColor(Color.YELLOW);
-                selectedLayer.setSelectionWidth(5);
-                return super.onSingleTapConfirmed(e);
-            }
-        });
+    future.addDoneListener(new Runnable() {
+      @Override
+      public void run() {
+        //call get on the future to get the result
+        try {
+          if (future.get().iterator().hasNext()) {
+            FeatureQueryResult result = future.get();
 
-        // respond to bottom sheet interaction
-        mBottomSheetBehavior.setBottomSheetCallback(new BottomSheetBehavior.BottomSheetCallback() {
-            @Override
-            public void onStateChanged(@NonNull View bottomSheet, int newState) {
-                if(newState == BottomSheetBehavior.STATE_COLLAPSED){
-                    // set attribution bar above bottom sheet when collapsed
-                    mMapView.setViewInsets(0, 0, 0, dp);
-                }else{
-                    // set attribution bar to bottom when bottom sheet hidden or sliding
-                    mMapView.setViewInsets(0, 0, 0, 0);
-                }
-            }
+            // iterate over features returned
+            for (Feature feature : result) {
+              ArcGISFeature arcGISFeature = (ArcGISFeature) feature;
+              ArcGISFeatureTable selectedTable = (ArcGISFeatureTable) feature.getFeatureTable();
 
-            @Override
-            public void onSlide(@NonNull View bottomSheet, float slideOffset) {
-                // bottom sheet sliding up or down
-            }
-        });
-    }
-
-    /**
-     * Uses the selected FeatureLayer to get FeatureTable RelationshipInfos used to
-     * QueryRelatedFeaturesAsync which returns a list of related features.
-     *
-     * @param featureLayer Layer selected from the Map
-     * @param queryParameters Input parameters for query
-     */
-    private void queryRelatedFeatures(final FeatureLayer featureLayer, QueryParameters queryParameters){
-        final ListenableFuture<FeatureQueryResult> future = featureLayer.selectFeaturesAsync(queryParameters, FeatureLayer.SelectionMode.NEW);
-        // clear previously selected layers
-        featureLayer.clearSelection();
-
-        future.addDoneListener(new Runnable() {
-            @Override
-            public void run() {
-                //call get on the future to get the result
-                try {
-                    if(future.get().iterator().hasNext()){
-                        FeatureQueryResult result = future.get();
-
-                        // iterate over features returned
-                        for (Feature feature : result) {
-                            ArcGISFeature arcGISFeature = (ArcGISFeature)feature;
-                            ArcGISFeatureTable selectedTable = (ArcGISFeatureTable)feature.getFeatureTable();
-
-                            final ListenableFuture<List<RelatedFeatureQueryResult>> relatedFeatureQueryResultFuture = selectedTable.queryRelatedFeaturesAsync(arcGISFeature);
-                            relatedFeatureQueryResultFuture.addDoneListener(new Runnable() {
-                                @Override
-                                public void run() {
-                                    try {
-                                        List<RelatedFeatureQueryResult> relatedFeatureQueryResultList = relatedFeatureQueryResultFuture.get();
-                                        // iterate over returned RelatedFeatureQueryResults
-                                        for(RelatedFeatureQueryResult relatedQueryResult : relatedFeatureQueryResultList){
-                                            // Add Table Name to List
-                                            String relatedTableName = relatedQueryResult.getRelatedTable().getTableName();
-                                            mRelatedValues.add(relatedTableName);
-                                            // iterate over Features returned
-                                            for (Feature relatedFeature : relatedQueryResult) {
-                                                // Get the Display field to use as filter on related attributes
-                                                ArcGISFeature agsFeature = (ArcGISFeature) relatedFeature;
-                                                String displayFieldName = agsFeature.getFeatureTable().getLayerInfo().getDisplayFieldName();
-                                                String displayFieldValue = agsFeature.getAttributes().get(displayFieldName).toString();
-                                                mRelatedValues.add(displayFieldValue);
-                                                // notify ListAdapter content has changed
-                                                mArrayAdapter.notifyDataSetChanged();
-                                            }
-                                        }
-                                    } catch (Exception e) {
-                                        Log.e(TAG, "Exception occurred: " + e.getMessage());
-                                    }
-                                }
-                            });
-                        }
-                    } else {
-                        // did not tap on a feature, display no results
-                        mRelatedValues.add(getResources().getString(R.string.no_results));
+              final ListenableFuture<List<RelatedFeatureQueryResult>> relatedFeatureQueryResultFuture = selectedTable
+                  .queryRelatedFeaturesAsync(arcGISFeature);
+              relatedFeatureQueryResultFuture.addDoneListener(new Runnable() {
+                @Override
+                public void run() {
+                  try {
+                    List<RelatedFeatureQueryResult> relatedFeatureQueryResultList = relatedFeatureQueryResultFuture
+                        .get();
+                    // iterate over returned RelatedFeatureQueryResults
+                    for (RelatedFeatureQueryResult relatedQueryResult : relatedFeatureQueryResultList) {
+                      // Add Table Name to List
+                      String relatedTableName = relatedQueryResult.getRelatedTable().getTableName();
+                      mRelatedValues.add(relatedTableName);
+                      // iterate over Features returned
+                      for (Feature relatedFeature : relatedQueryResult) {
+                        // Get the Display field to use as filter on related attributes
+                        ArcGISFeature agsFeature = (ArcGISFeature) relatedFeature;
+                        String displayFieldName = agsFeature.getFeatureTable().getLayerInfo().getDisplayFieldName();
+                        String displayFieldValue = agsFeature.getAttributes().get(displayFieldName).toString();
+                        mRelatedValues.add(displayFieldValue);
                         // notify ListAdapter content has changed
                         mArrayAdapter.notifyDataSetChanged();
+                      }
                     }
-
-                } catch (Exception e) {
+                  } catch (Exception e) {
                     Log.e(TAG, "Exception occurred: " + e.getMessage());
+                  }
                 }
-                // show the bottomsheet with results
-                mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+              });
             }
+          } else {
+            // did not tap on a feature, display no results
+            mRelatedValues.add(getResources().getString(R.string.no_results));
+            // notify ListAdapter content has changed
+            mArrayAdapter.notifyDataSetChanged();
+          }
 
-        });
-    }
-
-    /**
-     * Create Features from Layers in the Map
-     *
-     * @param map ArcGISMap to get Layers and Tables
-     */
-    private void createFeatures(ArcGISMap map){
-        LayerList layers = map.getOperationalLayers();
-        // add the National Parks Feature layer to LayerList
-        for(Layer layer: layers){
-            FeatureLayer fLayer = (FeatureLayer) layer;
-            if(fLayer.getName().contains("Alaska National Parks")){
-                mOperationalLayers.add(fLayer);
-            }
+        } catch (Exception e) {
+          Log.e(TAG, "Exception occurred: " + e.getMessage());
         }
-    }
+        // show the bottomsheet with results
+        mBottomSheetBehavior.setState(BottomSheetBehavior.STATE_COLLAPSED);
+      }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+    });
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
+  /**
+   * Create Features from Layers in the Map
+   *
+   * @param map ArcGISMap to get Layers and Tables
+   */
+  private void createFeatures(ArcGISMap map) {
+    LayerList layers = map.getOperationalLayers();
+    // add the National Parks Feature layer to LayerList
+    for (Layer layer : layers) {
+      FeatureLayer fLayer = (FeatureLayer) layer;
+      if (fLayer.getName().contains("Alaska National Parks")) {
+        mOperationalLayers.add(fLayer);
+      }
     }
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
 }

--- a/java/location-line-of-sight/src/main/AndroidManifest.xml
+++ b/java/location-line-of-sight/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize">
+        <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/location-line-of-sight/src/main/java/com/esri/arcgisruntime/sample/locationlineofsight/MainActivity.java
+++ b/java/location-line-of-sight/src/main/java/com/esri/arcgisruntime/sample/locationlineofsight/MainActivity.java
@@ -121,4 +121,11 @@ public class MainActivity extends AppCompatActivity {
     // resume SceneView
     mSceneView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose SceneView
+    mSceneView.dispose();
+  }
 }

--- a/java/manage-bookmarks/src/main/AndroidManifest.xml
+++ b/java/manage-bookmarks/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
         android:supportsRtl="true">
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/manage-bookmarks/src/main/java/com/esri/arcgisruntime/sample/managebookmarks/MainActivity.java
+++ b/java/manage-bookmarks/src/main/java/com/esri/arcgisruntime/sample/managebookmarks/MainActivity.java
@@ -18,6 +18,7 @@ package com.esri.arcgisruntime.sample.managebookmarks;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -42,166 +43,174 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
-    private BookmarkList mBookmarks;
-    private List<String> mBookmarksSpinnerList;
-    private Bookmark mBookmark;
-    private ArrayAdapter<String> mDataAdapter;
+  private MapView mMapView;
+  private BookmarkList mBookmarks;
+  private List<String> mBookmarksSpinnerList;
+  private Bookmark mBookmark;
+  private ArrayAdapter<String> mDataAdapter;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        FloatingActionButton addBookmarkFab;
+    FloatingActionButton addBookmarkFab;
 
-        Spinner bookmarksSpinner;
+    Spinner bookmarksSpinner;
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // create a map with the BasemapType imagery with labels
-        ArcGISMap mMap = new ArcGISMap(Basemap.createImageryWithLabels());
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
+    // create a map with the BasemapType imagery with labels
+    ArcGISMap mMap = new ArcGISMap(Basemap.createImageryWithLabels());
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
 
-        // inflate the floating action button
-        addBookmarkFab = (FloatingActionButton) findViewById(R.id.addbookmarkFAB);
+    // inflate the floating action button
+    addBookmarkFab = (FloatingActionButton) findViewById(R.id.addbookmarkFAB);
 
-        // show the dialog for acquiring bookmark name from the user
-        addBookmarkFab.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                showDialog(v.getContext());
-            }
-        });
+    // show the dialog for acquiring bookmark name from the user
+    addBookmarkFab.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        showDialog(v.getContext());
+      }
+    });
 
-        // get the maps BookmarkList
-        mBookmarks = mMap.getBookmarks();
+    // get the maps BookmarkList
+    mBookmarks = mMap.getBookmarks();
 
-        // add some default bookmarks to the map
-        addDefaultBookmarks();
+    // add some default bookmarks to the map
+    addDefaultBookmarks();
 
-        // populate the spinner list with default bookmark names
-        bookmarksSpinner = (Spinner) findViewById(R.id.bookmarksspinner);
-        mBookmarksSpinnerList = new ArrayList<>();
-        mBookmarksSpinnerList.add(mBookmarks.get(0).getName());
-        mBookmarksSpinnerList.add(mBookmarks.get(1).getName());
-        mBookmarksSpinnerList.add(mBookmarks.get(2).getName());
-        mBookmarksSpinnerList.add(mBookmarks.get(3).getName());
+    // populate the spinner list with default bookmark names
+    bookmarksSpinner = (Spinner) findViewById(R.id.bookmarksspinner);
+    mBookmarksSpinnerList = new ArrayList<>();
+    mBookmarksSpinnerList.add(mBookmarks.get(0).getName());
+    mBookmarksSpinnerList.add(mBookmarks.get(1).getName());
+    mBookmarksSpinnerList.add(mBookmarks.get(2).getName());
+    mBookmarksSpinnerList.add(mBookmarks.get(3).getName());
 
-        // initialize the adapter for the bookmarks spinner
-        mDataAdapter = new ArrayAdapter<>(this,
-                android.R.layout.simple_spinner_item, mBookmarksSpinnerList);
-        mDataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        bookmarksSpinner.setAdapter(mDataAdapter);
+    // initialize the adapter for the bookmarks spinner
+    mDataAdapter = new ArrayAdapter<>(this,
+        android.R.layout.simple_spinner_item, mBookmarksSpinnerList);
+    mDataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+    bookmarksSpinner.setAdapter(mDataAdapter);
 
-        // when an item is selected in the spinner set the mapview viewpoint to the selected
-        // bookmark's viewpoint
-        bookmarksSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                mMapView.setViewpointAsync(mBookmarks.get(position).getViewpoint());
-            }
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-            }
-        });
-    }
+    // when an item is selected in the spinner set the mapview viewpoint to the selected
+    // bookmark's viewpoint
+    bookmarksSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+      @Override
+      public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+        mMapView.setViewpointAsync(mBookmarks.get(position).getViewpoint());
+      }
 
-    /**
-     * adds the default bookmarks to the maps BookmarkList
-     */
-    private void addDefaultBookmarks() {
+      @Override
+      public void onNothingSelected(AdapterView<?> parent) {
+      }
+    });
+  }
 
-        Viewpoint viewpoint;
+  /**
+   * adds the default bookmarks to the maps BookmarkList
+   */
+  private void addDefaultBookmarks() {
 
-        //Mysterious Desert Pattern
-        viewpoint = new Viewpoint(27.3805833, 33.6321389, 6e3);
-        mBookmark = new Bookmark(getResources().getString(R.string.desert_pattern), viewpoint);
-        mBookmarks.add(mBookmark);
-        // Set the viewpoint to the default bookmark selected in the spinner
-        mMapView.setViewpointAsync(viewpoint);
+    Viewpoint viewpoint;
 
-        //Strange Symbol
-        viewpoint = new Viewpoint(37.401573, -116.867808, 6e3);
-        mBookmark = new Bookmark(getResources().getString(R.string.strange_symbol), viewpoint);
-        mBookmarks.add(mBookmark);
+    //Mysterious Desert Pattern
+    viewpoint = new Viewpoint(27.3805833, 33.6321389, 6e3);
+    mBookmark = new Bookmark(getResources().getString(R.string.desert_pattern), viewpoint);
+    mBookmarks.add(mBookmark);
+    // Set the viewpoint to the default bookmark selected in the spinner
+    mMapView.setViewpointAsync(viewpoint);
 
-        //Guitar-Shaped Trees
-        viewpoint = new Viewpoint(-33.867886, -63.985, 4e4);
-        mBookmark = new Bookmark(getResources().getString(R.string.guitar_trees), viewpoint);
-        mBookmarks.add(mBookmark);
+    //Strange Symbol
+    viewpoint = new Viewpoint(37.401573, -116.867808, 6e3);
+    mBookmark = new Bookmark(getResources().getString(R.string.strange_symbol), viewpoint);
+    mBookmarks.add(mBookmark);
 
-        //Grand Prismatic Spring
-        viewpoint = new Viewpoint(44.525049, -110.83819, 6e3);
-        mBookmark = new Bookmark(getResources().getString(R.string.prismatic_spring), viewpoint);
-        mBookmarks.add(mBookmark);
+    //Guitar-Shaped Trees
+    viewpoint = new Viewpoint(-33.867886, -63.985, 4e4);
+    mBookmark = new Bookmark(getResources().getString(R.string.guitar_trees), viewpoint);
+    mBookmarks.add(mBookmark);
 
-    }
+    //Grand Prismatic Spring
+    viewpoint = new Viewpoint(44.525049, -110.83819, 6e3);
+    mBookmark = new Bookmark(getResources().getString(R.string.prismatic_spring), viewpoint);
+    mBookmarks.add(mBookmark);
 
-    /**
-     * add a new bookmark at the location being displayed in the MapView's current Viewpoint
-     * @param Name of the new bookmark
-     */
-    private void addBookmark(String Name) {
+  }
 
-        mBookmark = new Bookmark(Name, mMapView.getCurrentViewpoint(Viewpoint.Type.BOUNDING_GEOMETRY));
-        mBookmarks.add(mBookmark);
-        mBookmarksSpinnerList.add(Name);
-        mDataAdapter.notifyDataSetChanged();
-    }
+  /**
+   * add a new bookmark at the location being displayed in the MapView's current Viewpoint
+   *
+   * @param Name of the new bookmark
+   */
+  private void addBookmark(String Name) {
 
-    /**
-     * shows dialog that prompts user to add a name for the new Bookmark
-     */
-    private void showDialog(Context context) {
+    mBookmark = new Bookmark(Name, mMapView.getCurrentViewpoint(Viewpoint.Type.BOUNDING_GEOMETRY));
+    mBookmarks.add(mBookmark);
+    mBookmarksSpinnerList.add(Name);
+    mDataAdapter.notifyDataSetChanged();
+  }
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setTitle(getResources().getString(R.string.alert_dialog_title));
+  /**
+   * shows dialog that prompts user to add a name for the new Bookmark
+   */
+  private void showDialog(Context context) {
 
-        // Set up the input
-        final EditText input = new EditText(this);
-        input.setInputType(InputType.TYPE_CLASS_TEXT);
-        builder.setView(input);
+    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+    builder.setTitle(getResources().getString(R.string.alert_dialog_title));
 
-        // Set up the buttons
-        builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                // get the input from EditText
-                String bookmarkName = input.getText().toString();
-                // check if EditText is not empty & bookmark name has not been used
-                if(bookmarkName.length() > 0 && !mBookmarksSpinnerList.contains(bookmarkName)){
-                    addBookmark(bookmarkName);
-                }else{
-                    // display toast explaining bookmark not set
-                    Toast.makeText(getApplicationContext(), getResources().getString(R.string.bookmark_not_saved), Toast.LENGTH_LONG).show();
-                    dialog.cancel();
-                }
-            }
-        });
-        builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(@NonNull DialogInterface dialog, int which) {
-                dialog.cancel();
-            }
-        });
+    // Set up the input
+    final EditText input = new EditText(this);
+    input.setInputType(InputType.TYPE_CLASS_TEXT);
+    builder.setView(input);
 
-        builder.show();
+    // Set up the buttons
+    builder.setPositiveButton("OK", new DialogInterface.OnClickListener() {
+      @Override
+      public void onClick(DialogInterface dialog, int which) {
+        // get the input from EditText
+        String bookmarkName = input.getText().toString();
+        // check if EditText is not empty & bookmark name has not been used
+        if (bookmarkName.length() > 0 && !mBookmarksSpinnerList.contains(bookmarkName)) {
+          addBookmark(bookmarkName);
+        } else {
+          // display toast explaining bookmark not set
+          Toast.makeText(getApplicationContext(), getResources().getString(R.string.bookmark_not_saved),
+              Toast.LENGTH_LONG).show();
+          dialog.cancel();
+        }
+      }
+    });
+    builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+      @Override
+      public void onClick(@NonNull DialogInterface dialog, int which) {
+        dialog.cancel();
+      }
+    });
 
-    }
+    builder.show();
 
-    @Override
-    protected void onPause() {
-        super.onPause();
-        mMapView.pause();
-    }
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/manage-operational-layers/src/main/AndroidManifest.xml
+++ b/java/manage-operational-layers/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
-            android:configChanges="orientation|screenSize|uiMode"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/java/manage-operational-layers/src/main/java/com/esri/arcgisruntime/sample/manageoperationallayers/MainActivity.java
+++ b/java/manage-operational-layers/src/main/java/com/esri/arcgisruntime/sample/manageoperationallayers/MainActivity.java
@@ -33,72 +33,76 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
-    private static LayerList mOperationalLayers;
+  private static LayerList mOperationalLayers;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  /**
+   * returns the LayerList associated with the Map
+   *
+   * @return LayerList containing all the operational layers in the Map
+   */
+  public static LayerList getOperationalLayerList() {
+    return mOperationalLayers;
+  }
 
-        ArcGISMapImageLayer imageLayerElevation, imagelayerCensus;
-        Button selectLayers;
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    ArcGISMapImageLayer imageLayerElevation, imagelayerCensus;
+    Button selectLayers;
 
-        // inflate operational layer selection button from the layout
-        selectLayers = (Button) findViewById(R.id.operationallayer);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // create a map with the BasemapType topographic
-        ArcGISMap mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 14);
+    // inflate operational layer selection button from the layout
+    selectLayers = (Button) findViewById(R.id.operationallayer);
 
-        imageLayerElevation = new ArcGISMapImageLayer(getResources().getString(R.string.imagelayer_elevation_url));
-        imagelayerCensus = new ArcGISMapImageLayer(getResources().getString(R.string.imagelayer_census_url));
+    // create a map with the BasemapType topographic
+    ArcGISMap mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 14);
 
-        // get the LayerList from the Map
-        mOperationalLayers = mMap.getOperationalLayers();
-        // add operational layers to the Map
-        mOperationalLayers.add(imageLayerElevation);
-        mOperationalLayers.add(imagelayerCensus);
+    imageLayerElevation = new ArcGISMapImageLayer(getResources().getString(R.string.imagelayer_elevation_url));
+    imagelayerCensus = new ArcGISMapImageLayer(getResources().getString(R.string.imagelayer_census_url));
 
-        // set the initial viewpoint on the map
-        mMap.setInitialViewpoint(new Viewpoint(new Point(-133e5, 45e5, SpatialReference.create(3857)), 2e7));
+    // get the LayerList from the Map
+    mOperationalLayers = mMap.getOperationalLayers();
+    // add operational layers to the Map
+    mOperationalLayers.add(imageLayerElevation);
+    mOperationalLayers.add(imagelayerCensus);
 
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
+    // set the initial viewpoint on the map
+    mMap.setInitialViewpoint(new Viewpoint(new Point(-133e5, 45e5, SpatialReference.create(3857)), 2e7));
 
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
 
-        selectLayers.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent intent = new Intent(MainActivity.this, OperationalLayers.class);
-                intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-                startActivity(intent);
+    selectLayers.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        Intent intent = new Intent(MainActivity.this, OperationalLayers.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        startActivity(intent);
 
-            }
-        });
-    }
+      }
+    });
+  }
 
-    /**
-     * returns the LayerList associated with the Map
-     *
-     * @return LayerList containing all the operational layers in the Map
-     */
-    public static LayerList getOperationalLayerList() {
-        return mOperationalLayers;
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onPause() {
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        mMapView.resume();
-    }
-
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/map-loaded/src/main/java/com/esri/arcgisruntime/sample/maploaded/MainActivity.java
+++ b/java/map-loaded/src/main/java/com/esri/arcgisruntime/sample/maploaded/MainActivity.java
@@ -32,104 +32,110 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private static final String TAG = "MapLoadStatus";
-    private MapView mMapView;
-    private TextView mMapLoadStatusTextView;
+  private static final String TAG = "MapLoadStatus";
+  private MapView mMapView;
+  private TextView mMapLoadStatusTextView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // inflate TextView of the map load status from the layout
-        mMapLoadStatusTextView = (TextView) findViewById(R.id.mapLoadStatusResult);
-        loadMap();
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // inflate TextView of the map load status from the layout
+    mMapLoadStatusTextView = (TextView) findViewById(R.id.mapLoadStatusResult);
+    loadMap();
 
+  }
+
+  @Override
+  public boolean onCreateOptionsMenu(Menu menu) {
+    // Inflate the menu; this adds items to the action bar if it is present.
+    getMenuInflater().inflate(R.menu.menu_main, menu);
+
+    return true;
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    // handle menu item selection
+    int itemId = item.getItemId();
+    if (itemId == R.id.Refresh) {
+      mMapLoadStatusTextView.setText("");
+      // reload the map in the MapView
+      loadMap();
     }
+    return true;
+  }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_main, menu);
+  /**
+   * add a load status change listener on the loadable Map and display the map load status
+   */
+  private void loadMap() {
 
-        return true;
-    }
+    //clear the current map load status of the TextView
+    mMapLoadStatusTextView.setText("");
+    // create a map with the BasemapType National Geographic
+    ArcGISMap map = new ArcGISMap(Basemap.createLightGrayCanvas());
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // handle menu item selection
-        int itemId = item.getItemId();
-        if (itemId == R.id.Refresh) {
-            mMapLoadStatusTextView.setText("");
-            // reload the map in the MapView
-            loadMap();
+    // Listener on change in map load status
+    map.addLoadStatusChangedListener(new LoadStatusChangedListener() {
+      @Override
+      public void loadStatusChanged(LoadStatusChangedEvent loadStatusChangedEvent) {
+        String mapLoadStatus;
+        mapLoadStatus = loadStatusChangedEvent.getNewLoadStatus().name();
+        // map load status can be any of LOADING, FAILED_TO_LOAD, NOT_LOADED or LOADED
+        // set the status in the TextView accordingly
+        switch (mapLoadStatus) {
+          case "LOADING":
+            mMapLoadStatusTextView.setText(R.string.status_loading);
+            mMapLoadStatusTextView.setTextColor(Color.BLUE);
+            break;
+
+          case "FAILED_TO_LOAD":
+            mMapLoadStatusTextView.setText(R.string.status_loadFail);
+            mMapLoadStatusTextView.setTextColor(Color.RED);
+            break;
+
+          case "NOT_LOADED":
+            mMapLoadStatusTextView.setText(R.string.status_notLoaded);
+            mMapLoadStatusTextView.setTextColor(Color.GRAY);
+            break;
+
+          case "LOADED":
+            mMapLoadStatusTextView.setText(R.string.status_loaded);
+            mMapLoadStatusTextView.setTextColor(Color.GREEN);
+            break;
+
+          default:
+            mMapLoadStatusTextView.setText(R.string.status_loadError);
+            mMapLoadStatusTextView.setTextColor(Color.WHITE);
+            break;
         }
-        return true;
-    }
 
-    /**
-     * add a load status change listener on the loadable Map and display the map load status
-     */
-    private void loadMap() {
+        Log.d(TAG, mapLoadStatus);
+      }
+    });
+    // set the map to be displayed in this view
+    mMapView.setMap(map);
+  }
 
-        //clear the current map load status of the TextView
-        mMapLoadStatusTextView.setText("");
-        // create a map with the BasemapType National Geographic
-        ArcGISMap map = new ArcGISMap(Basemap.createLightGrayCanvas());
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-        // Listener on change in map load status
-        map.addLoadStatusChangedListener(new LoadStatusChangedListener() {
-            @Override
-            public void loadStatusChanged(LoadStatusChangedEvent loadStatusChangedEvent) {
-                String mapLoadStatus;
-                mapLoadStatus = loadStatusChangedEvent.getNewLoadStatus().name();
-                // map load status can be any of LOADING, FAILED_TO_LOAD, NOT_LOADED or LOADED
-                // set the status in the TextView accordingly
-                switch (mapLoadStatus) {
-                    case "LOADING":
-                        mMapLoadStatusTextView.setText(R.string.status_loading);
-                        mMapLoadStatusTextView.setTextColor(Color.BLUE);
-                        break;
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
 
-                    case "FAILED_TO_LOAD":
-                        mMapLoadStatusTextView.setText(R.string.status_loadFail);
-                        mMapLoadStatusTextView.setTextColor(Color.RED);
-                        break;
-
-                    case "NOT_LOADED":
-                        mMapLoadStatusTextView.setText(R.string.status_notLoaded);
-                        mMapLoadStatusTextView.setTextColor(Color.GRAY);
-                        break;
-
-                    case "LOADED":
-                        mMapLoadStatusTextView.setText(R.string.status_loaded);
-                        mMapLoadStatusTextView.setTextColor(Color.GREEN);
-                        break;
-
-                    default :
-                        mMapLoadStatusTextView.setText(R.string.status_loadError);
-                        mMapLoadStatusTextView.setTextColor(Color.WHITE);
-                        break;
-                }
-
-                Log.d(TAG,mapLoadStatus);
-            }
-        });
-        // set the map to be displayed in this view
-        mMapView.setMap(map);
-    }
-
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
-
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/map-rotation/src/main/AndroidManifest.xml
+++ b/java/map-rotation/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme"
-        android:configChanges="orientation|screenSize|uiMode">
+        android:theme="@style/AppTheme">
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/java/map-rotation/src/main/java/com/esri/arcgisruntime/sample/maprotation/MainActivity.java
+++ b/java/map-rotation/src/main/java/com/esri/arcgisruntime/sample/maprotation/MainActivity.java
@@ -11,56 +11,62 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
-    private TextView mRotationValueText;
+  private MapView mMapView;
+  private TextView mRotationValueText;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // create MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the Basemap.Type topographic
-        ArcGISMap mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 10);
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
-        // create TextView to show angle of rotation
-        mRotationValueText = (TextView)findViewById(R.id.rotationValueText);
-        // create SeekBar
-        SeekBar mRotationSeekBar = (SeekBar) findViewById(R.id.rotationSeekBar);
-        mRotationSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
-            @Override
-            public void onProgressChanged(SeekBar seekBar, int angle, boolean b) {
-                // convert progress to double
-                double dAngle = angle;
-                // set the text to SeekBar value
-                mRotationValueText.setText(String.valueOf(angle));
-                // rotate MapView to double angle value
-                mMapView.setViewpointRotationAsync(dAngle);
-            }
+    // create MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the Basemap.Type topographic
+    ArcGISMap mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 10);
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
+    // create TextView to show angle of rotation
+    mRotationValueText = (TextView) findViewById(R.id.rotationValueText);
+    // create SeekBar
+    SeekBar mRotationSeekBar = (SeekBar) findViewById(R.id.rotationSeekBar);
+    mRotationSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+      @Override
+      public void onProgressChanged(SeekBar seekBar, int angle, boolean b) {
+        // convert progress to double
+        double dAngle = angle;
+        // set the text to SeekBar value
+        mRotationValueText.setText(String.valueOf(angle));
+        // rotate MapView to double angle value
+        mMapView.setViewpointRotationAsync(dAngle);
+      }
 
-            @Override
-            public void onStartTrackingTouch(SeekBar seekBar) {
-                
-            }
+      @Override
+      public void onStartTrackingTouch(SeekBar seekBar) {
 
-            @Override
-            public void onStopTrackingTouch(SeekBar seekBar) {
+      }
 
-            }
-        });
-    }
+      @Override
+      public void onStopTrackingTouch(SeekBar seekBar) {
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+      }
+    });
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/map-sketching/src/main/java/com/esri/arcgisruntime/sample/mapsketching/MainActivity.java
+++ b/java/map-sketching/src/main/java/com/esri/arcgisruntime/sample/mapsketching/MainActivity.java
@@ -78,6 +78,12 @@ public class MainActivity extends AppCompatActivity {
   }
 
   @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
+
+  @Override
   public boolean onCreateOptionsMenu(Menu menu) {
     // Inflate the menu; this adds items to the action bar if it is present.
     getMenuInflater().inflate(R.menu.menu_main, menu);

--- a/java/mobile-map-search-and-route/src/main/AndroidManifest.xml
+++ b/java/mobile-map-search-and-route/src/main/AndroidManifest.xml
@@ -17,8 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup">
-        <activity android:name=".MobileMapViewActivity"
-                  android:configChanges="orientation|screenSize|uiMode">
+        <activity android:name=".MobileMapViewActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/java/mobile-map-search-and-route/src/main/java/com/esri/arcgisruntime/sample/mobilemapsearchandroute/MobileMapViewActivity.java
+++ b/java/mobile-map-search-and-route/src/main/java/com/esri/arcgisruntime/sample/mobilemapsearchandroute/MobileMapViewActivity.java
@@ -16,6 +16,12 @@
 
 package com.esri.arcgisruntime.sample.mobilemapsearchandroute;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
 import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -31,6 +37,8 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.widget.TextView;
+
+import static com.esri.arcgisruntime.sample.mobilemapsearchandroute.R.layout.callout;
 
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.geometry.Point;
@@ -57,17 +65,9 @@ import com.esri.arcgisruntime.tasks.networkanalysis.RouteResult;
 import com.esri.arcgisruntime.tasks.networkanalysis.RouteTask;
 import com.esri.arcgisruntime.tasks.networkanalysis.Stop;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-
-import static com.esri.arcgisruntime.sample.mobilemapsearchandroute.R.layout.callout;
-
 /**
  * This class demonstrates offline functionality through the use of a mobile map package (mmpk).
- *
+ * <p>
  * This (main) activity handles:
  * loading of map package,
  * loading of maps and map previews from map packages,
@@ -75,442 +75,459 @@ import static com.esri.arcgisruntime.sample.mobilemapsearchandroute.R.layout.cal
  * routing.
  */
 public class MobileMapViewActivity extends AppCompatActivity {
-    private static final String TAG = "MMVA";
-    private MobileMapPackage mMobileMapPackage;
-    private MapView mMapView;
-    private String mMMPkTitle;
-    private final ArrayList <MapPreview> mMapPreviews = new ArrayList<>();
-    private LocatorTask mLocatorTask;
-    private Callout mCallout;
-    private static GraphicsOverlay mMarkerGraphicsOverlay;
-    private static GraphicsOverlay mRouteGraphicsOverlay;
-    private static RouteTask mRouteTask;
-    private static RouteParameters mRouteParameters;
-    private ReverseGeocodeParameters mReverseGeocodeParameters;
-    private final String[] reqPermission = new String[] {
-            Manifest.permission.WRITE_EXTERNAL_STORAGE
-    };
+  private static final String TAG = MobileMapViewActivity.class.getSimpleName();
+  private static GraphicsOverlay mMarkerGraphicsOverlay;
+  private static GraphicsOverlay mRouteGraphicsOverlay;
+  private static RouteTask mRouteTask;
+  private static RouteParameters mRouteParameters;
+  private final ArrayList<MapPreview> mMapPreviews = new ArrayList<>();
+  private final String[] reqPermission = new String[] {
+      Manifest.permission.WRITE_EXTERNAL_STORAGE
+  };
+  private MobileMapPackage mMobileMapPackage;
+  private MapView mMapView;
+  private String mMMPkTitle;
+  private LocatorTask mLocatorTask;
+  private Callout mCallout;
+  private ReverseGeocodeParameters mReverseGeocodeParameters;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
-        //initialize reverse geocode params
-        mReverseGeocodeParameters = new ReverseGeocodeParameters();
-        mReverseGeocodeParameters.setMaxResults(1);
-        mReverseGeocodeParameters.getResultAttributeNames().add("*");
-        //retrieve the MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        //add route and marker overlays to map view
-        mMarkerGraphicsOverlay = new GraphicsOverlay();
-        mRouteGraphicsOverlay = new GraphicsOverlay();
-        mMapView.getGraphicsOverlays().add(mRouteGraphicsOverlay);
-        mMapView.getGraphicsOverlays().add(mMarkerGraphicsOverlay);
-        // build the file path to access the mobile map package
-        String filePathMMPk = buildMMPkPath();
-        // add the map from the mobile map package to the MapView
-        loadMobileMapPackage(filePathMMPk);
-        mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView) {
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+    //initialize reverse geocode params
+    mReverseGeocodeParameters = new ReverseGeocodeParameters();
+    mReverseGeocodeParameters.setMaxResults(1);
+    mReverseGeocodeParameters.getResultAttributeNames().add("*");
+    //retrieve the MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    //add route and marker overlays to map view
+    mMarkerGraphicsOverlay = new GraphicsOverlay();
+    mRouteGraphicsOverlay = new GraphicsOverlay();
+    mMapView.getGraphicsOverlays().add(mRouteGraphicsOverlay);
+    mMapView.getGraphicsOverlays().add(mMarkerGraphicsOverlay);
+    // build the file path to access the mobile map package
+    String filePathMMPk = buildMMPkPath();
+    // add the map from the mobile map package to the MapView
+    loadMobileMapPackage(filePathMMPk);
+    mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView) {
 
-            @Override
-            public boolean onSingleTapConfirmed(MotionEvent motionEvent) {
-                Log.d(TAG, "onSingleTapConfirmed: " + motionEvent.toString());
-                // get the point that was clicked and convert it to a point in map coordinates
-                android.graphics.Point screenPoint = new android.graphics.Point(
-                        Math.round(motionEvent.getX()),
-                        Math.round(motionEvent.getY()));
-                // create a map point from screen point
-                Point mapPoint = mMapView.screenToLocation(screenPoint);
-                geoView(screenPoint, mapPoint);
-                return true;
-            }
-        });
+      @Override
+      public boolean onSingleTapConfirmed(MotionEvent motionEvent) {
+        Log.d(TAG, "onSingleTapConfirmed: " + motionEvent.toString());
+        // get the point that was clicked and convert it to a point in map coordinates
+        android.graphics.Point screenPoint = new android.graphics.Point(
+            Math.round(motionEvent.getX()),
+            Math.round(motionEvent.getY()));
+        // create a map point from screen point
+        Point mapPoint = mMapView.screenToLocation(screenPoint);
+        geoView(screenPoint, mapPoint);
+        return true;
+      }
+    });
+  }
+
+  @Override
+  public boolean onCreateOptionsMenu(Menu menu) {
+    //create button in action bar to allow user to access MapChooserActivity
+    MenuInflater inflater = getMenuInflater();
+    inflater.inflate(R.menu.map_preview_list, menu);
+    return super.onCreateOptionsMenu(menu);
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    final int MAP_CHOSEN_RESULT = 1;
+    Intent mapChooserIntent = new Intent(getApplicationContext(), MapChooserActivity.class);
+    //pass the list of mapPreviews
+    mapChooserIntent.putExtra("map_previews", mMapPreviews);
+    //pass the mobile map package title
+    mapChooserIntent.putExtra("MMPk_title", mMMPkTitle);
+    //start MapChooserActivity to determine user's chosen map number
+    startActivityForResult(mapChooserIntent, MAP_CHOSEN_RESULT);
+    return super.onOptionsItemSelected(item);
+  }
+
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    if (data != null) {
+      //get the map number chosen in MapChooserActivity and load that map
+      int mapNum = data.getIntExtra("map_num", -1);
+      loadMap(mapNum);
+      //dismiss any callout boxes
+      if (mCallout != null) {
+        mCallout.dismiss();
+      }
+      //clear any existing graphics
+      mMarkerGraphicsOverlay.getGraphics().clear();
+      mRouteGraphicsOverlay.getGraphics().clear();
     }
+    super.onActivityResult(requestCode, resultCode, data);
+  }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        //create button in action bar to allow user to access MapChooserActivity
-        MenuInflater inflater = getMenuInflater();
-        inflater.inflate(R.menu.map_preview_list, menu);
-        return super.onCreateOptionsMenu(menu);
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
+
+  /**
+   * Builds the path to the mobile map package on the device
+   *
+   * @return the assembled path
+   */
+  private String buildMMPkPath() {
+    // get sdcard resource name
+    File extStorDir = Environment.getExternalStorageDirectory();
+    // get the directory
+    String extSDCardDirName =
+        this.getResources().getString(R.string.config_data_sdcard_offline_dir);
+    // get mobile map package filename
+    String filename = this.getString(R.string.config_mmpk_name);
+    // create the full path to the mobile map package file
+    return extStorDir.getAbsolutePath()
+        + File.separator
+        + extSDCardDirName
+        + File.separator
+        + filename
+        + ".mmpk";
+  }
+
+  /**
+   * Handles read/write external storage permissions (for API 23+) and loads mobile map package
+   *
+   * @param path to location of mobile map package on device
+   */
+  private void loadMobileMapPackage(String path) {
+    //for API level 23+ request permission at runtime
+    if (ContextCompat.checkSelfPermission(getApplicationContext(),
+        reqPermission[0]) != PackageManager.PERMISSION_GRANTED) {
+      //request permission
+      int requestCode = 2;
+      ActivityCompat.requestPermissions(
+          MobileMapViewActivity.this, reqPermission, requestCode);
     }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        final int MAP_CHOSEN_RESULT = 1;
-        Intent mapChooserIntent = new Intent(getApplicationContext(), MapChooserActivity.class);
-        //pass the list of mapPreviews
-        mapChooserIntent.putExtra("map_previews", mMapPreviews);
-        //pass the mobile map package title
-        mapChooserIntent.putExtra("MMPk_title", mMMPkTitle);
-        //start MapChooserActivity to determine user's chosen map number
-        startActivityForResult(mapChooserIntent, MAP_CHOSEN_RESULT);
-        return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (data != null) {
-            //get the map number chosen in MapChooserActivity and load that map
-            int mapNum = data.getIntExtra("map_num", -1);
-            loadMap(mapNum);
-            //dismiss any callout boxes
-            if (mCallout != null) {
-                mCallout.dismiss();
-            }
-            //clear any existing graphics
-            mMarkerGraphicsOverlay.getGraphics().clear();
-            mRouteGraphicsOverlay.getGraphics().clear();
-        }
-        super.onActivityResult(requestCode, resultCode, data);
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-        mMapView.pause();
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        mMapView.resume();
-    }
-
-    /**
-     * Builds the path to the mobile map package on the device
-     * @return the assembled path
-     */
-    private String buildMMPkPath() {
-        // get sdcard resource name
-        File extStorDir = Environment.getExternalStorageDirectory();
-        // get the directory
-        String extSDCardDirName =
-                this.getResources().getString(R.string.config_data_sdcard_offline_dir);
-        // get mobile map package filename
-        String filename = this.getString(R.string.config_mmpk_name);
-        // create the full path to the mobile map package file
-        return extStorDir.getAbsolutePath()
-                + File.separator
-                + extSDCardDirName
-                + File.separator
-                + filename
-                + ".mmpk";
-    }
-
-    /**
-     * Handles read/write external storage permissions (for API 23+) and loads mobile map package
-     * @param path to location of mobile map package on device
-     */
-    private void loadMobileMapPackage(String path) {
-        //for API level 23+ request permission at runtime
-        if (ContextCompat.checkSelfPermission(getApplicationContext(),
-                reqPermission[0]) != PackageManager.PERMISSION_GRANTED) {
-            //request permission
-            int requestCode = 2;
-            ActivityCompat.requestPermissions(
-                    MobileMapViewActivity.this, reqPermission, requestCode);
-        }
-        //create the mobile map package
-        mMobileMapPackage = new MobileMapPackage(path);
-        //load the mobile map package asynchronously
-        mMobileMapPackage.loadAsync();
-        //add done listener which will load when package has maps
-        mMobileMapPackage.addDoneLoadingListener(new Runnable() {
-            @Override
-            public void run() {
-                //check load status and that the mobile map package has maps
-                if (mMobileMapPackage.getLoadStatus() == LoadStatus.LOADED &&
-                        mMobileMapPackage.getMaps().size() > 0) {
-                    mLocatorTask = mMobileMapPackage.getLocatorTask();
-                    //default to display of first map in package
-                    loadMap(0);
-                    loadMapPreviews();
-                } else {
-                    //log an issue if the mobile map package fails to load
-                    Log.e(TAG, mMobileMapPackage.getLoadError().getMessage());
-                }
-            }
-        });
-    }
-
-    /**
-     * Loads map from the mobile map package for a given index
-     * @param mapNum index of map in mobile map package
-     */
-    private void loadMap(int mapNum) {
-        ArcGISMap map = mMobileMapPackage.getMaps().get(mapNum);
-        //if map contains transport network setup route task
-        if (map.getTransportationNetworks().size() > 0) {
-            setupRouteTask(map);
+    //create the mobile map package
+    mMobileMapPackage = new MobileMapPackage(path);
+    //load the mobile map package asynchronously
+    mMobileMapPackage.loadAsync();
+    //add done listener which will load when package has maps
+    mMobileMapPackage.addDoneLoadingListener(new Runnable() {
+      @Override
+      public void run() {
+        //check load status and that the mobile map package has maps
+        if (mMobileMapPackage.getLoadStatus() == LoadStatus.LOADED &&
+            mMobileMapPackage.getMaps().size() > 0) {
+          mLocatorTask = mMobileMapPackage.getLocatorTask();
+          //default to display of first map in package
+          loadMap(0);
+          loadMapPreviews();
         } else {
-            //only allow routing on map with transport networks
-            mRouteTask = null;
+          //log an issue if the mobile map package fails to load
+          Log.e(TAG, mMobileMapPackage.getLoadError().getMessage());
         }
-            mMapView.setMap(map);
-    }
+      }
+    });
+  }
 
-    /**
-     * generates and populates the mapPreview models from information in the mobile map package
-     */
-    private void loadMapPreviews() {
-        //set mobile map package title
-        mMMPkTitle = mMobileMapPackage.getItem().getTitle();
-        //for each map in the mobile map package, pull out relevant thumbnail information
-        for (int i = 0; i < mMobileMapPackage.getMaps().size(); i++) {
-            ArcGISMap currMap = mMobileMapPackage.getMaps().get(i);
-            final MapPreview mapPreview = new MapPreview();
-            //set map number
-            mapPreview.setMapNum(i);
-            //set map title. If null use the index of the list of maps to name each map Map #
-            if (currMap.getItem() != null && currMap.getItem().getTitle() != null) {
-                mapPreview.setTitle(currMap.getItem().getTitle());
-            } else {
-                mapPreview.setTitle("Map " + i);
+  /**
+   * Loads map from the mobile map package for a given index
+   *
+   * @param mapNum index of map in mobile map package
+   */
+  private void loadMap(int mapNum) {
+    ArcGISMap map = mMobileMapPackage.getMaps().get(mapNum);
+    //if map contains transport network setup route task
+    if (map.getTransportationNetworks().size() > 0) {
+      setupRouteTask(map);
+    } else {
+      //only allow routing on map with transport networks
+      mRouteTask = null;
+    }
+    mMapView.setMap(map);
+  }
+
+  /**
+   * generates and populates the mapPreview models from information in the mobile map package
+   */
+  private void loadMapPreviews() {
+    //set mobile map package title
+    mMMPkTitle = mMobileMapPackage.getItem().getTitle();
+    //for each map in the mobile map package, pull out relevant thumbnail information
+    for (int i = 0; i < mMobileMapPackage.getMaps().size(); i++) {
+      ArcGISMap currMap = mMobileMapPackage.getMaps().get(i);
+      final MapPreview mapPreview = new MapPreview();
+      //set map number
+      mapPreview.setMapNum(i);
+      //set map title. If null use the index of the list of maps to name each map Map #
+      if (currMap.getItem() != null && currMap.getItem().getTitle() != null) {
+        mapPreview.setTitle(currMap.getItem().getTitle());
+      } else {
+        mapPreview.setTitle("Map " + i);
+      }
+      //set map description. If null use package description instead
+      if (currMap.getItem() != null && currMap.getItem().getDescription() != null) {
+        mapPreview.setDesc(currMap.getItem().getDescription());
+      } else {
+        mapPreview.setDesc(mMobileMapPackage.getItem().getDescription());
+      }
+      //check if map has transport data
+      if (currMap.getTransportationNetworks().size() > 0) {
+        mapPreview.setTransportNetwork(true);
+      }
+      //check if map has geocoding data
+      if (mMobileMapPackage.getLocatorTask() != null) {
+        mapPreview.setGeocoding(true);
+      }
+      //set map preview thumbnail
+      final ListenableFuture<byte[]> thumbnailAsync;
+      if (currMap.getItem() != null && currMap.getItem().fetchThumbnailAsync() != null) {
+        thumbnailAsync = currMap.getItem().fetchThumbnailAsync();
+      } else {
+        thumbnailAsync = mMobileMapPackage.getItem().fetchThumbnailAsync();
+      }
+      thumbnailAsync.addDoneListener(new Runnable() {
+        @Override
+        public void run() {
+          if (thumbnailAsync.isDone()) {
+            try {
+              mapPreview.setThumbnailByteStream(thumbnailAsync.get());
+              mMapPreviews.add(mapPreview);
+            } catch (InterruptedException | ExecutionException e) {
+              e.printStackTrace();
             }
-            //set map description. If null use package description instead
-            if (currMap.getItem() != null && currMap.getItem().getDescription() != null) {
-                mapPreview.setDesc(currMap.getItem().getDescription());
-            } else {
-                mapPreview.setDesc(mMobileMapPackage.getItem().getDescription());
-            }
-            //check if map has transport data
-            if (currMap.getTransportationNetworks().size() > 0) {
-                mapPreview.setTransportNetwork(true);
-            }
-            //check if map has geocoding data
-            if (mMobileMapPackage.getLocatorTask() != null) {
-                mapPreview.setGeocoding(true);
-            }
-            //set map preview thumbnail
-            final ListenableFuture<byte[]> thumbnailAsync;
-            if (currMap.getItem() != null && currMap.getItem().fetchThumbnailAsync() != null) {
-                thumbnailAsync = currMap.getItem().fetchThumbnailAsync();
-            } else {
-                thumbnailAsync = mMobileMapPackage.getItem().fetchThumbnailAsync();
-            }
-            thumbnailAsync.addDoneListener(new Runnable() {
-                @Override
-                public void run() {
-                    if (thumbnailAsync.isDone()) {
-                        try {
-                            mapPreview.setThumbnailByteStream(thumbnailAsync.get());
-                            mMapPreviews.add(mapPreview);
-                        } catch (InterruptedException | ExecutionException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                }
-            });
+          }
         }
+      });
     }
+  }
 
-    /**
-     * Defines a graphic symbol which represents geocoded locations
-     * @return the stop graphic
-     */
-    private SimpleMarkerSymbol simpleSymbolForStopGraphic() {
-        SimpleMarkerSymbol simpleMarkerSymbol = new SimpleMarkerSymbol(
-                SimpleMarkerSymbol.Style.CIRCLE, Color.RED, 12);
-        simpleMarkerSymbol.setLeaderOffsetY(5);
-        return simpleMarkerSymbol;
+  /**
+   * Defines a graphic symbol which represents geocoded locations
+   *
+   * @return the stop graphic
+   */
+  private SimpleMarkerSymbol simpleSymbolForStopGraphic() {
+    SimpleMarkerSymbol simpleMarkerSymbol = new SimpleMarkerSymbol(
+        SimpleMarkerSymbol.Style.CIRCLE, Color.RED, 12);
+    simpleMarkerSymbol.setLeaderOffsetY(5);
+    return simpleMarkerSymbol;
+  }
+
+  /**
+   * Defines a composite symbol consisting of the SimpleMarkerSymbol and a text symbol
+   * representing the index of a stop in a route
+   *
+   * @param simpleMarkerSymbol a SimpleMarkerSymbol which represents the background of the
+   *                           composite symbol
+   * @param index              number which corresponds to the stop number in a route
+   * @return the composite symbol
+   */
+  private CompositeSymbol compositeSymbolForStopGraphic(
+      SimpleMarkerSymbol simpleMarkerSymbol, Integer index) {
+    TextSymbol textSymbol = new TextSymbol(12, index.toString(), Color.BLACK,
+        TextSymbol.HorizontalAlignment.CENTER, TextSymbol.VerticalAlignment.MIDDLE);
+    List<Symbol> compositeSymbolList = new ArrayList<>();
+    compositeSymbolList.addAll(Arrays.asList(simpleMarkerSymbol, textSymbol));
+    return new CompositeSymbol(compositeSymbolList);
+  }
+
+  /**
+   * For a given point, returns a graphic
+   *
+   * @param point           map point
+   * @param isIndexRequired true if used in a route
+   * @param index           stop number in a route
+   * @return a Graphic at point with either a simple or composite symbol
+   */
+  private Graphic graphicForPoint(Point point, boolean isIndexRequired, Integer index) {
+    //make symbol composite if an index is required
+    Symbol symbol;
+    if (isIndexRequired && index != null) {
+      symbol = compositeSymbolForStopGraphic(simpleSymbolForStopGraphic(), index);
+    } else {
+      symbol = simpleSymbolForStopGraphic();
     }
+    return new Graphic(point, symbol);
+  }
 
-    /**
-     *  Defines a composite symbol consisting of the SimpleMarkerSymbol and a text symbol
-     *  representing the index of a stop in a route
-     * @param simpleMarkerSymbol a SimpleMarkerSymbol which represents the background of the
-     *                           composite symbol
-     * @param index number which corresponds to the stop number in a route
-     * @return the composite symbol
-     */
-    private CompositeSymbol compositeSymbolForStopGraphic(
-            SimpleMarkerSymbol simpleMarkerSymbol, Integer index) {
-        TextSymbol textSymbol = new TextSymbol(12, index.toString(), Color.BLACK,
-                TextSymbol.HorizontalAlignment.CENTER, TextSymbol.VerticalAlignment.MIDDLE);
-        List<Symbol> compositeSymbolList = new ArrayList<>();
-        compositeSymbolList.addAll(Arrays.asList(simpleMarkerSymbol, textSymbol));
-        return new CompositeSymbol(compositeSymbolList);
-    }
+  /**
+   * Shows the callout for a given graphic
+   *
+   * @param graphic     the graphic selected by the user
+   * @param tapLocation the location selected at a Point
+   */
+  private void showCalloutForGraphic(Graphic graphic, Point tapLocation) {
+    TextView calloutTextView = (TextView) getLayoutInflater().inflate(callout, null);
+    calloutTextView.setText(graphic.getAttributes().get("Match_addr").toString());
+    mCallout = mMapView.getCallout();
+    mCallout.setLocation(tapLocation);
+    mCallout.setContent(calloutTextView);
+    mCallout.show();
+  }
 
-    /**
-     * For a given point, returns a graphic
-     * @param point map point
-     * @param isIndexRequired true if used in a route
-     * @param index stop number in a route
-     * @return a Graphic at point with either a simple or composite symbol
-     */
-    private Graphic graphicForPoint(Point point, boolean isIndexRequired, Integer index) {
-        //make symbol composite if an index is required
-        Symbol symbol;
-        if (isIndexRequired && index != null) {
-            symbol = compositeSymbolForStopGraphic(simpleSymbolForStopGraphic(), index);
-        } else {
-            symbol = simpleSymbolForStopGraphic();
-        }
-        return new Graphic(point, symbol);
-    }
-
-    /**
-     * Shows the callout for a given graphic
-     * @param graphic the graphic selected by the user
-     * @param tapLocation the location selected at a Point
-     */
-    private void showCalloutForGraphic(Graphic graphic, Point tapLocation) {
-        TextView calloutTextView = (TextView) getLayoutInflater().inflate(callout, null);
-        calloutTextView.setText(graphic.getAttributes().get("Match_addr").toString());
-        mCallout = mMapView.getCallout();
-        mCallout.setLocation(tapLocation);
-        mCallout.setContent(calloutTextView);
-        mCallout.show();
-    }
-
-    /**
-     * Adds a graphic at a given point to GraphicsOverlay in the MapView. If RouteTask is not null
-     * get index for stop symbol. If identifyGraphicsOverlayAsync returns no graphics, call
-     * reverseGeocode and route, otherwise just call reverseGeocode.
-     * @param screenPoint point on the screen which the user selected
-     * @param mapPoint point on the map which the user selected
-     */
-    private void geoView(android.graphics.Point screenPoint, final Point mapPoint) {
-        if (mRouteTask != null || mLocatorTask != null) {
-            if (mRouteTask == null) {
-                mMarkerGraphicsOverlay.getGraphics().clear();
+  /**
+   * Adds a graphic at a given point to GraphicsOverlay in the MapView. If RouteTask is not null
+   * get index for stop symbol. If identifyGraphicsOverlayAsync returns no graphics, call
+   * reverseGeocode and route, otherwise just call reverseGeocode.
+   *
+   * @param screenPoint point on the screen which the user selected
+   * @param mapPoint    point on the map which the user selected
+   */
+  private void geoView(android.graphics.Point screenPoint, final Point mapPoint) {
+    if (mRouteTask != null || mLocatorTask != null) {
+      if (mRouteTask == null) {
+        mMarkerGraphicsOverlay.getGraphics().clear();
+      }
+      final ListenableFuture<IdentifyGraphicsOverlayResult> result =
+          mMapView.identifyGraphicsOverlayAsync(
+              mMarkerGraphicsOverlay, screenPoint, 12, false);
+      result.addDoneListener(new Runnable() {
+        public void run() {
+          try {
+            Graphic graphic;
+            if (result.isDone() && result.get().getGraphics().size() == 0) {
+              if (mRouteTask != null) {
+                int index = mMarkerGraphicsOverlay.getGraphics().size() + 1;
+                graphic = graphicForPoint(mapPoint, true, index);
+              } else {
+                graphic = graphicForPoint(mapPoint, false, null);
+              }
+              mMarkerGraphicsOverlay.getGraphics().add(graphic);
+              reverseGeocode(mapPoint, graphic);
+              route();
+            } else if (result.isDone()) {
+              //if graphic exists within screenPoint tolerance, show callout
+              //information of clicked graphic
+              reverseGeocode(mapPoint, result.get().getGraphics().get(0));
             }
-            final ListenableFuture<IdentifyGraphicsOverlayResult> result =
-                    mMapView.identifyGraphicsOverlayAsync(
-                            mMarkerGraphicsOverlay, screenPoint, 12, false);
-            result.addDoneListener(new Runnable() {
-                public void run() {
-                    try {
-                        Graphic graphic;
-                        if (result.isDone() && result.get().getGraphics().size() == 0) {
-                            if (mRouteTask != null) {
-                                int index = mMarkerGraphicsOverlay.getGraphics().size() + 1;
-                                graphic = graphicForPoint(mapPoint, true, index);
-                            } else {
-                                graphic = graphicForPoint(mapPoint, false, null);
-                            }
-                            mMarkerGraphicsOverlay.getGraphics().add(graphic);
-                            reverseGeocode(mapPoint, graphic);
-                            route();
-                        } else if (result.isDone()){
-                            //if graphic exists within screenPoint tolerance, show callout
-                            //information of clicked graphic
-                            reverseGeocode(mapPoint, result.get().getGraphics().get(0));
-                        }
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-            });
-        }
-    }
-
-    /**
-     *  Calls reverseGeocode on a Locator Task and, if there is a result, passes the result to a
-     *  Callout method
-     * @param point user generated map point
-     * @param graphic used for marking the point on which the user touched
-     */
-    private void reverseGeocode(final Point point, final Graphic graphic) {
-        if (mLocatorTask != null) {
-            final ListenableFuture<List<GeocodeResult>> results =
-                    mLocatorTask.reverseGeocodeAsync(point, mReverseGeocodeParameters);
-            results.addDoneListener(new Runnable() {
-                public void run() {
-                    try {
-                        List<GeocodeResult> geocodeResult = results.get();
-                        if (geocodeResult.size() > 0) {
-                            graphic.getAttributes().put(
-                                    "Match_addr", geocodeResult.get(0).getLabel());
-                            showCalloutForGraphic(graphic, point);
-                        } else {
-                            //no result was found
-                            mMapView.getCallout().dismiss();
-                        }
-                    } catch (InterruptedException | ExecutionException e) {
-                        e.printStackTrace();
-                    }
-                }
-            });
-        }
-    }
-
-    /**
-     * Given an ArcGISMap with a transport network, create a new RouteTask
-     * @param map a map with a transport network
-     */
-    private void setupRouteTask(ArcGISMap map) {
-        mRouteTask = new RouteTask(this, map.getTransportationNetworks().get(0));
-        try {
-            getDefaultParameters();
-        } catch (Exception e) {
+          } catch (Exception e) {
             e.printStackTrace();
+          }
         }
+      });
     }
+  }
 
-    /**
-     *  Get default RouteTask parameters
-     */
-    private void getDefaultParameters() {
-        try {
-            mRouteParameters = mRouteTask.createDefaultParametersAsync().get();
-        } catch (Exception e) {
+  /**
+   * Calls reverseGeocode on a Locator Task and, if there is a result, passes the result to a
+   * Callout method
+   *
+   * @param point   user generated map point
+   * @param graphic used for marking the point on which the user touched
+   */
+  private void reverseGeocode(final Point point, final Graphic graphic) {
+    if (mLocatorTask != null) {
+      final ListenableFuture<List<GeocodeResult>> results =
+          mLocatorTask.reverseGeocodeAsync(point, mReverseGeocodeParameters);
+      results.addDoneListener(new Runnable() {
+        public void run() {
+          try {
+            List<GeocodeResult> geocodeResult = results.get();
+            if (geocodeResult.size() > 0) {
+              graphic.getAttributes().put(
+                  "Match_addr", geocodeResult.get(0).getLabel());
+              showCalloutForGraphic(graphic, point);
+            } else {
+              //no result was found
+              mMapView.getCallout().dismiss();
+            }
+          } catch (InterruptedException | ExecutionException e) {
             e.printStackTrace();
+          }
         }
+      });
     }
+  }
 
-    /**
-     * Uses the last two markers drawn to calculate a route between them
-     */
-    private void route() {
-        if (mMarkerGraphicsOverlay.getGraphics().size() > 1 && mRouteParameters != null) {
-            //create stops for last and second to last graphic
-            int size = mMarkerGraphicsOverlay.getGraphics().size();
-            List<Graphic> graphics = new ArrayList<>();
-            Graphic lastGraphic = mMarkerGraphicsOverlay.getGraphics().get(size - 1);
-            graphics.add(lastGraphic);
-            Graphic secondLastGraphic = mMarkerGraphicsOverlay.getGraphics().get(size - 2);
-            graphics.add(secondLastGraphic);
-            List stops = stopsForGraphics(graphics);
-            //add stops to the parameters
-            mRouteParameters.getStops().clear();
-            mRouteParameters.getStops().addAll(stops);
-            //route
-            final ListenableFuture<RouteResult> routeResult =
-                    mRouteTask.solveRouteAsync(mRouteParameters);
-            routeResult.addDoneListener(new Runnable() {
-                public void run() {
-                    try {
-                        Route route = routeResult.get().getRoutes().get(0);
-                        Graphic routeGraphic = new Graphic(route.getRouteGeometry(),
-                                new SimpleLineSymbol(
-                                        SimpleLineSymbol.Style.SOLID, Color.BLUE, 5.0f));
-                        mRouteGraphicsOverlay.getGraphics().add(routeGraphic);
-                    } catch (InterruptedException | ExecutionException e) {
-                        e.printStackTrace();
-                        //if routing is interrupted, remove last graphic
-                        Log.e(TAG, "Routing interrupted. Removing last graphic");
-                        mMarkerGraphicsOverlay.getGraphics().remove(
-                                mMarkerGraphicsOverlay.getGraphics().size() - 1);
-                    }
-                }
-            });
-        }
+  /**
+   * Given an ArcGISMap with a transport network, create a new RouteTask
+   *
+   * @param map a map with a transport network
+   */
+  private void setupRouteTask(ArcGISMap map) {
+    mRouteTask = new RouteTask(this, map.getTransportationNetworks().get(0));
+    try {
+      getDefaultParameters();
+    } catch (Exception e) {
+      e.printStackTrace();
     }
+  }
 
-    /**
-     * Converts a given list of graphics into a list of stops
-     * @param graphics
-     * @return a list of stops
-     */
-    private List stopsForGraphics(List<Graphic> graphics) {
-        List<Stop> stops = new ArrayList<>();
-        for (Graphic graphic : graphics) {
-            Stop stop = new Stop((Point)graphic.getGeometry());
-            stops.add(stop);
-        }
-        return stops;
+  /**
+   * Get default RouteTask parameters
+   */
+  private void getDefaultParameters() {
+    try {
+      mRouteParameters = mRouteTask.createDefaultParametersAsync().get();
+    } catch (Exception e) {
+      e.printStackTrace();
     }
+  }
+
+  /**
+   * Uses the last two markers drawn to calculate a route between them
+   */
+  private void route() {
+    if (mMarkerGraphicsOverlay.getGraphics().size() > 1 && mRouteParameters != null) {
+      //create stops for last and second to last graphic
+      int size = mMarkerGraphicsOverlay.getGraphics().size();
+      List<Graphic> graphics = new ArrayList<>();
+      Graphic lastGraphic = mMarkerGraphicsOverlay.getGraphics().get(size - 1);
+      graphics.add(lastGraphic);
+      Graphic secondLastGraphic = mMarkerGraphicsOverlay.getGraphics().get(size - 2);
+      graphics.add(secondLastGraphic);
+      List stops = stopsForGraphics(graphics);
+      //add stops to the parameters
+      mRouteParameters.getStops().clear();
+      mRouteParameters.getStops().addAll(stops);
+      //route
+      final ListenableFuture<RouteResult> routeResult =
+          mRouteTask.solveRouteAsync(mRouteParameters);
+      routeResult.addDoneListener(new Runnable() {
+        public void run() {
+          try {
+            Route route = routeResult.get().getRoutes().get(0);
+            Graphic routeGraphic = new Graphic(route.getRouteGeometry(),
+                new SimpleLineSymbol(
+                    SimpleLineSymbol.Style.SOLID, Color.BLUE, 5.0f));
+            mRouteGraphicsOverlay.getGraphics().add(routeGraphic);
+          } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            //if routing is interrupted, remove last graphic
+            Log.e(TAG, "Routing interrupted. Removing last graphic");
+            mMarkerGraphicsOverlay.getGraphics().remove(
+                mMarkerGraphicsOverlay.getGraphics().size() - 1);
+          }
+        }
+      });
+    }
+  }
+
+  /**
+   * Converts a given list of graphics into a list of stops
+   *
+   * @param graphics
+   * @return a list of stops
+   */
+  private List stopsForGraphics(List<Graphic> graphics) {
+    List<Stop> stops = new ArrayList<>();
+    for (Graphic graphic : graphics) {
+      Stop stop = new Stop((Point) graphic.getGeometry());
+      stops.add(stop);
+    }
+    return stops;
+  }
 }

--- a/java/offline-geocode/src/main/AndroidManifest.xml
+++ b/java/offline-geocode/src/main/AndroidManifest.xml
@@ -12,8 +12,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme"
-        android:configChanges="orientation|screenSize|uiMode">
+        android:theme="@style/AppTheme">
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/java/offline-geocode/src/main/java/com/esri/arcgisruntime/sample/offlinegeocode/MainActivity.java
+++ b/java/offline-geocode/src/main/java/com/esri/arcgisruntime/sample/offlinegeocode/MainActivity.java
@@ -19,6 +19,7 @@ package com.esri.arcgisruntime.sample.offlinegeocode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+
 import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
@@ -68,523 +69,530 @@ import com.esri.arcgisruntime.tasks.geocode.ReverseGeocodeParameters;
 
 public class MainActivity extends AppCompatActivity {
 
-    private static final String TAG = "OfflineActivity";
-    private final String extern = Environment.getExternalStorageDirectory().getPath();
-    final int requestCode = 2;
-    final String[] permission = new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE};
-    private GraphicsOverlay graphicsOverlay;
-    private GeocodeParameters mGeocodeParameters;
-    private PictureMarkerSymbol mPinSourceSymbol;
-    ArcGISMap mMap;
-    ArcGISTiledLayer tiledLayer;
-    private MapView mMapView;
-    private LocatorTask mLocatorTask;
-    private ReverseGeocodeParameters mReverseGeocodeParameters;
-    private Callout mCallout;
-    private SearchView mSearchview;
-    private String mGraphicPointAddress;
-    private Point mGraphicPoint;
-    private GeocodeResult mGeocodedLocation;
-    Spinner mSpinner;
-    private boolean isPinSelected;
-    private TextView mCalloutContent;
+  private static final String TAG = MainActivity.class.getSimpleName();
+  final int requestCode = 2;
+  final String[] permission = new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE };
+  private final String extern = Environment.getExternalStorageDirectory().getPath();
+  ArcGISMap mMap;
+  ArcGISTiledLayer tiledLayer;
+  Spinner mSpinner;
+  private GraphicsOverlay graphicsOverlay;
+  private GeocodeParameters mGeocodeParameters;
+  private PictureMarkerSymbol mPinSourceSymbol;
+  private MapView mMapView;
+  private LocatorTask mLocatorTask;
+  private ReverseGeocodeParameters mReverseGeocodeParameters;
+  private Callout mCallout;
+  private SearchView mSearchview;
+  private String mGraphicPointAddress;
+  private Point mGraphicPoint;
+  private GeocodeResult mGeocodedLocation;
+  private boolean isPinSelected;
+  private TextView mCalloutContent;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // Check permissions to see if failure may be due to lack of permissions.
-        boolean permissionCheck = ContextCompat.checkSelfPermission(MainActivity.this, permission[0]) ==
-                PackageManager.PERMISSION_GRANTED;
+    // Check permissions to see if failure may be due to lack of permissions.
+    boolean permissionCheck = ContextCompat.checkSelfPermission(MainActivity.this, permission[0]) ==
+        PackageManager.PERMISSION_GRANTED;
 
-        if (!permissionCheck) {
-            // If permissions are not already granted, request permission from the user.
-            ActivityCompat.requestPermissions(MainActivity.this, permission, requestCode);
-        } else { // if permission was already granted, set up offline map and geocoding, reverse geocoding and LocatorTask
-            setUpOfflineMapGeocoding();
-            setSearchView();
-        }
-        mMapView.setOnTouchListener(new MapTouchListener(getApplicationContext(), mMapView));
+    if (!permissionCheck) {
+      // If permissions are not already granted, request permission from the user.
+      ActivityCompat.requestPermissions(MainActivity.this, permission, requestCode);
+    } else { // if permission was already granted, set up offline map and geocoding, reverse geocoding and LocatorTask
+      setUpOfflineMapGeocoding();
+      setSearchView();
     }
+    mMapView.setOnTouchListener(new MapTouchListener(getApplicationContext(), mMapView));
+  }
 
-    private void setSearchView() {
+  private void setSearchView() {
 
-
-        mSearchview = (SearchView) findViewById(R.id.searchView1);
-        mSearchview.setIconifiedByDefault(true);
-        mSearchview.setQueryHint(getResources().getString(R.string.search_hint));
-        mSearchview.setOnQueryTextListener(new OnQueryTextListener() {
-            @Override
-            public boolean onQueryTextSubmit(String query) {
-                hideKeyboard();
-                geoCodeTypedAddress(query);
-                mSearchview.clearFocus();
-                return true;
-            }
-
-            @Override
-            public boolean onQueryTextChange(String newText) {
-                return false;
-            }
-        });
-
-        mSpinner = (Spinner) findViewById(R.id.spinner);
-        // Create an ArrayAdapter using the string array and a default spinner layout
-        final ArrayAdapter<CharSequence> adapter = new ArrayAdapter<CharSequence>(this, android.R.layout.simple_spinner_dropdown_item) {
-            @Override
-            public View getView(int position, View convertView, ViewGroup parent) {
-
-                View v = super.getView(position, convertView, parent);
-                if (position == getCount()) {
-                    mSearchview.clearFocus();
-                }
-
-                return v;
-            }
-
-            @Override
-            public int getCount() {
-                return super.getCount() - 1; // you dont display last item. It is used as hint.
-            }
-
-        };
-
-        // Specify the layout to use when the list of choices appears
-        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        adapter.addAll(getResources().getStringArray(R.array.suggestion_items));
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            // set vertical offset to spinner dropdown for API less than 21
-            mSpinner.setDropDownVerticalOffset(80);
-        }
-        // Apply the adapter to the spinner
-        mSpinner.setAdapter(adapter);
-        mSpinner.setSelection(adapter.getCount());
-
-
-        mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                if (position == adapter.getCount()) {
-                    mSearchview.clearFocus();
-                } else {
-                    hideKeyboard();
-                    mSearchview.setQuery(getResources().getStringArray(R.array.suggestion_items)[position], false);
-                    geoCodeTypedAddress(getResources().getStringArray(R.array.suggestion_items)[position]);
-                    mSearchview.setIconified(false);
-                    mSearchview.clearFocus();
-                }
-            }
-
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-            }
-        });
-
-    }
-
-    private void setUpOfflineMapGeocoding() {
-        // create a basemap from a local tile package
-        TileCache tileCache = new TileCache(extern + getResources().getString(R.string.sandiego_tpk));
-        tiledLayer = new ArcGISTiledLayer(tileCache);
-        Basemap basemap = new Basemap(tiledLayer);
-
-        // create ArcGISMap with imagery basemap
-        mMap = new ArcGISMap(basemap);
-
-        mMapView.setMap(mMap);
-
-        mMap.addDoneLoadingListener(new Runnable() {
-            @Override
-            public void run() {
-                Point p = new Point(-117.162040, 32.718260, SpatialReference.create(4326));
-                Viewpoint vp = new Viewpoint(p, 10000);
-                mMapView.setViewpointAsync(vp, 3);
-            }
-        });
-
-
-        // add a graphics overlay
-        graphicsOverlay = new GraphicsOverlay();
-        graphicsOverlay.setSelectionColor(Color.CYAN);
-        mMapView.getGraphicsOverlays().add(graphicsOverlay);
-
-
-        mGeocodeParameters = new GeocodeParameters();
-        mGeocodeParameters.getResultAttributeNames().add("*");
-        mGeocodeParameters.setMaxResults(1);
-
-        //[DocRef: Name=Picture Marker Symbol Drawable-android, Category=Fundamentals, Topic=Symbols and Renderers]
-        //Create a picture marker symbol from an app resource
-        BitmapDrawable startDrawable = (BitmapDrawable) ContextCompat.getDrawable(this, R.drawable.pin);
-        mPinSourceSymbol = new PictureMarkerSymbol(startDrawable);
-        mPinSourceSymbol.setHeight(90);
-        mPinSourceSymbol.setWidth(20);
-        mPinSourceSymbol.loadAsync();
-        mPinSourceSymbol.setLeaderOffsetY(45);
-        mPinSourceSymbol.setOffsetY(-48);
-
-        mReverseGeocodeParameters = new ReverseGeocodeParameters();
-        mReverseGeocodeParameters.getResultAttributeNames().add("*");
-        mReverseGeocodeParameters.setOutputSpatialReference(mMap.getSpatialReference());
-        mReverseGeocodeParameters.setMaxResults(1);
-
-        mLocatorTask = new LocatorTask(extern + getResources().getString(R.string.sandiego_loc));
-
-        mCalloutContent = new TextView(getApplicationContext());
-        mCalloutContent.setTextColor(Color.BLACK);
-        mCalloutContent.setTextIsSelectable(true);
-    }
-
-    /**
-     * Geocode an address typed in by user
-     *
-     * @param address
-     */
-    private void geoCodeTypedAddress(final String address) {
-        // Null out any previously located result
-        mGeocodedLocation = null;
-
-        // Execute async task to find the address
-        mLocatorTask.addDoneLoadingListener(new Runnable() {
-            @Override
-            public void run() {
-                if (mLocatorTask.getLoadStatus() == LoadStatus.LOADED) {
-                    // Call geocodeAsync passing in an address
-                    final ListenableFuture<List<GeocodeResult>> geocodeFuture = mLocatorTask.geocodeAsync(address,
-                            mGeocodeParameters);
-                    geocodeFuture.addDoneListener(new Runnable() {
-                        @Override
-                        public void run() {
-                            try {
-                                // Get the results of the async operation
-                                List<GeocodeResult> geocodeResults = geocodeFuture.get();
-
-                                if (geocodeResults.size() > 0) {
-                                    // Use the first result - for example
-                                    // display on the map
-                                    mGeocodedLocation = geocodeResults.get(0);
-                                    displaySearchResult(mGeocodedLocation.getDisplayLocation(), mGeocodedLocation.getLabel());
-
-                                } else {
-                                    Toast.makeText(getApplicationContext(),
-                                            getString(R.string.location_not_foud) + address,
-                                            Toast.LENGTH_LONG).show();
-                                }
-
-                            } catch (InterruptedException | ExecutionException e) {
-                                // Deal with exception...
-                                e.printStackTrace();
-                                Toast.makeText(getApplicationContext(),
-                                        getString(R.string.geo_locate_error),
-                                        Toast.LENGTH_LONG).show();
-
-                            }
-                            // Done processing and can remove this listener.
-                            geocodeFuture.removeDoneListener(this);
-                        }
-                    });
-
-                } else {
-                    Log.i(TAG, "Trying to reload locator task");
-                    mLocatorTask.retryLoadAsync();
-                }
-            }
-        });
-        mLocatorTask.loadAsync();
-    }
-
-    /**
-     * Hides soft keyboard
-     */
-    private void hideKeyboard() {
+    mSearchview = (SearchView) findViewById(R.id.searchView1);
+    mSearchview.setIconifiedByDefault(true);
+    mSearchview.setQueryHint(getResources().getString(R.string.search_hint));
+    mSearchview.setOnQueryTextListener(new OnQueryTextListener() {
+      @Override
+      public boolean onQueryTextSubmit(String query) {
+        hideKeyboard();
+        geoCodeTypedAddress(query);
         mSearchview.clearFocus();
-        InputMethodManager inputManager = (InputMethodManager) getApplicationContext()
-                .getSystemService(Context.INPUT_METHOD_SERVICE);
-        inputManager.hideSoftInputFromWindow(mSearchview.getWindowToken(), 0);
-    }
+        return true;
+      }
 
-    private void displaySearchResult(Point resultPoint, String address) {
+      @Override
+      public boolean onQueryTextChange(String newText) {
+        return false;
+      }
+    });
 
+    mSpinner = (Spinner) findViewById(R.id.spinner);
+    // Create an ArrayAdapter using the string array and a default spinner layout
+    final ArrayAdapter<CharSequence> adapter = new ArrayAdapter<CharSequence>(this,
+        android.R.layout.simple_spinner_dropdown_item) {
+      @Override
+      public View getView(int position, View convertView, ViewGroup parent) {
 
-        if (mMapView.getCallout().isShowing()) {
-            mMapView.getCallout().dismiss();
+        View v = super.getView(position, convertView, parent);
+        if (position == getCount()) {
+          mSearchview.clearFocus();
         }
-        //remove any previous graphics/search results
-        //mMapView.getGraphicsOverlays().clear();
-        graphicsOverlay.getGraphics().clear();
-        // create graphic object for resulting location
-        Graphic resultLocGraphic = new Graphic(resultPoint, mPinSourceSymbol);
-        // add graphic to location layer
-        graphicsOverlay.getGraphics().add(resultLocGraphic);
 
-        // Zoom map to geocode result location
-        mMapView.setViewpointAsync(new Viewpoint(resultPoint, 8000), 3);
+        return v;
+      }
 
-        mGraphicPoint = resultPoint;
-        mGraphicPointAddress = address;
+      @Override
+      public int getCount() {
+        return super.getCount() - 1; // you dont display last item. It is used as hint.
+      }
+
+    };
+
+    // Specify the layout to use when the list of choices appears
+    adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+    adapter.addAll(getResources().getStringArray(R.array.suggestion_items));
+
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+      // set vertical offset to spinner dropdown for API less than 21
+      mSpinner.setDropDownVerticalOffset(80);
     }
+    // Apply the adapter to the spinner
+    mSpinner.setAdapter(adapter);
+    mSpinner.setSelection(adapter.getCount());
 
+    mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+      @Override
+      public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+        if (position == adapter.getCount()) {
+          mSearchview.clearFocus();
+        } else {
+          hideKeyboard();
+          mSearchview.setQuery(getResources().getStringArray(R.array.suggestion_items)[position], false);
+          geoCodeTypedAddress(getResources().getStringArray(R.array.suggestion_items)[position]);
+          mSearchview.setIconified(false);
+          mSearchview.clearFocus();
+        }
+      }
+
+      @Override
+      public void onNothingSelected(AdapterView<?> parent) {
+      }
+    });
+
+  }
+
+  private void setUpOfflineMapGeocoding() {
+    // create a basemap from a local tile package
+    TileCache tileCache = new TileCache(extern + getResources().getString(R.string.sandiego_tpk));
+    tiledLayer = new ArcGISTiledLayer(tileCache);
+    Basemap basemap = new Basemap(tiledLayer);
+
+    // create ArcGISMap with imagery basemap
+    mMap = new ArcGISMap(basemap);
+
+    mMapView.setMap(mMap);
+
+    mMap.addDoneLoadingListener(new Runnable() {
+      @Override
+      public void run() {
+        Point p = new Point(-117.162040, 32.718260, SpatialReference.create(4326));
+        Viewpoint vp = new Viewpoint(p, 10000);
+        mMapView.setViewpointAsync(vp, 3);
+      }
+    });
+
+    // add a graphics overlay
+    graphicsOverlay = new GraphicsOverlay();
+    graphicsOverlay.setSelectionColor(Color.CYAN);
+    mMapView.getGraphicsOverlays().add(graphicsOverlay);
+
+    mGeocodeParameters = new GeocodeParameters();
+    mGeocodeParameters.getResultAttributeNames().add("*");
+    mGeocodeParameters.setMaxResults(1);
+
+    //[DocRef: Name=Picture Marker Symbol Drawable-android, Category=Fundamentals, Topic=Symbols and Renderers]
+    //Create a picture marker symbol from an app resource
+    BitmapDrawable startDrawable = (BitmapDrawable) ContextCompat.getDrawable(this, R.drawable.pin);
+    mPinSourceSymbol = new PictureMarkerSymbol(startDrawable);
+    mPinSourceSymbol.setHeight(90);
+    mPinSourceSymbol.setWidth(20);
+    mPinSourceSymbol.loadAsync();
+    mPinSourceSymbol.setLeaderOffsetY(45);
+    mPinSourceSymbol.setOffsetY(-48);
+
+    mReverseGeocodeParameters = new ReverseGeocodeParameters();
+    mReverseGeocodeParameters.getResultAttributeNames().add("*");
+    mReverseGeocodeParameters.setOutputSpatialReference(mMap.getSpatialReference());
+    mReverseGeocodeParameters.setMaxResults(1);
+
+    mLocatorTask = new LocatorTask(extern + getResources().getString(R.string.sandiego_loc));
+
+    mCalloutContent = new TextView(getApplicationContext());
+    mCalloutContent.setTextColor(Color.BLACK);
+    mCalloutContent.setTextIsSelectable(true);
+  }
+
+  /**
+   * Geocode an address typed in by user
+   *
+   * @param address
+   */
+  private void geoCodeTypedAddress(final String address) {
+    // Null out any previously located result
+    mGeocodedLocation = null;
+
+    // Execute async task to find the address
+    mLocatorTask.addDoneLoadingListener(new Runnable() {
+      @Override
+      public void run() {
+        if (mLocatorTask.getLoadStatus() == LoadStatus.LOADED) {
+          // Call geocodeAsync passing in an address
+          final ListenableFuture<List<GeocodeResult>> geocodeFuture = mLocatorTask.geocodeAsync(address,
+              mGeocodeParameters);
+          geocodeFuture.addDoneListener(new Runnable() {
+            @Override
+            public void run() {
+              try {
+                // Get the results of the async operation
+                List<GeocodeResult> geocodeResults = geocodeFuture.get();
+
+                if (geocodeResults.size() > 0) {
+                  // Use the first result - for example
+                  // display on the map
+                  mGeocodedLocation = geocodeResults.get(0);
+                  displaySearchResult(mGeocodedLocation.getDisplayLocation(), mGeocodedLocation.getLabel());
+
+                } else {
+                  Toast.makeText(getApplicationContext(),
+                      getString(R.string.location_not_foud) + address,
+                      Toast.LENGTH_LONG).show();
+                }
+
+              } catch (InterruptedException | ExecutionException e) {
+                // Deal with exception...
+                e.printStackTrace();
+                Toast.makeText(getApplicationContext(),
+                    getString(R.string.geo_locate_error),
+                    Toast.LENGTH_LONG).show();
+
+              }
+              // Done processing and can remove this listener.
+              geocodeFuture.removeDoneListener(this);
+            }
+          });
+
+        } else {
+          Log.i(TAG, "Trying to reload locator task");
+          mLocatorTask.retryLoadAsync();
+        }
+      }
+    });
+    mLocatorTask.loadAsync();
+  }
+
+  /**
+   * Hides soft keyboard
+   */
+  private void hideKeyboard() {
+    mSearchview.clearFocus();
+    InputMethodManager inputManager = (InputMethodManager) getApplicationContext()
+        .getSystemService(Context.INPUT_METHOD_SERVICE);
+    inputManager.hideSoftInputFromWindow(mSearchview.getWindowToken(), 0);
+  }
+
+  private void displaySearchResult(Point resultPoint, String address) {
+
+    if (mMapView.getCallout().isShowing()) {
+      mMapView.getCallout().dismiss();
+    }
+    //remove any previous graphics/search results
+    //mMapView.getGraphicsOverlays().clear();
+    graphicsOverlay.getGraphics().clear();
+    // create graphic object for resulting location
+    Graphic resultLocGraphic = new Graphic(resultPoint, mPinSourceSymbol);
+    // add graphic to location layer
+    graphicsOverlay.getGraphics().add(resultLocGraphic);
+
+    // Zoom map to geocode result location
+    mMapView.setViewpointAsync(new Viewpoint(resultPoint, 8000), 3);
+
+    mGraphicPoint = resultPoint;
+    mGraphicPointAddress = address;
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    // If request is cancelled, the result arrays are empty.
+    if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+      // Location permission was granted. This would have been triggered in response to failing to start the
+      // LocationDisplay, so try starting this again.
+      setUpOfflineMapGeocoding();
+      setSearchView();
+    } else {
+      // If permission was denied, show toast to inform user what was chosen. If LocationDisplay is started again,
+      // request permission UX will be shown again, option should be shown to allow never showing the UX again.
+      // Alternative would be to disable functionality so request is not shown again.
+      Toast.makeText(MainActivity.this, getResources().getString(R.string.storage_permission_denied), Toast
+          .LENGTH_SHORT).show();
+
+    }
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
+
+  private class DragTouchListener extends DefaultMapViewOnTouchListener {
+
+    float dX, dY;
+
+    public DragTouchListener(Context context, MapView mapView) {
+      super(context, mapView);
+    }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        // If request is cancelled, the result arrays are empty.
-        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            // Location permission was granted. This would have been triggered in response to failing to start the
-            // LocationDisplay, so try starting this again.
-            setUpOfflineMapGeocoding();
-            setSearchView();
-        } else {
-            // If permission was denied, show toast to inform user what was chosen. If LocationDisplay is started again,
-            // request permission UX will be shown again, option should be shown to allow never showing the UX again.
-            // Alternative would be to disable functionality so request is not shown again.
-            Toast.makeText(MainActivity.this, getResources().getString(R.string.storage_permission_denied), Toast
-                    .LENGTH_SHORT).show();
+    public boolean onTouch(View view, MotionEvent event) {
 
-        }
-    }
+      switch (event.getAction()) {
 
-    private class DragTouchListener extends DefaultMapViewOnTouchListener {
+        case MotionEvent.ACTION_DOWN:
+          dX = view.getX() - event.getRawX();
+          dY = view.getY() - event.getRawY();
+          break;
 
-        float dX, dY;
-
-        public DragTouchListener(Context context, MapView mapView) {
-            super(context, mapView);
-        }
-
-        @Override
-        public boolean onTouch(View view, MotionEvent event) {
-
-            switch (event.getAction()) {
-
-                case MotionEvent.ACTION_DOWN:
-                    dX = view.getX() - event.getRawX();
-                    dY = view.getY() - event.getRawY();
-                    break;
-
-                case MotionEvent.ACTION_MOVE:
-                    final int pointerIndex = MotionEventCompat.getActionIndex(event);
-                    final float x = MotionEventCompat.getX(event, pointerIndex);
-                    final float y = MotionEventCompat.getY(event, pointerIndex);
-                    android.graphics.Point screenPoint = new android.graphics.Point(Math.round(x), Math.round(y));
-                    final Point singleTapPoint = mMapView.screenToLocation(screenPoint);
-                    final ListenableFuture<List<GeocodeResult>> results = mLocatorTask.reverseGeocodeAsync(singleTapPoint,
-                            mReverseGeocodeParameters);
-                    graphicsOverlay.getGraphics().clear();
-                    Graphic resultLocGraphic = new Graphic(singleTapPoint, mPinSourceSymbol);
-                    resultLocGraphic.setSelected(true);
-                    // add graphic to location layer
-                    graphicsOverlay.getGraphics().add(resultLocGraphic);
-                    // display callout with reverse-geocode result on UI thread
-                    runOnUiThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            try {
-                                List<GeocodeResult> geocodes = results.get();
-                                if (geocodes.size() > 0) {
-                                    // get the top result
-                                    GeocodeResult geocode = geocodes.get(0);
-                                    String detail;
-                                    // attributes from a click-based search
-                                    String street = geocode.getAttributes().get("Street").toString();
-                                    String city = geocode.getAttributes().get("City").toString();
-                                    String state = geocode.getAttributes().get("State").toString();
-                                    String zip = geocode.getAttributes().get("ZIP").toString();
-                                    detail = city + ", " + state + " " + zip;
-
-                                    String address = street + "," + detail;
-                                    mCalloutContent.setText(address);
-                                    // get callout, set content and show
-                                    mCallout = mMapView.getCallout();
-                                    mCallout.setLocation(singleTapPoint);
-                                    mCallout.setContent(mCalloutContent);
-                                    mCallout.show();
-
-                                    mGraphicPoint = singleTapPoint;
-                                    mGraphicPointAddress = address;
-                                }
-
-                            } catch (Exception e) {
-                                e.printStackTrace();
-                            }
-                        }
-                    });
-
-
-                    break;
-                case MotionEvent.ACTION_UP:
-                    if (graphicsOverlay.getGraphics().size() > 0) {
-                        graphicsOverlay.getGraphics().get(0).setSelected(false);
-                        isPinSelected = false;
-                        mMapView.setOnTouchListener(new MapTouchListener(getApplicationContext(), mMapView));
-                    }
-                    break;
-                default:
-                    return false;
-            }
-            return true;
-        }
-    }
-
-    private class MapTouchListener extends DefaultMapViewOnTouchListener {
-
-        public MapTouchListener(Context context, MapView mapView) {
-            super(context, mapView);
-        }
-
-        @Override
-        public void onLongPress(MotionEvent e) {
-            android.graphics.Point screenPoint = new android.graphics.Point(Math.round(e.getX()),
-                    Math.round(e.getY()));
-
-            Point longPressPoint = mMapView.screenToLocation(screenPoint);
-
-            ListenableFuture<List<GeocodeResult>> results = mLocatorTask.reverseGeocodeAsync(longPressPoint,
-                    mReverseGeocodeParameters);
-            results.addDoneListener(new ResultsLoadedListener(results));
-
-        }
-
-
-        @Override
-        public boolean onSingleTapConfirmed(MotionEvent e) {
-
-
-            if (mMapView.getCallout().isShowing()) {
-                mMapView.getCallout().dismiss();
-            }
-            if (graphicsOverlay.getGraphics().size() > 0) {
-                if (graphicsOverlay.getGraphics().get(0).isSelected()) {
-                    isPinSelected = false;
-                    graphicsOverlay.getGraphics().get(0).setSelected(false);
-                }
-            }
-            // get the screen point where user tapped
-            final android.graphics.Point screenPoint = new android.graphics.Point((int) e.getX(), (int) e.getY());
-
-            // identify graphics on the graphics overlay
-            final ListenableFuture<IdentifyGraphicsOverlayResult> identifyGraphic = mMapView.identifyGraphicsOverlayAsync(graphicsOverlay, screenPoint, 1.0, false, 1);
-
-            identifyGraphic.addDoneListener(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        IdentifyGraphicsOverlayResult grOverlayResult = identifyGraphic.get();
-                        // get the list of graphics returned by identify
-                        List<Graphic> graphic = grOverlayResult.getGraphics();
-                        // if identified graphic is not empty, start DragTouchListener
-                        if (!graphic.isEmpty()) {
-
-                            if (!isPinSelected) {
-                                isPinSelected = true;
-                                graphic.get(0).setSelected(true);
-                                Toast.makeText(getApplicationContext(),
-                                        getString(R.string.reverse_geocode_message),
-                                        Toast.LENGTH_SHORT).show();
-                                mMapView.setOnTouchListener(new DragTouchListener(getApplicationContext(), mMapView));
-                            }
-
-                            mCalloutContent.setText(mGraphicPointAddress);
-                            // get callout, set content and show
-                            mCallout = mMapView.getCallout();
-                            mCallout.setContent(mCalloutContent);
-                            mCallout.setLocation(mGraphicPoint);
-                            mCallout.show();
-                        }
-                    } catch (InterruptedException | ExecutionException ie) {
-                        ie.printStackTrace();
-                    }
-
-                }
-            });
-
-            return super.onSingleTapConfirmed(e);
-        }
-    }
-
-    /**
-     * Updates marker and callout when new results are loaded.
-     */
-    private class ResultsLoadedListener implements Runnable {
-
-        private final ListenableFuture<List<GeocodeResult>> results;
-
-        /**
-         * Constructs a runnable listener for the geocode results.
-         *
-         * @param results results from a {@link LocatorTask#geocodeAsync} task
-         */
-        ResultsLoadedListener(ListenableFuture<List<GeocodeResult>> results) {
-            this.results = results;
-        }
-
-
-        @Override
-        public void run() {
-
-            try {
+        case MotionEvent.ACTION_MOVE:
+          final int pointerIndex = MotionEventCompat.getActionIndex(event);
+          final float x = MotionEventCompat.getX(event, pointerIndex);
+          final float y = MotionEventCompat.getY(event, pointerIndex);
+          android.graphics.Point screenPoint = new android.graphics.Point(Math.round(x), Math.round(y));
+          final Point singleTapPoint = mMapView.screenToLocation(screenPoint);
+          final ListenableFuture<List<GeocodeResult>> results = mLocatorTask.reverseGeocodeAsync(singleTapPoint,
+              mReverseGeocodeParameters);
+          graphicsOverlay.getGraphics().clear();
+          Graphic resultLocGraphic = new Graphic(singleTapPoint, mPinSourceSymbol);
+          resultLocGraphic.setSelected(true);
+          // add graphic to location layer
+          graphicsOverlay.getGraphics().add(resultLocGraphic);
+          // display callout with reverse-geocode result on UI thread
+          runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+              try {
                 List<GeocodeResult> geocodes = results.get();
                 if (geocodes.size() > 0) {
-                    // get the top result
-                    GeocodeResult geocode = geocodes.get(0);
+                  // get the top result
+                  GeocodeResult geocode = geocodes.get(0);
+                  String detail;
+                  // attributes from a click-based search
+                  String street = geocode.getAttributes().get("Street").toString();
+                  String city = geocode.getAttributes().get("City").toString();
+                  String state = geocode.getAttributes().get("State").toString();
+                  String zip = geocode.getAttributes().get("ZIP").toString();
+                  detail = city + ", " + state + " " + zip;
 
-                    // set the viewpoint to the marker
-                    Point location = geocode.getDisplayLocation();
-                    // get attributes from the result for the callout
-                    String title;
-                    String detail;
-                    Object matchAddr = geocode.getAttributes().get("Match_addr");
-                    if (matchAddr != null) {
-                        // attributes from a query-based search
-                        title = matchAddr.toString().split(",")[0];
-                        detail = matchAddr.toString().substring(matchAddr.toString().indexOf(",") + 1);
-                    } else {
-                        // attributes from a click-based search
-                        String street = geocode.getAttributes().get("Street").toString();
-                        String city = geocode.getAttributes().get("City").toString();
-                        String state = geocode.getAttributes().get("State").toString();
-                        String zip = geocode.getAttributes().get("ZIP").toString();
-                        title = street;
-                        detail = city + ", " + state + " " + zip;
-                    }
+                  String address = street + "," + detail;
+                  mCalloutContent.setText(address);
+                  // get callout, set content and show
+                  mCallout = mMapView.getCallout();
+                  mCallout.setLocation(singleTapPoint);
+                  mCallout.setContent(mCalloutContent);
+                  mCallout.show();
 
-                    // get attributes from the result for the callout
-                    HashMap<String, Object> attributes = new HashMap<>();
-                    attributes.put("title", title);
-                    attributes.put("detail", detail);
-
-
-                    // create the marker
-                    Graphic marker = new Graphic(geocode.getDisplayLocation(), attributes, mPinSourceSymbol);
-                    graphicsOverlay.getGraphics().clear();
-
-                    // add the markers to the graphics overlay
-                    graphicsOverlay.getGraphics().add(marker);
-
-                    if (isPinSelected) {
-                        marker.setSelected(true);
-                    }
-                    String calloutText = title + ", " + detail;
-                    mCalloutContent.setText(calloutText);
-                    // get callout, set content and show
-                    mCallout = mMapView.getCallout();
-                    mCallout.setLocation(geocode.getDisplayLocation());
-                    mCallout.setContent(mCalloutContent);
-                    mCallout.show();
-
-                    mGraphicPoint = location;
-                    mGraphicPointAddress = title + ", " + detail;
+                  mGraphicPoint = singleTapPoint;
+                  mGraphicPointAddress = address;
                 }
 
-            } catch (Exception e) {
+              } catch (Exception e) {
                 e.printStackTrace();
+              }
             }
-        }
+          });
+
+          break;
+        case MotionEvent.ACTION_UP:
+          if (graphicsOverlay.getGraphics().size() > 0) {
+            graphicsOverlay.getGraphics().get(0).setSelected(false);
+            isPinSelected = false;
+            mMapView.setOnTouchListener(new MapTouchListener(getApplicationContext(), mMapView));
+          }
+          break;
+        default:
+          return false;
+      }
+      return true;
+    }
+  }
+
+  private class MapTouchListener extends DefaultMapViewOnTouchListener {
+
+    public MapTouchListener(Context context, MapView mapView) {
+      super(context, mapView);
+    }
+
+    @Override
+    public void onLongPress(MotionEvent e) {
+      android.graphics.Point screenPoint = new android.graphics.Point(Math.round(e.getX()),
+          Math.round(e.getY()));
+
+      Point longPressPoint = mMapView.screenToLocation(screenPoint);
+
+      ListenableFuture<List<GeocodeResult>> results = mLocatorTask.reverseGeocodeAsync(longPressPoint,
+          mReverseGeocodeParameters);
+      results.addDoneListener(new ResultsLoadedListener(results));
 
     }
 
+    @Override
+    public boolean onSingleTapConfirmed(MotionEvent e) {
+
+      if (mMapView.getCallout().isShowing()) {
+        mMapView.getCallout().dismiss();
+      }
+      if (graphicsOverlay.getGraphics().size() > 0) {
+        if (graphicsOverlay.getGraphics().get(0).isSelected()) {
+          isPinSelected = false;
+          graphicsOverlay.getGraphics().get(0).setSelected(false);
+        }
+      }
+      // get the screen point where user tapped
+      final android.graphics.Point screenPoint = new android.graphics.Point((int) e.getX(), (int) e.getY());
+
+      // identify graphics on the graphics overlay
+      final ListenableFuture<IdentifyGraphicsOverlayResult> identifyGraphic = mMapView
+          .identifyGraphicsOverlayAsync(graphicsOverlay, screenPoint, 1.0, false, 1);
+
+      identifyGraphic.addDoneListener(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            IdentifyGraphicsOverlayResult grOverlayResult = identifyGraphic.get();
+            // get the list of graphics returned by identify
+            List<Graphic> graphic = grOverlayResult.getGraphics();
+            // if identified graphic is not empty, start DragTouchListener
+            if (!graphic.isEmpty()) {
+
+              if (!isPinSelected) {
+                isPinSelected = true;
+                graphic.get(0).setSelected(true);
+                Toast.makeText(getApplicationContext(),
+                    getString(R.string.reverse_geocode_message),
+                    Toast.LENGTH_SHORT).show();
+                mMapView.setOnTouchListener(new DragTouchListener(getApplicationContext(), mMapView));
+              }
+
+              mCalloutContent.setText(mGraphicPointAddress);
+              // get callout, set content and show
+              mCallout = mMapView.getCallout();
+              mCallout.setContent(mCalloutContent);
+              mCallout.setLocation(mGraphicPoint);
+              mCallout.show();
+            }
+          } catch (InterruptedException | ExecutionException ie) {
+            ie.printStackTrace();
+          }
+
+        }
+      });
+
+      return super.onSingleTapConfirmed(e);
+    }
+  }
+
+  /**
+   * Updates marker and callout when new results are loaded.
+   */
+  private class ResultsLoadedListener implements Runnable {
+
+    private final ListenableFuture<List<GeocodeResult>> results;
+
+    /**
+     * Constructs a runnable listener for the geocode results.
+     *
+     * @param results results from a {@link LocatorTask#geocodeAsync} task
+     */
+    ResultsLoadedListener(ListenableFuture<List<GeocodeResult>> results) {
+      this.results = results;
+    }
+
+    @Override
+    public void run() {
+
+      try {
+        List<GeocodeResult> geocodes = results.get();
+        if (geocodes.size() > 0) {
+          // get the top result
+          GeocodeResult geocode = geocodes.get(0);
+
+          // set the viewpoint to the marker
+          Point location = geocode.getDisplayLocation();
+          // get attributes from the result for the callout
+          String title;
+          String detail;
+          Object matchAddr = geocode.getAttributes().get("Match_addr");
+          if (matchAddr != null) {
+            // attributes from a query-based search
+            title = matchAddr.toString().split(",")[0];
+            detail = matchAddr.toString().substring(matchAddr.toString().indexOf(",") + 1);
+          } else {
+            // attributes from a click-based search
+            String street = geocode.getAttributes().get("Street").toString();
+            String city = geocode.getAttributes().get("City").toString();
+            String state = geocode.getAttributes().get("State").toString();
+            String zip = geocode.getAttributes().get("ZIP").toString();
+            title = street;
+            detail = city + ", " + state + " " + zip;
+          }
+
+          // get attributes from the result for the callout
+          HashMap<String, Object> attributes = new HashMap<>();
+          attributes.put("title", title);
+          attributes.put("detail", detail);
+
+          // create the marker
+          Graphic marker = new Graphic(geocode.getDisplayLocation(), attributes, mPinSourceSymbol);
+          graphicsOverlay.getGraphics().clear();
+
+          // add the markers to the graphics overlay
+          graphicsOverlay.getGraphics().add(marker);
+
+          if (isPinSelected) {
+            marker.setSelected(true);
+          }
+          String calloutText = title + ", " + detail;
+          mCalloutContent.setText(calloutText);
+          // get callout, set content and show
+          mCallout = mMapView.getCallout();
+          mCallout.setLocation(geocode.getDisplayLocation());
+          mCallout.setContent(mCalloutContent);
+          mCallout.show();
+
+          mGraphicPoint = location;
+          mGraphicPointAddress = title + ", " + detail;
+        }
+
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+  }
 }

--- a/java/open-existing-map/src/main/AndroidManifest.xml
+++ b/java/open-existing-map/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/open-existing-map/src/main/java/com/esri/arcgisruntime/sample/openexistingmap/MainActivity.java
+++ b/java/open-existing-map/src/main/java/com/esri/arcgisruntime/sample/openexistingmap/MainActivity.java
@@ -16,7 +16,6 @@
 
 package com.esri.arcgisruntime.sample.openexistingmap;
 
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.widget.DrawerLayout;
@@ -164,13 +163,7 @@ public class MainActivity extends AppCompatActivity {
     super.onPostCreate(savedInstanceState);
     mDrawerToggle.syncState();
   }
-
-  @Override
-  public void onConfigurationChanged(Configuration newConfig) {
-    super.onConfigurationChanged(newConfig);
-    mDrawerToggle.onConfigurationChanged(newConfig);
-  }
-
+  
   public boolean onOptionsItemSelected(MenuItem item) {
     // activate the navigation drawer toggle
     return mDrawerToggle.onOptionsItemSelected(item) || super.onOptionsItemSelected(item);

--- a/java/open-existing-map/src/main/java/com/esri/arcgisruntime/sample/openexistingmap/MainActivity.java
+++ b/java/open-existing-map/src/main/java/com/esri/arcgisruntime/sample/openexistingmap/MainActivity.java
@@ -35,140 +35,145 @@ import com.esri.arcgisruntime.portal.PortalItem;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
-    private ArcGISMap mMap;
-    private Portal mPortal;
-    private PortalItem mPortalItem;
+  private MapView mMapView;
+  private ArcGISMap mMap;
+  private Portal mPortal;
+  private PortalItem mPortalItem;
 
-    private ListView mDrawerList;
+  private ListView mDrawerList;
 
-    private ActionBarDrawerToggle mDrawerToggle;
-    private DrawerLayout mDrawerLayout;
-    private String mActivityTitle;
+  private ActionBarDrawerToggle mDrawerToggle;
+  private DrawerLayout mDrawerLayout;
+  private String mActivityTitle;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        mDrawerList = (ListView)findViewById(R.id.navList);
-        mDrawerLayout = (DrawerLayout)findViewById(R.id.drawer_layout);
-        mActivityTitle = getTitle().toString();
+    mDrawerList = (ListView) findViewById(R.id.navList);
+    mDrawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+    mActivityTitle = getTitle().toString();
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // get the portal url for ArcGIS Online
-        mPortal = new Portal(getResources().getString(R.string.portal_url));
-        // get the pre-defined portal id and portal url
-        mPortalItem = new PortalItem(mPortal, getResources().getString(R.string.webmap_houses_with_mortgages_id));
-        // create a map from a PortalItem
-        mMap = new ArcGISMap(mPortalItem);
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
+    // get the portal url for ArcGIS Online
+    mPortal = new Portal(getResources().getString(R.string.portal_url));
+    // get the pre-defined portal id and portal url
+    mPortalItem = new PortalItem(mPortal, getResources().getString(R.string.webmap_houses_with_mortgages_id));
+    // create a map from a PortalItem
+    mMap = new ArcGISMap(mPortalItem);
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
 
-        // add the webmap titles to the drawer
-        addDrawerItems();
-        setupDrawer();
+    // add the webmap titles to the drawer
+    addDrawerItems();
+    setupDrawer();
 
-        // set icons on action bar
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-        getSupportActionBar().setHomeButtonEnabled(true);
-    }
+    // set icons on action bar
+    getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    getSupportActionBar().setHomeButtonEnabled(true);
+  }
 
-    private void addDrawerItems(){
-        String[] webmapTitles = {getResources().getString(R.string.webmap_houses_with_mortgages_title),
-                            getResources().getString(R.string.webmap_usa_tapestry_segmentation_title),
-                            getResources().getString(R.string.webmap_geology_us_title)};
-        ArrayAdapter<String> mAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, webmapTitles);
-        mDrawerList.setAdapter(mAdapter);
+  private void addDrawerItems() {
+    String[] webmapTitles = { getResources().getString(R.string.webmap_houses_with_mortgages_title),
+        getResources().getString(R.string.webmap_usa_tapestry_segmentation_title),
+        getResources().getString(R.string.webmap_geology_us_title) };
+    ArrayAdapter<String> mAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, webmapTitles);
+    mDrawerList.setAdapter(mAdapter);
 
-        mDrawerList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(@NonNull AdapterView<?> adapterView, @NonNull View view, int position, long id) {
-                if(position == 0){
-                    mPortalItem = new PortalItem(mPortal, getResources().getString(R.string.webmap_houses_with_mortgages_id));
-                    // create a map from a PortalItem
-                    mMap = new ArcGISMap(mPortalItem);
-                    // set the map to be displayed in this view
-                    mMapView.setMap(mMap);
-                    // close the drawer
-                    mDrawerLayout.closeDrawer(adapterView);
-                }else if(position == 1){
-                    mPortalItem = new PortalItem(mPortal, getResources().getString(R.string.webmap_usa_tapestry_segmentation_id));
-                    // create a map from a PortalItem
-                    mMap = new ArcGISMap(mPortalItem);
-                    // set the map to be displayed in this view
-                    mMapView.setMap(mMap);
-                    // close the drawer
-                    mDrawerLayout.closeDrawer(adapterView);
-                }else if(position == 2){
-                    mPortalItem = new PortalItem(mPortal, getResources().getString(R.string.webmap_geology_us));
-                    // create a map from a PortalItem
-                    mMap = new ArcGISMap(mPortalItem);
-                    // set the map to be displayed in this view
-                    mMapView.setMap(mMap);
-                    // close the drawer
-                    mDrawerLayout.closeDrawer(adapterView);
-                }
-            }
-        });
-    }
+    mDrawerList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+      @Override
+      public void onItemClick(@NonNull AdapterView<?> adapterView, @NonNull View view, int position, long id) {
+        if (position == 0) {
+          mPortalItem = new PortalItem(mPortal, getResources().getString(R.string.webmap_houses_with_mortgages_id));
+          // create a map from a PortalItem
+          mMap = new ArcGISMap(mPortalItem);
+          // set the map to be displayed in this view
+          mMapView.setMap(mMap);
+          // close the drawer
+          mDrawerLayout.closeDrawer(adapterView);
+        } else if (position == 1) {
+          mPortalItem = new PortalItem(mPortal, getResources().getString(R.string.webmap_usa_tapestry_segmentation_id));
+          // create a map from a PortalItem
+          mMap = new ArcGISMap(mPortalItem);
+          // set the map to be displayed in this view
+          mMapView.setMap(mMap);
+          // close the drawer
+          mDrawerLayout.closeDrawer(adapterView);
+        } else if (position == 2) {
+          mPortalItem = new PortalItem(mPortal, getResources().getString(R.string.webmap_geology_us));
+          // create a map from a PortalItem
+          mMap = new ArcGISMap(mPortalItem);
+          // set the map to be displayed in this view
+          mMapView.setMap(mMap);
+          // close the drawer
+          mDrawerLayout.closeDrawer(adapterView);
+        }
+      }
+    });
+  }
 
-    private void setupDrawer(){
-        mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, R.string.drawer_open, R.string.drawer_close){
+  private void setupDrawer() {
+    mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, R.string.drawer_open, R.string.drawer_close) {
 
-            // called when drawer has settled in an open state
-            public void onDrawerOpened(View drawerView){
-                super.onDrawerOpened(drawerView);
-                // change the title to the nav bar
-                getSupportActionBar().setTitle(getResources().getString(R.string.navbar_title));
-                // invalidate options menu
-                invalidateOptionsMenu();
-            }
+      // called when drawer has settled in an open state
+      public void onDrawerOpened(View drawerView) {
+        super.onDrawerOpened(drawerView);
+        // change the title to the nav bar
+        getSupportActionBar().setTitle(getResources().getString(R.string.navbar_title));
+        // invalidate options menu
+        invalidateOptionsMenu();
+      }
 
-            // called when drawer has settled in a closed state
-            public void onDrawerClosed(View view){
-                super.onDrawerClosed(view);
-                // set title to the app
-                getSupportActionBar().setTitle(mActivityTitle);
-                // invalidate options menu
-                invalidateOptionsMenu();
-            }
-        };
-        // enable draw indicator
-        mDrawerToggle.setDrawerIndicatorEnabled(true);
-        // attach toggle to drawer layout
-        mDrawerLayout.setDrawerListener(mDrawerToggle);
-    }
+      // called when drawer has settled in a closed state
+      public void onDrawerClosed(View view) {
+        super.onDrawerClosed(view);
+        // set title to the app
+        getSupportActionBar().setTitle(mActivityTitle);
+        // invalidate options menu
+        invalidateOptionsMenu();
+      }
+    };
+    // enable draw indicator
+    mDrawerToggle.setDrawerIndicatorEnabled(true);
+    // attach toggle to drawer layout
+    mDrawerLayout.setDrawerListener(mDrawerToggle);
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
 
-    @Override
-    protected void onPostCreate(Bundle savedInstanceState){
-        super.onPostCreate(savedInstanceState);
-        mDrawerToggle.syncState();
-    }
+  @Override protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 
-    @Override
-    public void onConfigurationChanged(Configuration newConfig){
-        super.onConfigurationChanged(newConfig);
-        mDrawerToggle.onConfigurationChanged(newConfig);
-    }
+  @Override
+  protected void onPostCreate(Bundle savedInstanceState) {
+    super.onPostCreate(savedInstanceState);
+    mDrawerToggle.syncState();
+  }
 
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // activate the navigation drawer toggle
-        return mDrawerToggle.onOptionsItemSelected(item) || super.onOptionsItemSelected(item);
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    mDrawerToggle.onConfigurationChanged(newConfig);
+  }
 
-    }
+  public boolean onOptionsItemSelected(MenuItem item) {
+    // activate the navigation drawer toggle
+    return mDrawerToggle.onOptionsItemSelected(item) || super.onOptionsItemSelected(item);
+
+  }
 }

--- a/java/open-mobile-mappackage/src/main/AndroidManifest.xml
+++ b/java/open-mobile-mappackage/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name=".MainActivity"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/open-mobile-mappackage/src/main/java/com/esri/arcgisruntime/sample/openmobilemappackage/MainActivity.java
+++ b/java/open-mobile-mappackage/src/main/java/com/esri/arcgisruntime/sample/openmobilemappackage/MainActivity.java
@@ -16,6 +16,8 @@
 
 package com.esri.arcgisruntime.sample.openmobilemappackage;
 
+import java.io.File;
+
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -31,109 +33,111 @@ import com.esri.arcgisruntime.loadable.LoadStatus;
 import com.esri.arcgisruntime.mapping.MobileMapPackage;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
-import java.io.File;
-
 public class MainActivity extends AppCompatActivity {
 
-    private static final String TAG = "MMPK";
-    private static final String FILE_EXTENSION = ".mmpk";
-    private static File extStorDir;
-    private static String extSDCardDirName;
-    private static String filename;
-    private static String mmpkFilePath;
-    private MapView mMapView;
-    private MobileMapPackage mapPackage;
+  private static final String TAG = MainActivity.class.getSimpleName();
+  private static final String FILE_EXTENSION = ".mmpk";
+  private static File extStorDir;
+  private static String extSDCardDirName;
+  private static String filename;
+  private static String mmpkFilePath;
+  // define permission to request
+  String[] reqPermission = new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE };
+  private MapView mMapView;
+  private MobileMapPackage mapPackage;
+  private int requestCode = 2;
 
-    // define permission to request
-    String[] reqPermission = new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE};
-    private int requestCode = 2;
+  /**
+   * Create the mobile map package file location and name structure
+   */
+  private static String createMobileMapPackageFilePath() {
+    return extStorDir.getAbsolutePath() + File.separator + extSDCardDirName + File.separator + filename
+        + FILE_EXTENSION;
+  }
 
-    /**
-     * Create the mobile map package file location and name structure
-     */
-    private static String createMobileMapPackageFilePath(){
-        return extStorDir.getAbsolutePath() + File.separator + extSDCardDirName + File.separator + filename + FILE_EXTENSION;
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+
+    // get sdcard resource name
+    extStorDir = Environment.getExternalStorageDirectory();
+    // get the directory
+    extSDCardDirName = this.getResources().getString(R.string.config_data_sdcard_offline_dir);
+    // get mobile map package filename
+    filename = this.getResources().getString(R.string.config_mmpk_name);
+    // create the full path to the mobile map package file
+    mmpkFilePath = createMobileMapPackageFilePath();
+
+    // retrieve the MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+
+    // For API level 23+ request permission at runtime
+    if (ContextCompat.checkSelfPermission(MainActivity.this, reqPermission[0]) == PackageManager.PERMISSION_GRANTED) {
+      loadMobileMapPackage(mmpkFilePath);
+    } else {
+      // request permission
+      ActivityCompat.requestPermissions(MainActivity.this, reqPermission, requestCode);
     }
+  }
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  /**
+   * Handle the permissions request response
+   */
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+      loadMobileMapPackage(mmpkFilePath);
+    } else {
+      // report to user that permission was denied
+      Toast.makeText(MainActivity.this, getResources().getString(R.string.location_permission_denied),
+          Toast.LENGTH_SHORT).show();
+    }
+  }
 
-        // get sdcard resource name
-        extStorDir = Environment.getExternalStorageDirectory();
-        // get the directory
-        extSDCardDirName = this.getResources().getString(R.string.config_data_sdcard_offline_dir);
-        // get mobile map package filename
-        filename = this.getResources().getString(R.string.config_mmpk_name);
-        // create the full path to the mobile map package file
-        mmpkFilePath = createMobileMapPackageFilePath();
+  /**
+   * Load a mobile map package into a MapView
+   *
+   * @param mmpkFile Full path to mmpk file
+   */
+  private void loadMobileMapPackage(String mmpkFile) {
+    //[DocRef: Name=Open Mobile Map Package-android, Category=Work with maps, Topic=Create an offline map]
+    // create the mobile map package
+    mapPackage = new MobileMapPackage(mmpkFile);
+    // load the mobile map package asynchronously
+    mapPackage.loadAsync();
 
-        // retrieve the MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-
-        // For API level 23+ request permission at runtime
-        if(ContextCompat.checkSelfPermission(MainActivity.this, reqPermission[0]) == PackageManager.PERMISSION_GRANTED){
-            loadMobileMapPackage(mmpkFilePath);
-        }else{
-            // request permission
-            ActivityCompat.requestPermissions(MainActivity.this, reqPermission, requestCode);
+    // add done listener which will invoke when mobile map package has loaded
+    mapPackage.addDoneLoadingListener(new Runnable() {
+      @Override
+      public void run() {
+        // check load status and that the mobile map package has maps
+        if (mapPackage.getLoadStatus() == LoadStatus.LOADED && mapPackage.getMaps().size() > 0) {
+          // add the map from the mobile map package to the MapView
+          mMapView.setMap(mapPackage.getMaps().get(0));
+        } else {
+          // Log an issue if the mobile map package fails to load
+          Log.e(TAG, mapPackage.getLoadError().getMessage());
         }
+      }
+    });
+    //[DocRef: END]
+  }
 
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    /**
-     * Handle the permissions request response
-     *
-     */
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults){
-        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED){
-            loadMobileMapPackage(mmpkFilePath);
-        }else{
-            // report to user that permission was denied
-            Toast.makeText(MainActivity.this, getResources().getString(R.string.location_permission_denied),
-                    Toast.LENGTH_SHORT).show();
-        }
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
 
-    /**
-     * Load a mobile map package into a MapView
-     *
-     * @param mmpkFile Full path to mmpk file
-     */
-    private void loadMobileMapPackage(String mmpkFile){
-        //[DocRef: Name=Open Mobile Map Package-android, Category=Work with maps, Topic=Create an offline map]
-        // create the mobile map package
-        mapPackage = new MobileMapPackage(mmpkFile);
-        // load the mobile map package asynchronously
-        mapPackage.loadAsync();
-
-        // add done listener which will invoke when mobile map package has loaded
-        mapPackage.addDoneLoadingListener(new Runnable() {
-            @Override
-            public void run() {
-                // check load status and that the mobile map package has maps
-                if(mapPackage.getLoadStatus() == LoadStatus.LOADED && mapPackage.getMaps().size() > 0){
-                    // add the map from the mobile map package to the MapView
-                    mMapView.setMap(mapPackage.getMaps().get(0));
-                }else{
-                    // Log an issue if the mobile map package fails to load
-                    Log.e(TAG, mapPackage.getLoadError().getMessage());
-                }
-            }
-        });
-        //[DocRef: END]
-    }
-
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
-
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/openstreetmap-layer/src/main/java/com/esri/arcgisruntime/sample/openstreetmaplayer/MainActivity.java
+++ b/java/openstreetmap-layer/src/main/java/com/esri/arcgisruntime/sample/openstreetmaplayer/MainActivity.java
@@ -25,31 +25,38 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // access MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // instantiate an ArcGISMap with OpenStreetMap Basemap
-        ArcGISMap map = new ArcGISMap(Basemap.Type.OPEN_STREET_MAP, 34.056295, -117.195800, 10);
-        mMapView.setMap(map);
-    }
+    // access MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // instantiate an ArcGISMap with OpenStreetMap Basemap
+    ArcGISMap map = new ArcGISMap(Basemap.Type.OPEN_STREET_MAP, 34.056295, -117.195800, 10);
+    mMapView.setMap(map);
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
 }

--- a/java/picture-marker-symbols/src/main/java/com/esri/arcgisruntime/sample/picturemarkersymbols/MainActivity.java
+++ b/java/picture-marker-symbols/src/main/java/com/esri/arcgisruntime/sample/picturemarkersymbols/MainActivity.java
@@ -47,15 +47,12 @@ import com.esri.arcgisruntime.symbology.PictureMarkerSymbol;
 
 public class MainActivity extends AppCompatActivity {
 
-  private static final String TAG = "PictureMarkerSymbols";
-
+  private static final String TAG = MainActivity.class.getSimpleName();
+  private final static int MY_PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 101;
   MapView mMapView;
   GraphicsOverlay mGraphicsOverlay;
-
   String mArcGISTempFolderPath;
   String mPinBlankOrangeFilePath;
-
-  private final static int MY_PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 101;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -85,7 +82,8 @@ public class MainActivity extends AppCompatActivity {
     //Create a picture marker symbol from a URL resource
     //When using a URL, you need to call load to fetch the remote resource
     final PictureMarkerSymbol campsiteSymbol = new PictureMarkerSymbol(
-        "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae");
+        "http://sampleserver6.arcgisonline"
+            + ".com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae");
     //Optionally set the size, if not set the image will be auto sized based on its size in pixels,
     //its appearance would then differ across devices with different resolutions.
     campsiteSymbol.setHeight(18);
@@ -173,7 +171,8 @@ public class MainActivity extends AppCompatActivity {
       return;
     }
 
-    //Check for required permission of saving to disc, for devices < android 6 this is set in the manifest and should be granted
+    //Check for required permission of saving to disc, for devices < android 6 this is set in the manifest and should
+    // be granted
     if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
         != PackageManager.PERMISSION_GRANTED) {
       //no permission, need to task, onRequestPermissionsResult will handle the result
@@ -217,9 +216,9 @@ public class MainActivity extends AppCompatActivity {
 
     //create new ArcGIS temp folder
     File folder = new File(mArcGISTempFolderPath);
-    if(folder.mkdirs()){
+    if (folder.mkdirs()) {
       Log.d(TAG, "Temp folder created");
-    }else{
+    } else {
       Toast.makeText(MainActivity.this, "Could not create temp folder", Toast.LENGTH_LONG).show();
     }
 
@@ -243,21 +242,25 @@ public class MainActivity extends AppCompatActivity {
   @Override
   public void onDestroy() {
     super.onDestroy();
+
+    // dispose MapView
+    mMapView.dispose();
+
     //Clean up file and folders we saved to disk
     try {
       File file = new File(mPinBlankOrangeFilePath);
 
-      if(file.delete()){
-        Log.d(TAG, "Temp folder created");
-      }else{
+      if (file.delete()) {
+        Log.i(TAG, "Temp folder created");
+      } else {
         Toast.makeText(MainActivity.this, "Could not create temp folder", Toast.LENGTH_LONG).show();
       }
 
       File tempFolder = new File(mArcGISTempFolderPath);
 
-      if(tempFolder.delete()){
-        Log.d(TAG, "Temp folder created");
-      }else{
+      if (tempFolder.delete()) {
+        Log.i(TAG, "Temp folder created");
+      } else {
         Toast.makeText(MainActivity.this, "Could not create temp folder", Toast.LENGTH_LONG).show();
       }
 

--- a/java/raster-layer-file/src/main/java/com/esri/arcgisruntime/sample/rasterlayerfile/MainActivity.java
+++ b/java/raster-layer-file/src/main/java/com/esri/arcgisruntime/sample/rasterlayerfile/MainActivity.java
@@ -16,6 +16,8 @@
 
 package com.esri.arcgisruntime.sample.rasterlayerfile;
 
+import java.io.File;
+
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -32,106 +34,111 @@ import com.esri.arcgisruntime.mapping.Basemap;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.raster.Raster;
 
-import java.io.File;
-
 /**
  * A sample class which demonstrates loading a Raster from the local device.
  */
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // retrieve the MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // retrieve the MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // define permission to request
-        String[] reqPermission = new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE };
-        int requestCode = 2;
-        // For API level 23+ request permission at runtime
-        if(ContextCompat.checkSelfPermission(MainActivity.this,
-                reqPermission[0]) == PackageManager.PERMISSION_GRANTED){
-            loadRaster();
-        } else {
-            // request permission
-            ActivityCompat.requestPermissions(MainActivity.this, reqPermission, requestCode);
-        }
+    // define permission to request
+    String[] reqPermission = new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE };
+    int requestCode = 2;
+    // For API level 23+ request permission at runtime
+    if (ContextCompat.checkSelfPermission(MainActivity.this,
+        reqPermission[0]) == PackageManager.PERMISSION_GRANTED) {
+      loadRaster();
+    } else {
+      // request permission
+      ActivityCompat.requestPermissions(MainActivity.this, reqPermission, requestCode);
     }
+  }
 
-    /**
-     * Using values stored in strings.xml, builds path to Shasta.tif.
-     * @return the path to raster file
-     */
-    private String buildRasterPath() {
-        // get sdcard resource name
-        File extStorDir = Environment.getExternalStorageDirectory();
-        // get the directory
-        String extSDCardDirName =
-                this.getResources().getString(R.string.config_data_sdcard_offline_dir);
-        // get raster filename
-        String filename = this.getString(R.string.config_raster_name);
-        // create the full path to the raster file
-        return extStorDir.getAbsolutePath()
-                + File.separator
-                + extSDCardDirName
-                + File.separator
-                + filename
-                + ".tif";
-    }
+  /**
+   * Using values stored in strings.xml, builds path to Shasta.tif.
+   *
+   * @return the path to raster file
+   */
+  private String buildRasterPath() {
+    // get sdcard resource name
+    File extStorDir = Environment.getExternalStorageDirectory();
+    // get the directory
+    String extSDCardDirName =
+        this.getResources().getString(R.string.config_data_sdcard_offline_dir);
+    // get raster filename
+    String filename = this.getString(R.string.config_raster_name);
+    // create the full path to the raster file
+    return extStorDir.getAbsolutePath()
+        + File.separator
+        + extSDCardDirName
+        + File.separator
+        + filename
+        + ".tif";
+  }
 
-    /**
-     * Loads Shasta.tif as a Raster and adds it to a new RasterLayer. The RasterLayer is then added
-     * to the map as an operational layer. Map viewpoint is then set based on the Raster's geometry.
-     */
-    private void loadRaster() {
-        // create a raster from a local raster file
-        Raster raster = new Raster(buildRasterPath());
-        // create a raster layer
-        final RasterLayer rasterLayer = new RasterLayer(raster);
-        // create a Map with imagery basemap
-        ArcGISMap map = new ArcGISMap(Basemap.createImagery());
-        // add the map to a map view
-        mMapView.setMap(map);
-        // add the raster as an operational layer
-        map.getOperationalLayers().add(rasterLayer);
-        // set viewpoint on the raster
-        rasterLayer.addDoneLoadingListener(new Runnable() {
-            @Override
-            public void run() {
-                mMapView.setViewpointGeometryAsync(rasterLayer.getFullExtent(), 50);
-            }
-        });
-    }
+  /**
+   * Loads Shasta.tif as a Raster and adds it to a new RasterLayer. The RasterLayer is then added
+   * to the map as an operational layer. Map viewpoint is then set based on the Raster's geometry.
+   */
+  private void loadRaster() {
+    // create a raster from a local raster file
+    Raster raster = new Raster(buildRasterPath());
+    // create a raster layer
+    final RasterLayer rasterLayer = new RasterLayer(raster);
+    // create a Map with imagery basemap
+    ArcGISMap map = new ArcGISMap(Basemap.createImagery());
+    // add the map to a map view
+    mMapView.setMap(map);
+    // add the raster as an operational layer
+    map.getOperationalLayers().add(rasterLayer);
+    // set viewpoint on the raster
+    rasterLayer.addDoneLoadingListener(new Runnable() {
+      @Override
+      public void run() {
+        mMapView.setViewpointGeometryAsync(rasterLayer.getFullExtent(), 50);
+      }
+    });
+  }
 
-    /**
-     * Handle the permissions request response.
-     */
-    public void onRequestPermissionsResult(int requestCode,
-                                           @NonNull String[] permissions,
-                                           @NonNull int[] grantResults){
-        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            loadRaster();
-        } else {
-            // report to user that permission was denied
-            Toast.makeText(MainActivity.this,
-                    getResources().getString(R.string.location_permission_denied),
-                    Toast.LENGTH_SHORT).show();
-        }
+  /**
+   * Handle the permissions request response.
+   */
+  public void onRequestPermissionsResult(int requestCode,
+      @NonNull String[] permissions,
+      @NonNull int[] grantResults) {
+    if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+      loadRaster();
+    } else {
+      // report to user that permission was denied
+      Toast.makeText(MainActivity.this,
+          getResources().getString(R.string.location_permission_denied),
+          Toast.LENGTH_SHORT).show();
     }
+  }
 
-    @Override
-    protected void onPause() {
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/raster-layer-geopackage/src/main/java/com/esri/arcgisruntime/sample/rasterlayergeopackage/MainActivity.java
+++ b/java/raster-layer-geopackage/src/main/java/com/esri/arcgisruntime/sample/rasterlayergeopackage/MainActivity.java
@@ -114,4 +114,10 @@ public class MainActivity extends AppCompatActivity {
     super.onResume();
     mMapView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/raster-layer-service/src/main/java/com/esri/arcgisruntime/sample/rasterservicelayer/MainActivity.java
+++ b/java/raster-layer-service/src/main/java/com/esri/arcgisruntime/sample/rasterservicelayer/MainActivity.java
@@ -29,47 +29,53 @@ import com.esri.arcgisruntime.raster.ImageServiceRaster;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // create MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a Dark Gray Canvas Vector basemap
-        ArcGISMap map = new ArcGISMap(Basemap.createDarkGrayCanvasVector());
-        // add the map to a map view
-        mMapView.setMap(map);
-        // create image service raster as raster layer
-        final ImageServiceRaster imageServiceRaster = new ImageServiceRaster(
-                getResources().getString(R.string.image_service_url));
-        final RasterLayer rasterLayer = new RasterLayer(imageServiceRaster);
-        // add raster layer as map operational layer
-        map.getOperationalLayers().add(rasterLayer);
-        // zoom to the extent of the raster service
-        rasterLayer.addDoneLoadingListener(new Runnable() {
-            @Override
-            public void run() {
-                if(rasterLayer.getLoadStatus() == LoadStatus.LOADED){
-                    // get the center point
-                    Point centerPnt = imageServiceRaster.getServiceInfo().getFullExtent().getCenter();
-                    mMapView.setViewpointCenterAsync(centerPnt, 55000000);
-                }
-            }
-        });
-    }
+    // create MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a Dark Gray Canvas Vector basemap
+    ArcGISMap map = new ArcGISMap(Basemap.createDarkGrayCanvasVector());
+    // add the map to a map view
+    mMapView.setMap(map);
+    // create image service raster as raster layer
+    final ImageServiceRaster imageServiceRaster = new ImageServiceRaster(
+        getResources().getString(R.string.image_service_url));
+    final RasterLayer rasterLayer = new RasterLayer(imageServiceRaster);
+    // add raster layer as map operational layer
+    map.getOperationalLayers().add(rasterLayer);
+    // zoom to the extent of the raster service
+    rasterLayer.addDoneLoadingListener(new Runnable() {
+      @Override
+      public void run() {
+        if (rasterLayer.getLoadStatus() == LoadStatus.LOADED) {
+          // get the center point
+          Point centerPnt = imageServiceRaster.getServiceInfo().getFullExtent().getCenter();
+          mMapView.setViewpointCenterAsync(centerPnt, 55000000);
+        }
+      }
+    });
+  }
 
-    @Override
-    protected void onPause() {
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/raster-rendering-rule/src/main/java/com/esri/arcgisruntime/samples/renderingrule/MainActivity.java
+++ b/java/raster-rendering-rule/src/main/java/com/esri/arcgisruntime/samples/renderingrule/MainActivity.java
@@ -18,6 +18,7 @@ package com.esri.arcgisruntime.samples.renderingrule;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -37,97 +38,106 @@ import com.esri.arcgisruntime.raster.RenderingRule;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
-    private ArcGISMap map;
+  private MapView mMapView;
+  private ArcGISMap map;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // create MapView from layout
-        mMapView = findViewById(R.id.mapView);
+    // create MapView from layout
+    mMapView = findViewById(R.id.mapView);
 
-        // create a Streets BaseMap
-        map = new ArcGISMap(Basemap.createStreets());
-        // set the map to be displayed in this view
-        mMapView.setMap(map);
+    // create a Streets BaseMap
+    map = new ArcGISMap(Basemap.createStreets());
+    // set the map to be displayed in this view
+    mMapView.setMap(map);
 
-        // create image service raster as raster layer and add to map
-        final ImageServiceRaster imageServiceRaster = new ImageServiceRaster(getResources().getString(R.string.image_service_url));
-        final RasterLayer imageRasterLayer = new RasterLayer(imageServiceRaster);
-        map.getOperationalLayers().add(imageRasterLayer);
+    // create image service raster as raster layer and add to map
+    final ImageServiceRaster imageServiceRaster = new ImageServiceRaster(
+        getResources().getString(R.string.image_service_url));
+    final RasterLayer imageRasterLayer = new RasterLayer(imageServiceRaster);
+    map.getOperationalLayers().add(imageRasterLayer);
 
-        Spinner spinner = findViewById(R.id.spinner);
-        final List<String> renderRulesList = new ArrayList<>();
-        final ArrayAdapter<String> spinnerAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, renderRulesList);
-        spinner.setAdapter(spinnerAdapter);
-        // zoom to the extent of the raster service
-        imageRasterLayer.addDoneLoadingListener(new Runnable() {
-            @Override
-            public void run() {
-                if(imageRasterLayer.getLoadStatus() == LoadStatus.LOADED){
-                    // zoom to extent of raster
-                    mMapView.setViewpointGeometryAsync(imageServiceRaster.getServiceInfo().getFullExtent());
-                    // get the predefined rendering rules and add to spinner
-                    List<RenderingRuleInfo> renderingRuleInfos = imageServiceRaster.getServiceInfo().getRenderingRuleInfos();
-                    for(RenderingRuleInfo renderRuleInfo : renderingRuleInfos){
-                        String renderingRuleName = renderRuleInfo.getName();
-                        renderRulesList.add(renderingRuleName);
-                        // update array adapter with list update
-                        spinnerAdapter.notifyDataSetChanged();
-                    }
-                }
-            }
-        });
+    Spinner spinner = findViewById(R.id.spinner);
+    final List<String> renderRulesList = new ArrayList<>();
+    final ArrayAdapter<String> spinnerAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1,
+        renderRulesList);
+    spinner.setAdapter(spinnerAdapter);
+    // zoom to the extent of the raster service
+    imageRasterLayer.addDoneLoadingListener(new Runnable() {
+      @Override
+      public void run() {
+        if (imageRasterLayer.getLoadStatus() == LoadStatus.LOADED) {
+          // zoom to extent of raster
+          mMapView.setViewpointGeometryAsync(imageServiceRaster.getServiceInfo().getFullExtent());
+          // get the predefined rendering rules and add to spinner
+          List<RenderingRuleInfo> renderingRuleInfos = imageServiceRaster.getServiceInfo().getRenderingRuleInfos();
+          for (RenderingRuleInfo renderRuleInfo : renderingRuleInfos) {
+            String renderingRuleName = renderRuleInfo.getName();
+            renderRulesList.add(renderingRuleName);
+            // update array adapter with list update
+            spinnerAdapter.notifyDataSetChanged();
+          }
+        }
+      }
+    });
 
-        // listen to the spinner
-        spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> adapterView, View view, int position, long id) {
-                applyRenderingRule(imageServiceRaster, position);
-            }
+    // listen to the spinner
+    spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+      @Override
+      public void onItemSelected(AdapterView<?> adapterView, View view, int position, long id) {
+        applyRenderingRule(imageServiceRaster, position);
+      }
 
-            @Override
-            public void onNothingSelected(AdapterView<?> adapterView) {
-                Log.d("MainActivity", "Spinner nothing selected");
-            }
-        });
+      @Override
+      public void onNothingSelected(AdapterView<?> adapterView) {
+        Log.d("MainActivity", "Spinner nothing selected");
+      }
+    });
 
-    }
+  }
 
-    /**
-     * Apply a rendering rule on a Raster and add it to the map
-     *
-     * @param imageServiceRaster image service raster to apply rendering on
-     * @param index spinner selected position representing the rule to apply
-     */
-    private void applyRenderingRule(ImageServiceRaster imageServiceRaster, int index){
-        // clear all rasters
-        map.getOperationalLayers().clear();
-        // get the rendering rule info at the selected index
-        RenderingRuleInfo renderRuleInfo = imageServiceRaster.getServiceInfo().getRenderingRuleInfos().get(index);
-        // create a rendering rule object using the rendering rule info
-        RenderingRule renderingRule = new RenderingRule(renderRuleInfo);
-        // create a new image service raster
-        ImageServiceRaster appliedImageServiceRaster = new ImageServiceRaster(getResources().getString(R.string.image_service_url));
-        // apply the rendering rule
-        appliedImageServiceRaster.setRenderingRule(renderingRule);
-        // create a raster layer using the image service raster
-        RasterLayer rasterLayer = new RasterLayer(appliedImageServiceRaster);
-        // add the raster layer to the map
-        map.getOperationalLayers().add(rasterLayer);
-    }
+  /**
+   * Apply a rendering rule on a Raster and add it to the map
+   *
+   * @param imageServiceRaster image service raster to apply rendering on
+   * @param index              spinner selected position representing the rule to apply
+   */
+  private void applyRenderingRule(ImageServiceRaster imageServiceRaster, int index) {
+    // clear all rasters
+    map.getOperationalLayers().clear();
+    // get the rendering rule info at the selected index
+    RenderingRuleInfo renderRuleInfo = imageServiceRaster.getServiceInfo().getRenderingRuleInfos().get(index);
+    // create a rendering rule object using the rendering rule info
+    RenderingRule renderingRule = new RenderingRule(renderRuleInfo);
+    // create a new image service raster
+    ImageServiceRaster appliedImageServiceRaster = new ImageServiceRaster(
+        getResources().getString(R.string.image_service_url));
+    // apply the rendering rule
+    appliedImageServiceRaster.setRenderingRule(renderingRule);
+    // create a raster layer using the image service raster
+    RasterLayer rasterLayer = new RasterLayer(appliedImageServiceRaster);
+    // add the raster layer to the map
+    map.getOperationalLayers().add(rasterLayer);
+  }
 
-    @Override
-    protected void onPause() {
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/rgb-renderer/src/main/java/com/esri/arcgisruntime/sample/rgbrenderer/MainActivity.java
+++ b/java/rgb-renderer/src/main/java/com/esri/arcgisruntime/sample/rgbrenderer/MainActivity.java
@@ -16,6 +16,9 @@
 
 package com.esri.arcgisruntime.sample.rgbrenderer;
 
+import java.io.File;
+import java.util.Arrays;
+
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -29,6 +32,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.Toast;
+
 import com.esri.arcgisruntime.layers.RasterLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.Basemap;
@@ -39,9 +43,6 @@ import com.esri.arcgisruntime.raster.RGBRenderer;
 import com.esri.arcgisruntime.raster.Raster;
 import com.esri.arcgisruntime.raster.StandardDeviationStretchParameters;
 import com.esri.arcgisruntime.raster.StretchParameters;
-
-import java.io.File;
-import java.util.Arrays;
 
 public class MainActivity extends AppCompatActivity implements ParametersDialogFragment.ParametersListener {
 
@@ -218,6 +219,12 @@ public class MainActivity extends AppCompatActivity implements ParametersDialogF
   protected void onResume() {
     super.onResume();
     mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
   }
 
   enum StretchType {

--- a/java/scene-layer/src/main/AndroidManifest.xml
+++ b/java/scene-layer/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize">
+        <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/scene-layer/src/main/java/com/esri/arcgisruntime/sample/scenelayer/MainActivity.java
+++ b/java/scene-layer/src/main/java/com/esri/arcgisruntime/sample/scenelayer/MainActivity.java
@@ -63,4 +63,11 @@ public class MainActivity extends AppCompatActivity {
     // resume SceneView
     mSceneView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose SceneView
+    mSceneView.dispose();
+  }
 }

--- a/java/service-feature-table-cache/src/main/java/com/esri/arcgisruntime/sample/servicefeaturetablecache/MainActivity.java
+++ b/java/service-feature-table-cache/src/main/java/com/esri/arcgisruntime/sample/servicefeaturetablecache/MainActivity.java
@@ -25,55 +25,61 @@ import com.esri.arcgisruntime.mapping.Basemap;
 import com.esri.arcgisruntime.mapping.Viewpoint;
 import com.esri.arcgisruntime.mapping.view.MapView;
 
-
 public class MainActivity extends AppCompatActivity {
 
-    MapView mMapView;
+  MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // create a map with the light grey canvas basemap
-        ArcGISMap map = new ArcGISMap(Basemap.createLightGrayCanvas());
-        //set an initial viewpoint
-        map.setInitialViewpoint( new Viewpoint(new Envelope(-1.30758164047166E7, 4014771.46954516, -1.30730056797177E7
-                , 4016869.78617381, SpatialReferences.getWebMercator() )));
+    // create a map with the light grey canvas basemap
+    ArcGISMap map = new ArcGISMap(Basemap.createLightGrayCanvas());
+    //set an initial viewpoint
+    map.setInitialViewpoint(new Viewpoint(new Envelope(-1.30758164047166E7, 4014771.46954516, -1.30730056797177E7
+        , 4016869.78617381, SpatialReferences.getWebMercator())));
 
+    // create feature layer with its service feature table
+    // create the service feature table
+    ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(
+        getResources().getString(R.string.sample_service_url));
 
-        // create feature layer with its service feature table
-        // create the service feature table
-        ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.sample_service_url));
+    //explicitly set the mode to on interaction cache (which is also the default mode for service feature tables)
+    serviceFeatureTable.setFeatureRequestMode(ServiceFeatureTable.FeatureRequestMode.ON_INTERACTION_CACHE);
 
-        //explicitly set the mode to on interaction cache (which is also the default mode for service feature tables)
-        serviceFeatureTable.setFeatureRequestMode(ServiceFeatureTable.FeatureRequestMode.ON_INTERACTION_CACHE);
+    // create the feature layer using the service feature table
+    FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
 
-        // create the feature layer using the service feature table
-        FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
+    // add the layer to the map
+    map.getOperationalLayers().add(featureLayer);
 
-        // add the layer to the map
-        map.getOperationalLayers().add(featureLayer);
+    // set the map to be displayed in the mapview
+    mMapView.setMap(map);
 
-        // set the map to be displayed in the mapview
-        mMapView.setMap(map);
+  }
 
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
-    }
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
 }

--- a/java/service-feature-table-manualcache/src/main/java/com/esri/arcgisruntime/samples/servicefeaturetablemanualcache/MainActivity.java
+++ b/java/service-feature-table-manualcache/src/main/java/com/esri/arcgisruntime/samples/servicefeaturetablemanualcache/MainActivity.java
@@ -19,6 +19,7 @@ package com.esri.arcgisruntime.samples.servicefeaturetablemanualcache;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -39,96 +40,104 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
+  private MapView mMapView;
 
-    private MapView mMapView;
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the topographic basemap
+    ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
 
-        // create a map with the topographic basemap
-        ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+    // create feature layer with its service feature table
+    // create the service feature table
+    final ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(
+        getResources().getString(R.string.sample_service_url));
 
-        // create feature layer with its service feature table
-        // create the service feature table
-        final ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.sample_service_url));
+    //explicitly set the mode to on manual cache (which means you need to call populate from service)
+    serviceFeatureTable.setFeatureRequestMode(ServiceFeatureTable.FeatureRequestMode.MANUAL_CACHE);
 
-        //explicitly set the mode to on manual cache (which means you need to call populate from service)
-        serviceFeatureTable.setFeatureRequestMode(ServiceFeatureTable.FeatureRequestMode.MANUAL_CACHE);
+    // create the feature layer using the service feature table
+    FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
 
-        // create the feature layer using the service feature table
-        FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
+    // add the layer to the map
+    map.getOperationalLayers().add(featureLayer);
 
-        // add the layer to the map
-        map.getOperationalLayers().add(featureLayer);
+    // load the table
+    serviceFeatureTable.loadAsync();
+    // add a done loading listener to call populate from service when the table is loaded is done
+    serviceFeatureTable.addDoneLoadingListener(new Runnable() {
+      @Override
+      public void run() {
 
-        // load the table
-        serviceFeatureTable.loadAsync();
-        // add a done loading listener to call populate from service when the table is loaded is done
-        serviceFeatureTable.addDoneLoadingListener(new Runnable() {
-            @Override
-            public void run() {
+        // set up the query parameters
+        QueryParameters params = new QueryParameters();
+        // for a specific 311 request type
+        params.setWhereClause("req_type = 'Tree Maintenance or Damage'");
+        // set all outfields
+        List<String> outFields = new ArrayList<>();
+        outFields.add("*");
+        //populate the table based on the query, listen for result in a listenable future
+        final ListenableFuture<FeatureQueryResult> future = serviceFeatureTable
+            .populateFromServiceAsync(params, true, outFields);
+        //add done listener to the future which fires when the async method is complete
+        future.addDoneListener(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              //call get on the future to get the result
+              FeatureQueryResult result = future.get();
+              // create an Iterator
+              Iterator<Feature> iterator = result.iterator();
+              Feature feature;
+              // cycle through selections
+              int counter = 0;
+              while (iterator.hasNext()) {
+                feature = iterator.next();
+                counter++;
+                Log.d(getResources().getString(R.string.app_name),
+                    "Selection #: " + counter + " Table name: " + feature.getFeatureTable().getTableName());
+              }
+              Toast.makeText(getApplicationContext(), counter + " features returned", Toast.LENGTH_SHORT).show();
 
-                // set up the query parameters
-                QueryParameters params = new QueryParameters();
-                // for a specific 311 request type
-                params.setWhereClause("req_type = 'Tree Maintenance or Damage'");
-                // set all outfields
-                List<String> outFields = new ArrayList<>();
-                outFields.add("*");
-                //populate the table based on the query, listen for result in a listenable future
-                final ListenableFuture<FeatureQueryResult> future = serviceFeatureTable.populateFromServiceAsync(params, true, outFields);
-                //add done listener to the future which fires when the async method is complete
-                future.addDoneListener(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            //call get on the future to get the result
-                            FeatureQueryResult result = future.get();
-                            // create an Iterator
-                            Iterator<Feature> iterator = result.iterator();
-                            Feature feature;
-                            // cycle through selections
-                            int counter = 0;
-                            while (iterator.hasNext()){
-                                feature = iterator.next();
-                                counter++;
-                                Log.d(getResources().getString(R.string.app_name), "Selection #: " + counter + " Table name: " + feature.getFeatureTable().getTableName());
-                            }
-                            Toast.makeText(getApplicationContext(), counter + " features returned", Toast.LENGTH_SHORT).show();
-
-                        } catch (Exception e) {
-                            Log.e(getResources().getString(R.string.app_name), "Populate from service failed: " + e.getMessage());
-                        }
-                    }
-                });
+            } catch (Exception e) {
+              Log.e(getResources().getString(R.string.app_name), "Populate from service failed: " + e.getMessage());
             }
+          }
         });
+      }
+    });
 
+    // set the map to be displayed in the mapview
+    mMapView.setMap(map);
 
-        // set the map to be displayed in the mapview
-        mMapView.setMap(map);
+    //set a viewpoint on the mapview so it zooms to the features once they are cached.
+    mMapView.setViewpoint(new Viewpoint(new Point(-13630484, 4545415, SpatialReferences.getWebMercator()), 500000));
 
-        //set a viewpoint on the mapview so it zooms to the features once they are cached.
-        mMapView.setViewpoint(new Viewpoint(new Point(-13630484, 4545415, SpatialReferences.getWebMercator()), 500000));
+  }
 
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
-    }
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
 }

--- a/java/service-feature-table-nocache/src/main/java/com/esri/arcgisruntime/samples/servicefeaturetablenocache/MainActivity.java
+++ b/java/service-feature-table-nocache/src/main/java/com/esri/arcgisruntime/samples/servicefeaturetablenocache/MainActivity.java
@@ -29,52 +29,60 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // create a map with the topographic basemap
-        ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
-        //set an initial viewpoint
-        map.setInitialViewpoint( new Viewpoint(new Envelope(-1.30758164047166E7, 4014771.46954516, -1.30730056797177E7
-                , 4016869.78617381, SpatialReferences.getWebMercator() )));
+    // create a map with the topographic basemap
+    ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+    //set an initial viewpoint
+    map.setInitialViewpoint(new Viewpoint(new Envelope(-1.30758164047166E7, 4014771.46954516, -1.30730056797177E7
+        , 4016869.78617381, SpatialReferences.getWebMercator())));
 
+    // create feature layer with its service feature table
+    // create the service feature table
+    ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(
+        getResources().getString(R.string.sample_service_url));
 
-        // create feature layer with its service feature table
-        // create the service feature table
-        ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.sample_service_url));
+    //explicitly set the mode to on interaction no cache (every interaction (pan, query etc) new features will be
+      // requested
+    serviceFeatureTable.setFeatureRequestMode(ServiceFeatureTable.FeatureRequestMode.ON_INTERACTION_NO_CACHE);
 
-        //explicitly set the mode to on interaction no cache (every interaction (pan, query etc) new features will be requested
-        serviceFeatureTable.setFeatureRequestMode(ServiceFeatureTable.FeatureRequestMode.ON_INTERACTION_NO_CACHE);
+    // create the feature layer using the service feature table
+    FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
 
-        // create the feature layer using the service feature table
-        FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
+    // add the layer to the map
+    map.getOperationalLayers().add(featureLayer);
 
-        // add the layer to the map
-        map.getOperationalLayers().add(featureLayer);
+    // set the map to be displayed in the mapview
+    mMapView.setMap(map);
 
-        // set the map to be displayed in the mapview
-        mMapView.setMap(map);
+  }
 
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
-    }
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
 }

--- a/java/set-initial-map-area/src/main/java/com/esri/arcgisruntime/sample/mapinitialextent/MainActivity.java
+++ b/java/set-initial-map-area/src/main/java/com/esri/arcgisruntime/sample/mapinitialextent/MainActivity.java
@@ -21,7 +21,6 @@ import android.support.v7.app.AppCompatActivity;
 
 import com.esri.arcgisruntime.geometry.Envelope;
 import com.esri.arcgisruntime.geometry.SpatialReference;
-import com.esri.arcgisruntime.layers.ArcGISTiledLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.Basemap;
 import com.esri.arcgisruntime.mapping.Viewpoint;
@@ -29,43 +28,46 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create new Tiled Layer from service url
-        ArcGISTiledLayer mTopoBasemap = new ArcGISTiledLayer(getResources().getString(R.string.world_topo_service));
-        // set tiled layer as basemap
-        Basemap mBasemap = new Basemap(mTopoBasemap);
-        // create a map with the basemap
-        ArcGISMap mMap = new ArcGISMap(mBasemap);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the basemap
+    ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
 
-        // create an initial extent envelope
-        Envelope mInitExtent = new Envelope(-12211308.778729, 4645116.003309, -12208257.879667, 4650542.535773, SpatialReference.create(102100));
-        // create a viewpoint from envelope
-        Viewpoint vp = new Viewpoint(mInitExtent);
-        // set initial map extent
-        mMap.setInitialViewpoint(vp);
+    // create an initial extent envelope
+    Envelope mInitExtent = new Envelope(-12211308.778729, 4645116.003309, -12208257.879667, 4650542.535773,
+        SpatialReference.create(102100));
+    // create a viewpoint from envelope
+    Viewpoint vp = new Viewpoint(mInitExtent);
+    // set initial map extent
+    map.setInitialViewpoint(vp);
 
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
+    // set the map to be displayed in this view
+    mMapView.setMap(map);
 
-    }
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/set-initial-map-location/src/main/AndroidManifest.xml
+++ b/java/set-initial-map-location/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/set-initial-map-location/src/main/java/com/esri/arcgisruntime/sample/setinitialmaplocation/MainActivity.java
+++ b/java/set-initial-map-location/src/main/java/com/esri/arcgisruntime/sample/setinitialmaplocation/MainActivity.java
@@ -25,30 +25,36 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // create MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the BasemapType topographic
-        ArcGISMap mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 16);
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
-    }
+    // create MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the BasemapType topographic
+    ArcGISMap mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 16);
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/set-map-spatial-reference/src/main/AndroidManifest.xml
+++ b/java/set-map-spatial-reference/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/set-map-spatial-reference/src/main/java/com/esri/arcgisruntime/sample/mapspatialreference/MainActivity.java
+++ b/java/set-map-spatial-reference/src/main/java/com/esri/arcgisruntime/sample/mapspatialreference/MainActivity.java
@@ -27,38 +27,44 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with World_Bonne projection
-        ArcGISMap mMap = new ArcGISMap(SpatialReference.create(54024));
-        //Adding a map image layer which can reproject itself to the map's spatial reference
-        ArcGISMapImageLayer mapImageLayer = new ArcGISMapImageLayer(getResources().getString(R.string.world_cities_service));
-        // set the map image layer as basemap
-        Basemap basemap = new Basemap(mapImageLayer);
-        // add the basemap to the map
-        mMap.setBasemap(basemap);
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with World_Bonne projection
+    ArcGISMap mMap = new ArcGISMap(SpatialReference.create(54024));
+    //Adding a map image layer which can reproject itself to the map's spatial reference
+    ArcGISMapImageLayer mapImageLayer = new ArcGISMapImageLayer(
+        getResources().getString(R.string.world_cities_service));
+    // set the map image layer as basemap
+    Basemap basemap = new Basemap(mapImageLayer);
+    // add the basemap to the map
+    mMap.setBasemap(basemap);
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
 
-    }
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
 
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/show-callout/src/main/AndroidManifest.xml
+++ b/java/show-callout/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name=".MainActivity"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/show-callout/src/main/java/com/esri/arcgisruntime/samples/showcallout/MainActivity.java
+++ b/java/show-callout/src/main/java/com/esri/arcgisruntime/samples/showcallout/MainActivity.java
@@ -34,67 +34,71 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private static final String sTag = "Gesture";
-    private MapView mMapView;
-    private Callout mCallout;
+  private static final String sTag = "Gesture";
+  private MapView mMapView;
+  private Callout mCallout;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the Basemap Type topographic
-        final ArcGISMap mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 10);
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the Basemap Type topographic
+    final ArcGISMap mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 10);
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
 
-        mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView) {
+    mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView) {
 
-            @Override
-            public boolean onSingleTapConfirmed(MotionEvent motionEvent) {
-                Log.d(sTag, "onSingleTapConfirmed: " + motionEvent.toString());
+      @Override
+      public boolean onSingleTapConfirmed(MotionEvent motionEvent) {
+        Log.d(sTag, "onSingleTapConfirmed: " + motionEvent.toString());
 
-                // get the point that was clicked and convert it to a point in map coordinates
-                android.graphics.Point screenPoint = new android.graphics.Point(Math.round(motionEvent.getX()),
-                        Math.round(motionEvent.getY()));
-                // create a map point from screen point
-                Point mapPoint = mMapView.screenToLocation(screenPoint);
-                // convert to WGS84 for lat/lon format
-                Point wgs84Point = (Point) GeometryEngine.project(mapPoint, SpatialReferences.getWgs84());
-                // create a textview for the callout
-                TextView calloutContent = new TextView(getApplicationContext());
-                calloutContent.setTextColor(Color.BLACK);
-                calloutContent.setSingleLine();
-                // format coordinates to 4 decimal places
-                calloutContent.setText("Lat: " +  String.format("%.4f", wgs84Point.getY()) +
-                        ", Lon: " + String.format("%.4f", wgs84Point.getX()));
+        // get the point that was clicked and convert it to a point in map coordinates
+        android.graphics.Point screenPoint = new android.graphics.Point(Math.round(motionEvent.getX()),
+            Math.round(motionEvent.getY()));
+        // create a map point from screen point
+        Point mapPoint = mMapView.screenToLocation(screenPoint);
+        // convert to WGS84 for lat/lon format
+        Point wgs84Point = (Point) GeometryEngine.project(mapPoint, SpatialReferences.getWgs84());
+        // create a textview for the callout
+        TextView calloutContent = new TextView(getApplicationContext());
+        calloutContent.setTextColor(Color.BLACK);
+        calloutContent.setSingleLine();
+        // format coordinates to 4 decimal places
+        calloutContent.setText("Lat: " + String.format("%.4f", wgs84Point.getY()) + ", Lon: " + String.format("%.4f", wgs84Point.getX()));
 
-                // get callout, set content and show
-                mCallout = mMapView.getCallout();
-                mCallout.setLocation(mapPoint);
-                mCallout.setContent(calloutContent);
-                mCallout.show();
+        // get callout, set content and show
+        mCallout = mMapView.getCallout();
+        mCallout.setLocation(mapPoint);
+        mCallout.setContent(calloutContent);
+        mCallout.show();
 
-                // center on tapped point
-                mMapView.setViewpointCenterAsync(mapPoint);
+        // center on tapped point
+        mMapView.setViewpointCenterAsync(mapPoint);
 
-                return true;
-            }
-        });
-    }
+        return true;
+      }
+    });
+  }
 
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/show-magnifier/src/main/AndroidManifest.xml
+++ b/java/show-magnifier/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/show-magnifier/src/main/java/com/esri/arcgisruntime/sample/showmagnifier/MainActivity.java
+++ b/java/show-magnifier/src/main/java/com/esri/arcgisruntime/sample/showmagnifier/MainActivity.java
@@ -25,34 +25,40 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the Basemap Type topographic
-        ArcGISMap mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 10);
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
-        // enable magnifier
-        mMapView.setMagnifierEnabled(true);
-        // allow magnifier to pan near the edge of the map bounds
-        mMapView.setCanMagnifierPanMap(true);
-    }
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the Basemap Type topographic
+    ArcGISMap mMap = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 10);
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
+    // enable magnifier
+    mMapView.setMagnifierEnabled(true);
+    // allow magnifier to pan near the edge of the map bounds
+    mMapView.setCanMagnifierPanMap(true);
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/simple-marker-symbol/src/main/java/com/esri/arcgisruntime/sample/simplemarkersymbol/MainActivity.java
+++ b/java/simple-marker-symbol/src/main/java/com/esri/arcgisruntime/sample/simplemarkersymbol/MainActivity.java
@@ -27,59 +27,66 @@ import com.esri.arcgisruntime.mapping.view.GraphicsOverlay;
 import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.SimpleMarkerSymbol;
 
-
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // create a map with the imagery basemap
-        ArcGISMap map = new ArcGISMap(Basemap.createImagery());
+    // create a map with the imagery basemap
+    ArcGISMap map = new ArcGISMap(Basemap.createImagery());
 
-        // create an initial viewpoint with a point and scale
-        Point point = new Point(-226773, 6550477, SpatialReferences.getWebMercator());
-        Viewpoint vp = new Viewpoint(point, 7500);
+    // create an initial viewpoint with a point and scale
+    Point point = new Point(-226773, 6550477, SpatialReferences.getWebMercator());
+    Viewpoint vp = new Viewpoint(point, 7500);
 
-        // set initial map extent
-        map.setInitialViewpoint(vp);
+    // set initial map extent
+    map.setInitialViewpoint(vp);
 
-        // set the map to be displayed in the mapview
-        mMapView.setMap(map);
+    // set the map to be displayed in the mapview
+    mMapView.setMap(map);
 
-        // create a new graphics overlay and add it to the mapview
-        GraphicsOverlay graphicsOverlay = new GraphicsOverlay();
-        mMapView.getGraphicsOverlays().add(graphicsOverlay);
+    // create a new graphics overlay and add it to the mapview
+    GraphicsOverlay graphicsOverlay = new GraphicsOverlay();
+    mMapView.getGraphicsOverlays().add(graphicsOverlay);
 
-        //[DocRef: Name=Point graphic with symbol, Category=Fundamentals, Topic=Symbols and Renderers]
-        //create a simple marker symbol
-        SimpleMarkerSymbol symbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.CIRCLE, Color.RED, 12); //size 12, style of circle
+    //[DocRef: Name=Point graphic with symbol, Category=Fundamentals, Topic=Symbols and Renderers]
+    //create a simple marker symbol
+    SimpleMarkerSymbol symbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.CIRCLE, Color.RED,
+        12); //size 12, style of circle
 
-        //add a new graphic with a new point geometry
-        Point graphicPoint = new Point(-226773, 6550477, SpatialReferences.getWebMercator());
-        Graphic graphic = new Graphic(graphicPoint, symbol);
-        graphicsOverlay.getGraphics().add(graphic);
-        //[DocRef: END]
+    //add a new graphic with a new point geometry
+    Point graphicPoint = new Point(-226773, 6550477, SpatialReferences.getWebMercator());
+    Graphic graphic = new Graphic(graphicPoint, symbol);
+    graphicsOverlay.getGraphics().add(graphic);
+    //[DocRef: END]
 
-    }
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
 }

--- a/java/simple-renderer/src/main/java/com/esri/arcgisruntime/sample/simplerenderer/MainActivity.java
+++ b/java/simple-renderer/src/main/java/com/esri/arcgisruntime/sample/simplerenderer/MainActivity.java
@@ -31,70 +31,79 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 import com.esri.arcgisruntime.symbology.SimpleMarkerSymbol;
 import com.esri.arcgisruntime.symbology.SimpleRenderer;
 
-
 public class MainActivity extends AppCompatActivity {
 
-    MapView mMapView;
+  MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        //Create points to add graphics to the map to allow a renderer to style them
-        //These are in WGS84 coordinates (Long, Lat)
-        Point oldFaithfullPoint = new Point(-110.828140, 44.460458, SpatialReferences.getWgs84());
-        Point cascadeGeyserPoint = new Point(-110.829004, 44.462438, SpatialReferences.getWgs84());
-        Point plumeGeyserPoint = new Point(-110.829381, 44.462735, SpatialReferences.getWgs84());
-        //Use the farthest points to create an envelope to use for the map views visible area
-        Envelope initialEnvelope = new Envelope(oldFaithfullPoint, plumeGeyserPoint);
+    //Create points to add graphics to the map to allow a renderer to style them
+    //These are in WGS84 coordinates (Long, Lat)
+    Point oldFaithfullPoint = new Point(-110.828140, 44.460458, SpatialReferences.getWgs84());
+    Point cascadeGeyserPoint = new Point(-110.829004, 44.462438, SpatialReferences.getWgs84());
+    Point plumeGeyserPoint = new Point(-110.829381, 44.462735, SpatialReferences.getWgs84());
+    //Use the farthest points to create an envelope to use for the map views visible area
+    Envelope initialEnvelope = new Envelope(oldFaithfullPoint, plumeGeyserPoint);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the imagery basemap. This will set the map to have a WebMercator spatial reference
-        ArcGISMap map = new ArcGISMap(Basemap.createImageryWithLabels());
-        // set the map to be displayed in the mapview
-        mMapView.setMap(map);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the imagery basemap. This will set the map to have a WebMercator spatial reference
+    ArcGISMap map = new ArcGISMap(Basemap.createImageryWithLabels());
+    // set the map to be displayed in the mapview
+    mMapView.setMap(map);
 
-        //set initial envelope on the map view sith some padding so all points will be visible
-        //This envelope is using the WGS84 points above, but is reprojected by the mapview into the maps spatial reference, so its works fine
-        mMapView.setViewpointGeometryAsync(initialEnvelope, 100);
+    //set initial envelope on the map view sith some padding so all points will be visible
+    //This envelope is using the WGS84 points above, but is reprojected by the mapview into the maps spatial
+      // reference, so its works fine
+    mMapView.setViewpointGeometryAsync(initialEnvelope, 100);
 
-        // create a new graphics overlay and add it to the mapview
-        GraphicsOverlay graphicOverlay = new GraphicsOverlay();
-        mMapView.getGraphicsOverlays().add(graphicOverlay);
+    // create a new graphics overlay and add it to the mapview
+    GraphicsOverlay graphicOverlay = new GraphicsOverlay();
+    mMapView.getGraphicsOverlays().add(graphicOverlay);
 
-        //[DocRef: Name=Simple Renderer, Category=Fundamentals, Topic=Symbols and Renderers]
-        //create a simple symbol for use in a simple renderer
-        SimpleMarkerSymbol symbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.CROSS, Color.RED, 12); //size 12, style of cross
-        SimpleRenderer renderer = new SimpleRenderer(symbol);
+    //[DocRef: Name=Simple Renderer, Category=Fundamentals, Topic=Symbols and Renderers]
+    //create a simple symbol for use in a simple renderer
+    SimpleMarkerSymbol symbol = new SimpleMarkerSymbol(SimpleMarkerSymbol.Style.CROSS, Color.RED,
+        12); //size 12, style of cross
+    SimpleRenderer renderer = new SimpleRenderer(symbol);
 
-        //apply the renderer to the graphics overlay (so all graphics will use the same symbol from the renderer)
-        graphicOverlay.setRenderer(renderer);
-        //[DocRef: END]
+    //apply the renderer to the graphics overlay (so all graphics will use the same symbol from the renderer)
+    graphicOverlay.setRenderer(renderer);
+    //[DocRef: END]
 
-        //create graphics from the geyser location points. NOTE: no need to set the symbol on the graphic because the renderer takes care of it
-        //The points are in WGS84, but graphics get reprojected automatically, so they work fine in a map with a spatial reference of web mercator
-        Graphic oldFaithfullGraphic = new Graphic(oldFaithfullPoint);
-        Graphic cascadeGeyserGraphic = new Graphic(cascadeGeyserPoint);
-        Graphic plumeGeyserGraphic = new Graphic(plumeGeyserPoint);
-        graphicOverlay.getGraphics().add(oldFaithfullGraphic);
-        graphicOverlay.getGraphics().add(cascadeGeyserGraphic);
-        graphicOverlay.getGraphics().add(plumeGeyserGraphic);
+    //create graphics from the geyser location points. NOTE: no need to set the symbol on the graphic because the
+      // renderer takes care of it
+    //The points are in WGS84, but graphics get reprojected automatically, so they work fine in a map with a spatial
+      // reference of web mercator
+    Graphic oldFaithfullGraphic = new Graphic(oldFaithfullPoint);
+    Graphic cascadeGeyserGraphic = new Graphic(cascadeGeyserPoint);
+    Graphic plumeGeyserGraphic = new Graphic(plumeGeyserPoint);
+    graphicOverlay.getGraphics().add(oldFaithfullGraphic);
+    graphicOverlay.getGraphics().add(cascadeGeyserGraphic);
+    graphicOverlay.getGraphics().add(plumeGeyserGraphic);
 
-    }
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/sketch-editor/src/main/java/com/esri/arcgisruntime/sample/mapsketchingapi/MainActivity.java
+++ b/java/sketch-editor/src/main/java/com/esri/arcgisruntime/sample/mapsketchingapi/MainActivity.java
@@ -273,4 +273,9 @@ public class MainActivity extends AppCompatActivity {
     mMapView.resume();
   }
 
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/spatial-operations/src/main/java/com/esri/arcgisandroid/sample/spatialoperations/MainActivity.java
+++ b/java/spatial-operations/src/main/java/com/esri/arcgisandroid/sample/spatialoperations/MainActivity.java
@@ -25,41 +25,41 @@ public class MainActivity extends AppCompatActivity {
 
   final private GraphicsOverlay inputGeometryOverlay = new GraphicsOverlay();
   final private GraphicsOverlay resultGeometryOverlay = new GraphicsOverlay();
-  private Polygon inputPolygon1;
-  private Polygon inputPolygon2;
-
   // simple black (0xFF000000) line symbol for outlines
   final private SimpleLineSymbol lineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, 0xFF000000, 1);
-  final private SimpleFillSymbol resultFillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, 0xFFE91F1F, lineSymbol);
-
+  final private SimpleFillSymbol resultFillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, 0xFFE91F1F,
+      lineSymbol);
+  private Polygon inputPolygon1;
+  private Polygon inputPolygon2;
   // The spatial operation switching menu items.
   private MenuItem noOperationMenuItem = null;
   private MenuItem intersectionMenuItem = null;
   private MenuItem unionMenuItem = null;
   private MenuItem differenceMenuItem = null;
   private MenuItem symmetricDifferenceMenuItem = null;
+  private MapView mMapView;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
 
-    MapView mapView = (MapView)findViewById(R.id.mapView);
+    mMapView = (MapView) findViewById(R.id.mapView);
 
     // create ArcGISMap with topographic basemap
     ArcGISMap map = new ArcGISMap(Basemap.createLightGrayCanvas());
-    mapView.setMap(map);
+    mMapView.setMap(map);
 
     // create graphics overlays to show the inputs and results of the spatial operation
-    mapView.getGraphicsOverlays().add(inputGeometryOverlay);
-    mapView.getGraphicsOverlays().add(resultGeometryOverlay);
+    mMapView.getGraphicsOverlays().add(inputGeometryOverlay);
+    mMapView.getGraphicsOverlays().add(resultGeometryOverlay);
 
     // create input polygons and add graphics to display these polygons in an overlay
     createPolygons();
 
     // center the map view on the input geometries
     Geometry viewpointGeom = GeometryEngine.union(inputPolygon1, inputPolygon2).getExtent();
-    mapView.setViewpointGeometryAsync(viewpointGeom, 20);
+    mMapView.setViewpointGeometryAsync(viewpointGeom, 20);
   }
 
   @Override
@@ -94,29 +94,24 @@ public class MainActivity extends AppCompatActivity {
       // no spatial operation - graphics have been cleared previously
       noOperationMenuItem.setChecked(true);
       return true;
-    }
-    else if (itemId == R.id.action_intersection) {
+    } else if (itemId == R.id.action_intersection) {
       intersectionMenuItem.setChecked(true);
       showGeometry(GeometryEngine.intersection(inputPolygon1, inputPolygon2));
       return true;
-    }
-    else if (itemId == R.id.action_union) {
+    } else if (itemId == R.id.action_union) {
       unionMenuItem.setChecked(true);
       showGeometry(GeometryEngine.union(inputPolygon1, inputPolygon2));
       return true;
-    }
-    else if (itemId == R.id.action_difference) {
+    } else if (itemId == R.id.action_difference) {
       differenceMenuItem.setChecked(true);
       // note that the difference method gives different results depending on the order of input geometries
       showGeometry(GeometryEngine.difference(inputPolygon1, inputPolygon2));
       return true;
-    }
-    else if (itemId == R.id.action_symmetric_difference) {
+    } else if (itemId == R.id.action_symmetric_difference) {
       symmetricDifferenceMenuItem.setChecked(true);
       showGeometry(GeometryEngine.symmetricDifference(inputPolygon1, inputPolygon2));
       return true;
-    }
-    else {
+    } else {
       return super.onOptionsItemSelected(item);
     }
   }
@@ -174,4 +169,21 @@ public class MainActivity extends AppCompatActivity {
     inputGeometryOverlay.getGraphics().add(new Graphic(inputPolygon2, fillSymbol));
   }
 
+  @Override
+  protected void onPause() {
+    mMapView.pause();
+    super.onPause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/statistical-query/src/main/java/com/esri/arcgisruntime/sample/statisticalquery/MainActivity.java
+++ b/java/statistical-query/src/main/java/com/esri/arcgisruntime/sample/statisticalquery/MainActivity.java
@@ -139,8 +139,8 @@ public class MainActivity extends AppCompatActivity {
         while (statisticRecordIterator.hasNext()) {
           Map<String, Object> statisticsMap = statisticRecordIterator.next().getStatistics();
           for (Map.Entry<String, Object> stat : statisticsMap.entrySet()) {
-            result.append(stat.getKey()).append(": ").append(String.format(Locale.US, "%,.0f", (Double) stat.getValue()))
-                .append("\n");
+            result.append(stat.getKey()).append(": ")
+                .append(String.format(Locale.US, "%,.0f", (Double) stat.getValue())).append("\n");
           }
         }
 
@@ -152,10 +152,29 @@ public class MainActivity extends AppCompatActivity {
         reportSnackbar.show();
 
       } catch (InterruptedException | ExecutionException e) {
-        Toast.makeText(MainActivity.this, "Error getting Statistical Query Results: " + e.getMessage(), Toast.LENGTH_LONG).show();
+        Toast.makeText(MainActivity.this, "Error getting Statistical Query Results: " + e.getMessage(),
+            Toast.LENGTH_LONG).show();
         Log.e(TAG, "Error getting Statistical Query Results: " + e.getMessage());
         e.printStackTrace();
       }
     });
+  }
+
+  @Override
+  protected void onPause() {
+    mMapView.pause();
+    super.onPause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
   }
 }

--- a/java/stretch-renderer/src/main/java/com/esri/arcgisruntime/sample/stretchrenderer/MainActivity.java
+++ b/java/stretch-renderer/src/main/java/com/esri/arcgisruntime/sample/stretchrenderer/MainActivity.java
@@ -16,6 +16,9 @@
 
 package com.esri.arcgisruntime.sample.stretchrenderer;
 
+import java.io.File;
+import java.util.Collections;
+
 import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
@@ -29,6 +32,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.Toast;
+
 import com.esri.arcgisruntime.layers.RasterLayer;
 import com.esri.arcgisruntime.mapping.ArcGISMap;
 import com.esri.arcgisruntime.mapping.Basemap;
@@ -39,9 +43,6 @@ import com.esri.arcgisruntime.raster.Raster;
 import com.esri.arcgisruntime.raster.StandardDeviationStretchParameters;
 import com.esri.arcgisruntime.raster.StretchParameters;
 import com.esri.arcgisruntime.raster.StretchRenderer;
-
-import java.io.File;
-import java.util.Collections;
 
 public class MainActivity extends AppCompatActivity implements ParametersDialogFragment.ParametersListener {
 
@@ -203,6 +204,12 @@ public class MainActivity extends AppCompatActivity implements ParametersDialogF
   protected void onResume() {
     super.onResume();
     mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
   }
 
   enum StretchType {

--- a/java/surface-placement/src/main/AndroidManifest.xml
+++ b/java/surface-placement/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.esri.arcgisruntime.sample.surfaceplacement.MainActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize">
+        <activity android:name="com.esri.arcgisruntime.sample.surfaceplacement.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/surface-placement/src/main/java/com/esri/arcgisruntime/sample/surfaceplacement/MainActivity.java
+++ b/java/surface-placement/src/main/java/com/esri/arcgisruntime/sample/surfaceplacement/MainActivity.java
@@ -106,4 +106,10 @@ public class MainActivity extends AppCompatActivity {
     // resume SceneView
     mSceneView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mSceneView.dispose();
+  }
 }

--- a/java/symbolize-shapefile/src/main/AndroidManifest.xml
+++ b/java/symbolize-shapefile/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/symbolize-shapefile/src/main/java/com/esri/arcgisruntime/sample/symbolizeshapefile/MainActivity.java
+++ b/java/symbolize-shapefile/src/main/java/com/esri/arcgisruntime/sample/symbolizeshapefile/MainActivity.java
@@ -129,4 +129,10 @@ public class MainActivity extends AppCompatActivity {
     super.onResume();
     mMapView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/take-screenshot/src/main/java/com/esri/arcgisruntime/sample/takescreenshot/MainActivity.java
+++ b/java/take-screenshot/src/main/java/com/esri/arcgisruntime/sample/takescreenshot/MainActivity.java
@@ -19,6 +19,7 @@ package com.esri.arcgisruntime.sample.takescreenshot;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+
 import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -44,176 +45,183 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
-    private static final String TAG = "TakeScreenshot";
-    private final int requestCode = 2;
-    private final String[] permission = new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE};
+  private static final String TAG = MainActivity.class.getSimpleName();
+  private final int requestCode = 2;
+  private final String[] permission = new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE };
+  private MapView mMapView;
 
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // create a map with the BasemapType Imagery with Labels
+    ArcGISMap mMap = new ArcGISMap(Basemap.createImageryWithLabels());
+    // set the map to be displayed in this view
+    mMapView.setMap(mMap);
+  }
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // create a map with the BasemapType Imagery with Labels
-        ArcGISMap mMap = new ArcGISMap(Basemap.createImageryWithLabels());
-        // set the map to be displayed in this view
-        mMapView.setMap(mMap);
+  @Override
+  public boolean onCreateOptionsMenu(Menu menu) {
+    // Inflate the menu; this adds items to the action bar if it is present.
+    getMenuInflater().inflate(R.menu.menu_main, menu);
+    return true;
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    // handle menu item selection
+
+    int itemId = item.getItemId();
+    if (itemId == R.id.CaptureMap) {
+      // Check permissions to see if failure may be due to lack of permissions.
+      boolean permissionCheck = ContextCompat.checkSelfPermission(MainActivity.this, permission[0]) ==
+          PackageManager.PERMISSION_GRANTED;
+
+      if (!permissionCheck) {
+        // If permissions are not already granted, request permission from the user.
+        ActivityCompat.requestPermissions(MainActivity.this, permission, requestCode);
+      } else {
+        captureScreenshotAsync();
+      }
     }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_main, menu);
-        return true;
-    }
+    return true;
+  }
 
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // handle menu item selection
+  /**
+   * capture the map as an image
+   */
+  private void captureScreenshotAsync() {
 
-        int itemId = item.getItemId();
-        if (itemId == R.id.CaptureMap) {
-            // Check permissions to see if failure may be due to lack of permissions.
-            boolean permissionCheck = ContextCompat.checkSelfPermission(MainActivity.this, permission[0]) ==
-                    PackageManager.PERMISSION_GRANTED;
-
-            if (!permissionCheck) {
-                // If permissions are not already granted, request permission from the user.
-                ActivityCompat.requestPermissions(MainActivity.this, permission, requestCode);
-            } else {
-                captureScreenshotAsync();
-            }
+    // export the image from the mMapView
+    final ListenableFuture<Bitmap> export = mMapView.exportImageAsync();
+    export.addDoneListener(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          Bitmap currentMapImage = export.get();
+          // play the camera shutter sound
+          MediaActionSound sound = new MediaActionSound();
+          sound.play(MediaActionSound.SHUTTER_CLICK);
+          Log.d(TAG, "Captured the image!!");
+          // save the exported bitmap to an image file
+          SaveImageTask saveImageTask = new SaveImageTask();
+          saveImageTask.execute(currentMapImage);
+        } catch (Exception e) {
+          Toast
+              .makeText(getApplicationContext(), getResources().getString(R.string.map_export_failure) + e.getMessage(),
+                  Toast.LENGTH_SHORT).show();
+          Log.e(TAG, getResources().getString(R.string.map_export_failure) + e.getMessage());
         }
+      }
+    });
+  }
 
-        return true;
+  /**
+   * save the bitmap image to file and open it
+   *
+   * @param bitmap
+   * @throws IOException
+   */
+  private File saveToFile(Bitmap bitmap) throws IOException {
+
+    // create a directory ArcGIS to save the file
+    File root;
+    File file = null;
+    String fileName = "map-export-image" + System.currentTimeMillis() + ".png";
+    root = Environment.getExternalStorageDirectory();
+    File fileDir = new File(root.getAbsolutePath() + "/ArcGIS Export/");
+    boolean isDirectoryCreated = fileDir.exists();
+    if (!isDirectoryCreated) {
+      isDirectoryCreated = fileDir.mkdirs();
+    }
+    if (isDirectoryCreated) {
+      file = new File(fileDir, fileName);
+      // write the bitmap to PNG file
+      FileOutputStream fos = new FileOutputStream(file);
+      bitmap.compress(Bitmap.CompressFormat.PNG, 100, fos);
+
+      // close the stream
+      fos.flush();
+      fos.close();
+    }
+    return file;
+
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    // If request is cancelled, the result arrays are empty.
+    if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+      // Location permission was granted. This would have been triggered in response to failing to start the
+      // LocationDisplay, so try starting this again.
+      captureScreenshotAsync();
+    } else {
+      // If permission was denied, show toast to inform user what was chosen. If LocationDisplay is started again,
+      // request permission UX will be shown again, option should be shown to allow never showing the UX again.
+      // Alternative would be to disable functionality so request is not shown again.
+      Toast.makeText(MainActivity.this, getResources().getString(R.string.storage_permission_denied), Toast
+          .LENGTH_SHORT).show();
+
+    }
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
+
+  /**
+   * AsyncTask class to save the bitmap as an image
+   */
+  private class SaveImageTask extends AsyncTask<Bitmap, Void, File> {
+
+    protected void onPreExecute() {
+      // display a toast message to inform saving the map as an image
+      Toast.makeText(getApplicationContext(), getResources().getString(R.string.map_export_message), Toast.LENGTH_SHORT)
+          .show();
     }
 
     /**
-     * capture the map as an image
+     * save the file using a worker thread
      */
-    private void captureScreenshotAsync() {
+    protected File doInBackground(Bitmap... mapBitmap) {
 
-        // export the image from the mMapView
-        final ListenableFuture<Bitmap> export = mMapView.exportImageAsync();
-        export.addDoneListener(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Bitmap currentMapImage = export.get();
-                    // play the camera shutter sound
-                    MediaActionSound sound = new MediaActionSound();
-                    sound.play(MediaActionSound.SHUTTER_CLICK);
-                    Log.d(TAG,"Captured the image!!");
-                    // save the exported bitmap to an image file
-                    SaveImageTask saveImageTask = new SaveImageTask();
-                    saveImageTask.execute(currentMapImage);
-                } catch (Exception e) {
-                    Toast.makeText(getApplicationContext(), getResources().getString(R.string.map_export_failure) + e.getMessage(), Toast.LENGTH_SHORT).show();
-                    Log.e(TAG, getResources().getString(R.string.map_export_failure) + e.getMessage());
-                }
-            }
-        });
-    }
+      try {
+        return saveToFile(mapBitmap[0]);
+      } catch (Exception e) {
+        Log.e(TAG, getResources().getString(R.string.map_export_failure) + e.getMessage());
+      }
 
-    /**
-     * save the bitmap image to file and open it
-     *
-     * @param bitmap
-     * @throws IOException
-     */
-    private File saveToFile(Bitmap bitmap) throws IOException {
-
-        // create a directory ArcGIS to save the file
-        File root;
-        File file = null;
-        String fileName = "map-export-image" + System.currentTimeMillis() + ".png";
-        root = Environment.getExternalStorageDirectory();
-        File fileDir = new File(root.getAbsolutePath() + "/ArcGIS Export/");
-        boolean isDirectoryCreated=fileDir.exists();
-        if (!isDirectoryCreated) {
-            isDirectoryCreated= fileDir.mkdirs();
-        }
-        if(isDirectoryCreated) {
-            file = new File(fileDir, fileName);
-            // write the bitmap to PNG file
-            FileOutputStream fos = new FileOutputStream(file);
-            bitmap.compress(Bitmap.CompressFormat.PNG, 100, fos);
-
-            // close the stream
-            fos.flush();
-            fos.close();
-        }
-        return file;
+      return null;
 
     }
 
     /**
-     * AsyncTask class to save the bitmap as an image
+     * Perform the work on UI thread to open the exported map image
      */
-    private class SaveImageTask extends AsyncTask<Bitmap, Void, File> {
-
-        protected void onPreExecute() {
-            // display a toast message to inform saving the map as an image
-            Toast.makeText(getApplicationContext(), getResources().getString(R.string.map_export_message), Toast.LENGTH_SHORT).show();
-        }
-
-        /**
-         * save the file using a worker thread
-         */
-        protected File doInBackground(Bitmap... mapBitmap) {
-
-            try {
-                return saveToFile(mapBitmap[0]);
-            } catch (Exception e) {
-                Log.e(TAG, getResources().getString(R.string.map_export_failure) + e.getMessage());
-            }
-
-            return null;
-
-        }
-
-        /**
-         * Perform the work on UI thread to open the exported map image
-         */
-        protected void onPostExecute(File file) {
-            // Open the file to view
-            Intent i = new Intent();
-            i.setAction(android.content.Intent.ACTION_VIEW);
-            i.setDataAndType(Uri.fromFile(file), "image/png");
-            startActivity(i);
-        }
+    protected void onPostExecute(File file) {
+      // Open the file to view
+      Intent i = new Intent();
+      i.setAction(android.content.Intent.ACTION_VIEW);
+      i.setDataAndType(Uri.fromFile(file), "image/png");
+      startActivity(i);
     }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        // If request is cancelled, the result arrays are empty.
-        if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            // Location permission was granted. This would have been triggered in response to failing to start the
-            // LocationDisplay, so try starting this again.
-            captureScreenshotAsync();
-        } else {
-            // If permission was denied, show toast to inform user what was chosen. If LocationDisplay is started again,
-            // request permission UX will be shown again, option should be shown to allow never showing the UX again.
-            // Alternative would be to disable functionality so request is not shown again.
-            Toast.makeText(MainActivity.this, getResources().getString(R.string.storage_permission_denied), Toast
-                    .LENGTH_SHORT).show();
-
-        }
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-        mMapView.pause();
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        mMapView.resume();
-    }
-
+  }
 }

--- a/java/transforms-by-suitability/src/main/java/com/esri/arcgisruntime/sample/transformsbysuitability/MainActivity.java
+++ b/java/transforms-by-suitability/src/main/java/com/esri/arcgisruntime/sample/transformsbysuitability/MainActivity.java
@@ -338,4 +338,11 @@ public class MainActivity extends AppCompatActivity {
     // resume MapView
     mMapView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
 }

--- a/java/unique-value-renderer/src/main/java/com/esri/arcgisruntime/sample/uniquevaluerenderer/MainActivity.java
+++ b/java/unique-value-renderer/src/main/java/com/esri/arcgisruntime/sample/uniquevaluerenderer/MainActivity.java
@@ -18,6 +18,7 @@ package com.esri.arcgisruntime.sample.uniquevaluerenderer;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -34,91 +35,108 @@ import com.esri.arcgisruntime.symbology.SimpleFillSymbol;
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol;
 import com.esri.arcgisruntime.symbology.UniqueValueRenderer;
 
-
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // inflate MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // create a map with the topographic basemap
-        ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
+    // create a map with the topographic basemap
+    ArcGISMap map = new ArcGISMap(Basemap.createTopographic());
 
-        //[DocRef: Name=Unique Value Renderer, Topic=Symbols and Renderers, Category=Fundamentals]
-        // Create service feature table
-        ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.sample_service_url));
+    //[DocRef: Name=Unique Value Renderer, Topic=Symbols and Renderers, Category=Fundamentals]
+    // Create service feature table
+    ServiceFeatureTable serviceFeatureTable = new ServiceFeatureTable(
+        getResources().getString(R.string.sample_service_url));
 
-        // Create the feature layer using the service feature table
-        FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
+    // Create the feature layer using the service feature table
+    FeatureLayer featureLayer = new FeatureLayer(serviceFeatureTable);
 
-        // Override the renderer of the feature layer with a new unique value renderer
-        UniqueValueRenderer uniqueValueRenderer = new UniqueValueRenderer();
-        // Set the field to use for the unique values
-        uniqueValueRenderer.getFieldNames().add("STATE_ABBR"); //You can add multiple fields to be used for the renderer in the form of a list, in this case we are only adding a single field
+    // Override the renderer of the feature layer with a new unique value renderer
+    UniqueValueRenderer uniqueValueRenderer = new UniqueValueRenderer();
+    // Set the field to use for the unique values
+    uniqueValueRenderer.getFieldNames().add(
+        "STATE_ABBR"); //You can add multiple fields to be used for the renderer in the form of a list, in this case
+      // we are only adding a single field
 
-        // Create the symbols to be used in the renderer
-        SimpleFillSymbol defaultFillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.NULL, Color.BLACK, new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.GRAY, 2));
-        SimpleFillSymbol californiaFillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, Color.RED, new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.RED, 2));
-        SimpleFillSymbol arizonaFillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, Color.GREEN, new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.GREEN, 2));
-        SimpleFillSymbol nevadaFillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID,Color.BLUE, new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.BLUE, 2));
+    // Create the symbols to be used in the renderer
+    SimpleFillSymbol defaultFillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.NULL, Color.BLACK,
+        new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.GRAY, 2));
+    SimpleFillSymbol californiaFillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, Color.RED,
+        new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.RED, 2));
+    SimpleFillSymbol arizonaFillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, Color.GREEN,
+        new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.GREEN, 2));
+    SimpleFillSymbol nevadaFillSymbol = new SimpleFillSymbol(SimpleFillSymbol.Style.SOLID, Color.BLUE,
+        new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.BLUE, 2));
 
-        // Set default symbol
-        uniqueValueRenderer.setDefaultSymbol(defaultFillSymbol);
-        uniqueValueRenderer.setDefaultLabel("Other");
+    // Set default symbol
+    uniqueValueRenderer.setDefaultSymbol(defaultFillSymbol);
+    uniqueValueRenderer.setDefaultLabel("Other");
 
-        // Set value for california
-        List<Object> californiaValue = new ArrayList<>();
-        // You add values associated with fields set on the unique value renderer.
-        // If there are multiple values, they should be set in the same order as the fields are set
-        californiaValue.add("CA");
-        uniqueValueRenderer.getUniqueValues().add(new UniqueValueRenderer.UniqueValue("California", "State of California", californiaFillSymbol, californiaValue));
+    // Set value for california
+    List<Object> californiaValue = new ArrayList<>();
+    // You add values associated with fields set on the unique value renderer.
+    // If there are multiple values, they should be set in the same order as the fields are set
+    californiaValue.add("CA");
+    uniqueValueRenderer.getUniqueValues().add(
+        new UniqueValueRenderer.UniqueValue("California", "State of California", californiaFillSymbol,
+            californiaValue));
 
-        // Set value for arizona
-        List<Object> arizonaValue = new ArrayList<>();
-        // You add values associated with fields set on the unique value renderer.
-        // If there are multiple values, they should be set in the same order as the fields are set
-        arizonaValue.add("AZ");
-        uniqueValueRenderer.getUniqueValues().add(new UniqueValueRenderer.UniqueValue("Arizona", "State of Arizona", arizonaFillSymbol, arizonaValue));
+    // Set value for arizona
+    List<Object> arizonaValue = new ArrayList<>();
+    // You add values associated with fields set on the unique value renderer.
+    // If there are multiple values, they should be set in the same order as the fields are set
+    arizonaValue.add("AZ");
+    uniqueValueRenderer.getUniqueValues()
+        .add(new UniqueValueRenderer.UniqueValue("Arizona", "State of Arizona", arizonaFillSymbol, arizonaValue));
 
-        // Set value for nevada
-        List<Object> nevadaValue = new ArrayList<>();
-        // You add values associated with fields set on the unique value renderer.
-        // If there are multiple values, they should be set in the same order as the fields are set
-        nevadaValue.add("NV");
-        uniqueValueRenderer.getUniqueValues().add(new UniqueValueRenderer.UniqueValue("Nevada", "State of Nevada", nevadaFillSymbol, nevadaValue));
+    // Set value for nevada
+    List<Object> nevadaValue = new ArrayList<>();
+    // You add values associated with fields set on the unique value renderer.
+    // If there are multiple values, they should be set in the same order as the fields are set
+    nevadaValue.add("NV");
+    uniqueValueRenderer.getUniqueValues()
+        .add(new UniqueValueRenderer.UniqueValue("Nevada", "State of Nevada", nevadaFillSymbol, nevadaValue));
 
-        // Set the renderer on the feature layer
-        featureLayer.setRenderer(uniqueValueRenderer);
-        //[DocRef: END]
+    // Set the renderer on the feature layer
+    featureLayer.setRenderer(uniqueValueRenderer);
+    //[DocRef: END]
 
-        // add the layer to the map
-        map.getOperationalLayers().add(featureLayer);
+    // add the layer to the map
+    map.getOperationalLayers().add(featureLayer);
 
-        map.setInitialViewpoint(new Viewpoint(new Envelope(-13893029.0, 3573174.0, -12038972.0, 5309823.0, SpatialReferences.getWebMercator())));
+    map.setInitialViewpoint(new Viewpoint(
+        new Envelope(-13893029.0, 3573174.0, -12038972.0, 5309823.0, SpatialReferences.getWebMercator())));
 
-        // set the map to be displayed in the mapview
-        mMapView.setMap(map);
+    // set the map to be displayed in the mapview
+    mMapView.setMap(map);
 
-    }
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
 
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
-    }
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
 }

--- a/java/update-related-features/src/main/java/com/esri/arcgisruntime/sample/updaterelatedfeatures/MainActivity.java
+++ b/java/update-related-features/src/main/java/com/esri/arcgisruntime/sample/updaterelatedfeatures/MainActivity.java
@@ -18,6 +18,7 @@ package com.esri.arcgisruntime.sample.updaterelatedfeatures;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+
 import android.app.ProgressDialog;
 import android.graphics.Color;
 import android.graphics.Point;
@@ -49,262 +50,274 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    private ServiceFeatureTable mParksFeatureTable;
-    private FeatureLayer mParksFeatureLayer;
-    private ArcGISFeature mSelectedArcGISFeature;
-    private ServiceFeatureTable mPreservesFeatureTable;
-    private ArcGISFeature mSelectedRelatedFeature;
+  private ServiceFeatureTable mParksFeatureTable;
+  private FeatureLayer mParksFeatureLayer;
+  private ArcGISFeature mSelectedArcGISFeature;
+  private ServiceFeatureTable mPreservesFeatureTable;
+  private ArcGISFeature mSelectedRelatedFeature;
 
-    private Point mTappedPoint;
-    private Callout mCallout;
+  private Point mTappedPoint;
+  private Callout mCallout;
 
-    private ProgressDialog mProgressDialog;
-    private String mAttributeValue;
+  private ProgressDialog mProgressDialog;
+  private String mAttributeValue;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // create MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
-        // center the map over AK
-        ArcGISMap map = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 65.399121, -151.521682, 4);
-        // get callout and set style
-        mCallout = mMapView.getCallout();
-        Callout.Style calloutStyle = new Callout.Style(this, R.xml.callout_style);
-        mCallout.setStyle(calloutStyle);
-        // create progress dialog and set title
-        mProgressDialog = new ProgressDialog(this);
-        mProgressDialog.setTitle(getResources().getString(R.string.app_name));
-        // set up feature tables and layers
-        mParksFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.parks_feature_table));
-        mParksFeatureLayer = new FeatureLayer(mParksFeatureTable);
-        mParksFeatureLayer.setSelectionColor(Color.YELLOW);
-        mParksFeatureLayer.setSelectionWidth(5);
-        mPreservesFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.preserves_feature_table));
-        FeatureLayer preservesFeatureLayer = new FeatureLayer(mPreservesFeatureTable);
-        // add feature layers to map
-        map.getOperationalLayers().add(mParksFeatureLayer);
-        map.getOperationalLayers().add(preservesFeatureLayer);
-        // set the mArcGISMap to be displayed in this view
-        mMapView.setMap(map);
-        // identify feature 
-        mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView){
-            @Override
-            public boolean onSingleTapConfirmed(MotionEvent me){
-                mProgressDialog.setMessage(getResources().getString(R.string.progress_identify));
-                mProgressDialog.show();
-                // tapped point
-                mTappedPoint = new Point((int)me.getX(), (int)me.getY());
-                // clear any selected features or callouts
-                mParksFeatureLayer.clearSelection();
-                if(mCallout.isShowing()){
-                    mCallout.dismiss();
-                }
-
-                final ListenableFuture<IdentifyLayerResult> identifyFuture = mMapView.identifyLayerAsync(
-                        mParksFeatureLayer, mTappedPoint, 5, false, 1);
-                identifyFuture.addDoneListener(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            mProgressDialog.dismiss();
-                            // call get on the future to get the result
-                            IdentifyLayerResult layerResult = identifyFuture.get();
-
-                            if(layerResult.getElements().size() > 0){
-                                mSelectedArcGISFeature = (ArcGISFeature)layerResult.getElements().get(0);
-                                // highlight the selected feature
-                                mParksFeatureLayer.selectFeature(mSelectedArcGISFeature);
-                                mProgressDialog.setMessage(getResources().getString(R.string.progress_query));
-                                mProgressDialog.show();
-                                queryRelatedFeatures(mSelectedArcGISFeature);
-                            }
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        } catch (ExecutionException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                });
-                return super.onSingleTapConfirmed(me);
-            }
-        });
-    }
-
-    /**
-     * Query related features from selected feature
-     * @param feature selected feature
-     */
-    private void queryRelatedFeatures(ArcGISFeature feature){
-        final ListenableFuture<List<RelatedFeatureQueryResult>> relatedFeatureQueryResultFuture = mParksFeatureTable.queryRelatedFeaturesAsync(feature);
-
-        relatedFeatureQueryResultFuture.addDoneListener(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    mProgressDialog.dismiss();
-                    List<RelatedFeatureQueryResult> relatedFeatureQueryResultList = relatedFeatureQueryResultFuture.get();
-
-                    // iterate over returned RelatedFeatureQueryResults
-                    for(RelatedFeatureQueryResult relatedQueryResult : relatedFeatureQueryResultList){
-                        // iterate over Features returned
-                        for (Feature relatedFeature : relatedQueryResult) {
-                            // persist selected related feature
-                            mSelectedRelatedFeature = (ArcGISFeature) relatedFeature;
-                            // get preserve park name
-                            String parkName = mSelectedRelatedFeature.getAttributes().get("UNIT_NAME").toString();
-                            // use the Annual Visitors field to use as filter on related attributes
-                            mAttributeValue = mSelectedRelatedFeature.getAttributes().get("ANNUAL_VISITORS").toString();
-                            showCallout(parkName);
-                            // center on tapped point
-                            mMapView.setViewpointCenterAsync(mMapView.screenToLocation(mTappedPoint));
-                        }
-                    }
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                } catch (ExecutionException e) {
-                    e.printStackTrace();
-                }
-            }
-        });
-    }
-
-    /**
-     * Show a callout with Attribute Key and editable Value
-     * @param parkName preserves park name
-     */
-    private void showCallout(String parkName){
-        // create a text view for the callout
-        View calloutLayout = LayoutInflater.from(getApplicationContext()).inflate(R.layout.callout, null);
-        // create a text view and add park name
-        TextView parkText = (TextView) calloutLayout.findViewById(R.id.attribute);
-        String parkLabel = String.format(getResources().getString(R.string.callout_label), parkName);
-        parkText.setText(parkLabel);
-        // create spinner with selection options
-        final Spinner visitorSpinner = (Spinner) calloutLayout.findViewById(R.id.spinner_values);
-        // create an array adapter using the string array and default spinner layout
-        final ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(
-                getApplicationContext(), R.array.visitors_range, android.R.layout.simple_spinner_item);
-        // Specify the layout to use when the list of choices appear
-        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        // apply the adapter to the spinner
-        visitorSpinner.setAdapter(adapter);
-        visitorSpinner.setSelection(getIndex(visitorSpinner, mAttributeValue));
-        // show callout at tapped location
-        mCallout.setLocation(mMapView.screenToLocation(mTappedPoint));
-        mCallout.setContent(calloutLayout);
-        mCallout.show();
-        // respond to user interaction
-        visitorSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                // check if selection has changed
-                String selectedValue = visitorSpinner.getSelectedItem().toString();
-                if(!selectedValue.equalsIgnoreCase(mAttributeValue)){
-                    // selection changed, update the related feature
-                    mCallout.dismiss();
-                    mProgressDialog.setMessage(getResources().getString(R.string.progress_update));
-                    mProgressDialog.show();
-                    updateRelatedFeature(selectedValue);
-                }
-            }
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-                //
-            }
-        });
-
-    }
-
-    /**
-     * Update the related feature table and apply update on the server
-     * @param visitors annual visitors value
-     */
-    private void updateRelatedFeature(final String visitors){
-        // load the related feature
-        mSelectedRelatedFeature.loadAsync();
-        mSelectedRelatedFeature.addDoneLoadingListener(new Runnable() {
-            @Override
-            public void run() {
-                if(mSelectedRelatedFeature.getLoadStatus() == LoadStatus.LOADED){
-                    // put new attribute value
-                    mSelectedRelatedFeature.getAttributes().put("ANNUAL_VISITORS", visitors);
-                    // persist the attribute value
-                    mAttributeValue = visitors;
-                    // update feature in the related feature table
-                    ListenableFuture<Void> updateFeature = mPreservesFeatureTable.updateFeatureAsync(mSelectedRelatedFeature);
-                    updateFeature.addDoneListener(new Runnable() {
-                        @Override
-                        public void run() {
-                            // apply update to the server
-                            final ListenableFuture<List<FeatureEditResult>> serverResult = mPreservesFeatureTable.applyEditsAsync();
-                            serverResult.addDoneListener(new Runnable() {
-                                @Override
-                                public void run() {
-                                    try {
-                                        // check if server result successful
-                                        List<FeatureEditResult> edits = serverResult.get();
-                                        if(edits.size() > 0){
-                                            if(!edits.get(0).hasCompletedWithErrors()){
-                                                mParksFeatureLayer.clearSelection();
-                                                mProgressDialog.dismiss();
-                                                Toast.makeText(getApplicationContext(), getResources().getString(R.string.update_success), Toast.LENGTH_SHORT).show();
-                                                // show callout with new value
-                                                mCallout.show();
-                                            }else{
-                                                mProgressDialog.dismiss();
-                                                Toast.makeText(getApplicationContext(), getResources().getString(R.string.update_fail), Toast.LENGTH_LONG).show();
-                                            }
-                                        }
-                                    } catch (InterruptedException e) {
-                                        e.printStackTrace();
-                                    } catch (ExecutionException e) {
-                                        e.printStackTrace();
-                                    }
-                                }
-                            });
-                        }
-                    });
-                }
-            }
-        });
-    }
-
-    /**
-     * Get the position of attribute value
-     * @param spinner spinner with list of selection options
-     * @param value attribute value
-     * @return position of attribute value
-     */
-    private int getIndex(Spinner spinner, String value){
-        if(value == null || spinner.getCount() == 0){
-            return -1;
-        }else{
-            for (int i=0; i < spinner.getCount(); i++) {
-                if (spinner.getItemAtPosition(i).toString().equalsIgnoreCase(value)) {
-                    return i;
-
-                }
-            }
+    // create MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
+    // center the map over AK
+    ArcGISMap map = new ArcGISMap(Basemap.Type.TOPOGRAPHIC, 65.399121, -151.521682, 4);
+    // get callout and set style
+    mCallout = mMapView.getCallout();
+    Callout.Style calloutStyle = new Callout.Style(this, R.xml.callout_style);
+    mCallout.setStyle(calloutStyle);
+    // create progress dialog and set title
+    mProgressDialog = new ProgressDialog(this);
+    mProgressDialog.setTitle(getResources().getString(R.string.app_name));
+    // set up feature tables and layers
+    mParksFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.parks_feature_table));
+    mParksFeatureLayer = new FeatureLayer(mParksFeatureTable);
+    mParksFeatureLayer.setSelectionColor(Color.YELLOW);
+    mParksFeatureLayer.setSelectionWidth(5);
+    mPreservesFeatureTable = new ServiceFeatureTable(getResources().getString(R.string.preserves_feature_table));
+    FeatureLayer preservesFeatureLayer = new FeatureLayer(mPreservesFeatureTable);
+    // add feature layers to map
+    map.getOperationalLayers().add(mParksFeatureLayer);
+    map.getOperationalLayers().add(preservesFeatureLayer);
+    // set the mArcGISMap to be displayed in this view
+    mMapView.setMap(map);
+    // identify feature
+    mMapView.setOnTouchListener(new DefaultMapViewOnTouchListener(this, mMapView) {
+      @Override
+      public boolean onSingleTapConfirmed(MotionEvent me) {
+        mProgressDialog.setMessage(getResources().getString(R.string.progress_identify));
+        mProgressDialog.show();
+        // tapped point
+        mTappedPoint = new Point((int) me.getX(), (int) me.getY());
+        // clear any selected features or callouts
+        mParksFeatureLayer.clearSelection();
+        if (mCallout.isShowing()) {
+          mCallout.dismiss();
         }
-        return -1;
-    }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+        final ListenableFuture<IdentifyLayerResult> identifyFuture = mMapView.identifyLayerAsync(
+            mParksFeatureLayer, mTappedPoint, 5, false, 1);
+        identifyFuture.addDoneListener(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              mProgressDialog.dismiss();
+              // call get on the future to get the result
+              IdentifyLayerResult layerResult = identifyFuture.get();
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
+              if (layerResult.getElements().size() > 0) {
+                mSelectedArcGISFeature = (ArcGISFeature) layerResult.getElements().get(0);
+                // highlight the selected feature
+                mParksFeatureLayer.selectFeature(mSelectedArcGISFeature);
+                mProgressDialog.setMessage(getResources().getString(R.string.progress_query));
+                mProgressDialog.show();
+                queryRelatedFeatures(mSelectedArcGISFeature);
+              }
+            } catch (InterruptedException e) {
+              e.printStackTrace();
+            } catch (ExecutionException e) {
+              e.printStackTrace();
+            }
+          }
+        });
+        return super.onSingleTapConfirmed(me);
+      }
+    });
+  }
+
+  /**
+   * Query related features from selected feature
+   *
+   * @param feature selected feature
+   */
+  private void queryRelatedFeatures(ArcGISFeature feature) {
+    final ListenableFuture<List<RelatedFeatureQueryResult>> relatedFeatureQueryResultFuture = mParksFeatureTable
+        .queryRelatedFeaturesAsync(feature);
+
+    relatedFeatureQueryResultFuture.addDoneListener(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          mProgressDialog.dismiss();
+          List<RelatedFeatureQueryResult> relatedFeatureQueryResultList = relatedFeatureQueryResultFuture.get();
+
+          // iterate over returned RelatedFeatureQueryResults
+          for (RelatedFeatureQueryResult relatedQueryResult : relatedFeatureQueryResultList) {
+            // iterate over Features returned
+            for (Feature relatedFeature : relatedQueryResult) {
+              // persist selected related feature
+              mSelectedRelatedFeature = (ArcGISFeature) relatedFeature;
+              // get preserve park name
+              String parkName = mSelectedRelatedFeature.getAttributes().get("UNIT_NAME").toString();
+              // use the Annual Visitors field to use as filter on related attributes
+              mAttributeValue = mSelectedRelatedFeature.getAttributes().get("ANNUAL_VISITORS").toString();
+              showCallout(parkName);
+              // center on tapped point
+              mMapView.setViewpointCenterAsync(mMapView.screenToLocation(mTappedPoint));
+            }
+          }
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        } catch (ExecutionException e) {
+          e.printStackTrace();
+        }
+      }
+    });
+  }
+
+  /**
+   * Show a callout with Attribute Key and editable Value
+   *
+   * @param parkName preserves park name
+   */
+  private void showCallout(String parkName) {
+    // create a text view for the callout
+    View calloutLayout = LayoutInflater.from(getApplicationContext()).inflate(R.layout.callout, null);
+    // create a text view and add park name
+    TextView parkText = (TextView) calloutLayout.findViewById(R.id.attribute);
+    String parkLabel = String.format(getResources().getString(R.string.callout_label), parkName);
+    parkText.setText(parkLabel);
+    // create spinner with selection options
+    final Spinner visitorSpinner = (Spinner) calloutLayout.findViewById(R.id.spinner_values);
+    // create an array adapter using the string array and default spinner layout
+    final ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(
+        getApplicationContext(), R.array.visitors_range, android.R.layout.simple_spinner_item);
+    // Specify the layout to use when the list of choices appear
+    adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+    // apply the adapter to the spinner
+    visitorSpinner.setAdapter(adapter);
+    visitorSpinner.setSelection(getIndex(visitorSpinner, mAttributeValue));
+    // show callout at tapped location
+    mCallout.setLocation(mMapView.screenToLocation(mTappedPoint));
+    mCallout.setContent(calloutLayout);
+    mCallout.show();
+    // respond to user interaction
+    visitorSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+      @Override
+      public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+        // check if selection has changed
+        String selectedValue = visitorSpinner.getSelectedItem().toString();
+        if (!selectedValue.equalsIgnoreCase(mAttributeValue)) {
+          // selection changed, update the related feature
+          mCallout.dismiss();
+          mProgressDialog.setMessage(getResources().getString(R.string.progress_update));
+          mProgressDialog.show();
+          updateRelatedFeature(selectedValue);
+        }
+      }
+
+      @Override
+      public void onNothingSelected(AdapterView<?> parent) {
+      }
+    });
+
+  }
+
+  /**
+   * Update the related feature table and apply update on the server
+   *
+   * @param visitors annual visitors value
+   */
+  private void updateRelatedFeature(final String visitors) {
+    // load the related feature
+    mSelectedRelatedFeature.loadAsync();
+    mSelectedRelatedFeature.addDoneLoadingListener(new Runnable() {
+      @Override
+      public void run() {
+        if (mSelectedRelatedFeature.getLoadStatus() == LoadStatus.LOADED) {
+          // put new attribute value
+          mSelectedRelatedFeature.getAttributes().put("ANNUAL_VISITORS", visitors);
+          // persist the attribute value
+          mAttributeValue = visitors;
+          // update feature in the related feature table
+          ListenableFuture<Void> updateFeature = mPreservesFeatureTable.updateFeatureAsync(mSelectedRelatedFeature);
+          updateFeature.addDoneListener(new Runnable() {
+            @Override
+            public void run() {
+              // apply update to the server
+              final ListenableFuture<List<FeatureEditResult>> serverResult = mPreservesFeatureTable.applyEditsAsync();
+              serverResult.addDoneListener(new Runnable() {
+                @Override
+                public void run() {
+                  try {
+                    // check if server result successful
+                    List<FeatureEditResult> edits = serverResult.get();
+                    if (edits.size() > 0) {
+                      if (!edits.get(0).hasCompletedWithErrors()) {
+                        mParksFeatureLayer.clearSelection();
+                        mProgressDialog.dismiss();
+                        Toast.makeText(getApplicationContext(), getResources().getString(R.string.update_success), Toast.LENGTH_SHORT).show();
+                        // show callout with new value
+                        mCallout.show();
+                      } else {
+                        mProgressDialog.dismiss();
+                        Toast.makeText(getApplicationContext(), getResources().getString(R.string.update_fail), Toast.LENGTH_LONG).show();
+                      }
+                    }
+                  } catch (InterruptedException e) {
+                    e.printStackTrace();
+                  } catch (ExecutionException e) {
+                    e.printStackTrace();
+                  }
+                }
+              });
+            }
+          });
+        }
+      }
+    });
+  }
+
+  /**
+   * Get the position of attribute value
+   *
+   * @param spinner spinner with list of selection options
+   * @param value   attribute value
+   * @return position of attribute value
+   */
+  private int getIndex(Spinner spinner, String value) {
+    if (value == null || spinner.getCount() == 0) {
+      return -1;
+    } else {
+      for (int i = 0; i < spinner.getCount(); i++) {
+        if (spinner.getItemAtPosition(i).toString().equalsIgnoreCase(value)) {
+          return i;
+
+        }
+      }
     }
+    return -1;
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
 }

--- a/java/viewshed-camera/src/main/AndroidManifest.xml
+++ b/java/viewshed-camera/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize">
+        <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/viewshed-camera/src/main/java/com/esri/arcgisruntime/sample/viewshedcamera/MainActivity.java
+++ b/java/viewshed-camera/src/main/java/com/esri/arcgisruntime/sample/viewshedcamera/MainActivity.java
@@ -87,4 +87,11 @@ public class MainActivity extends AppCompatActivity {
     // resume SceneView
     mSceneView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose SceneView
+    mSceneView.dispose();
+  }
 }

--- a/java/viewshed-geoelement/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoelement/MainActivity.java
+++ b/java/viewshed-geoelement/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoelement/MainActivity.java
@@ -264,4 +264,10 @@ public class MainActivity extends AppCompatActivity {
     mSceneView.resume();
   }
 
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose SceneView
+    mSceneView.dispose();
+  }
 }

--- a/java/viewshed-geoprocessing/src/main/AndroidManifest.xml
+++ b/java/viewshed-geoprocessing/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
         <activity
             android:name="com.esri.arcgisruntime.sample.viewshedgeoprocessing.MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/viewshed-geoprocessing/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoprocessing/MainActivity.java
+++ b/java/viewshed-geoprocessing/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoprocessing/MainActivity.java
@@ -217,4 +217,10 @@ public class MainActivity extends AppCompatActivity {
     super.onResume();
     mMapView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/java/viewshed-location/src/main/java/com/esri/arcgisruntime/sample/viewshedlocation/MainActivity.java
+++ b/java/viewshed-location/src/main/java/com/esri/arcgisruntime/sample/viewshedlocation/MainActivity.java
@@ -349,4 +349,10 @@ public class MainActivity extends AppCompatActivity {
     super.onResume();
     mSceneView.resume();
   }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mSceneView.dispose();
+  }
 }

--- a/java/web-tiledlayer/src/main/java/com/esri/arcgisruntime/sample/webtiledlayer/MainActivity.java
+++ b/java/web-tiledlayer/src/main/java/com/esri/arcgisruntime/sample/webtiledlayer/MainActivity.java
@@ -18,6 +18,7 @@ package com.esri.arcgisruntime.sample.webtiledlayer;
 
 import java.util.Arrays;
 import java.util.List;
+
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -29,52 +30,60 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // access MapView from layout
-        mMapView = (MapView) findViewById(R.id.mapView);
+    // access MapView from layout
+    mMapView = (MapView) findViewById(R.id.mapView);
 
-        // list of subdomains
-        List<String> subDomains = Arrays.asList("a", "b", "c", "d");
-        // url pattern
-        String templateUri = "http://{subDomain}.tile.stamen.com/terrain/{level}/{col}/{row}.png";
+    // list of subdomains
+    List<String> subDomains = Arrays.asList("a", "b", "c", "d");
+    // url pattern
+    String templateUri = "http://{subDomain}.tile.stamen.com/terrain/{level}/{col}/{row}.png";
 
-        // webtile layer
-        final WebTiledLayer webTiledLayer = new WebTiledLayer(templateUri, subDomains);
-        webTiledLayer.loadAsync();
-        webTiledLayer.addDoneLoadingListener(new Runnable() {
-            @Override
-            public void run() {
-                if(webTiledLayer.getLoadStatus() == LoadStatus.LOADED){
-                    // use webtile layer as Basemap
-                    ArcGISMap map = new ArcGISMap(new Basemap(webTiledLayer));
-                    mMapView.setMap(map);
-                    // custom attributes
-                    webTiledLayer.setAttribution("Map tiles by <a href=\"http://stamen.com/\">Stamen Design</a>, " +
-                            "under <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a>. " +
-                            "Data by <a href=\"http://openstreetmap.org/\">OpenStreetMap</a>, " +
-                            "under <a href=\"http://creativecommons.org/licenses/by-sa/3.0\">CC BY SA</a>.");
-                }
-            }
-        });
-    }
+    // webtile layer
+    final WebTiledLayer webTiledLayer = new WebTiledLayer(templateUri, subDomains);
+    webTiledLayer.loadAsync();
+    webTiledLayer.addDoneLoadingListener(new Runnable() {
+      @Override
+      public void run() {
+        if (webTiledLayer.getLoadStatus() == LoadStatus.LOADED) {
+          // use webtile layer as Basemap
+          ArcGISMap map = new ArcGISMap(new Basemap(webTiledLayer));
+          mMapView.setMap(map);
+          // custom attributes
+          webTiledLayer.setAttribution("Map tiles by <a href=\"http://stamen.com/\">Stamen Design</a>, " +
+              "under <a href=\"http://creativecommons.org/licenses/by/3.0\">CC BY 3.0</a>. " +
+              "Data by <a href=\"http://openstreetmap.org/\">OpenStreetMap</a>, " +
+              "under <a href=\"http://creativecommons.org/licenses/by-sa/3.0\">CC BY SA</a>.");
+        }
+      }
+    });
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        // pause MapView
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    // pause MapView
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        // resume MapView
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    // resume MapView
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // dispose MapView
+    mMapView.dispose();
+  }
+}
 }

--- a/java/web-tiledlayer/src/main/java/com/esri/arcgisruntime/sample/webtiledlayer/MainActivity.java
+++ b/java/web-tiledlayer/src/main/java/com/esri/arcgisruntime/sample/webtiledlayer/MainActivity.java
@@ -86,4 +86,3 @@ public class MainActivity extends AppCompatActivity {
     mMapView.dispose();
   }
 }
-}

--- a/java/wms-layer-url/src/main/AndroidManifest.xml
+++ b/java/wms-layer-url/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/java/wms-layer-url/src/main/java/com/esri/arcgisruntime/sample/wmslayerurl/MainActivity.java
+++ b/java/wms-layer-url/src/main/java/com/esri/arcgisruntime/sample/wmslayerurl/MainActivity.java
@@ -29,40 +29,46 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 
 public class MainActivity extends AppCompatActivity {
 
-    private MapView mMapView;
+  private MapView mMapView;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
 
-        // inflate MapView from layout
-        mMapView = findViewById(R.id.mapView);
-        // create a map with the BasemapType topographic
-        ArcGISMap map = new ArcGISMap(Basemap.Type.IMAGERY, 2.0, 18.0, 3);
-        // set the map to be displayed in this view
-        mMapView.setMap(map);
+    // inflate MapView from layout
+    mMapView = findViewById(R.id.mapView);
+    // create a map with the BasemapType topographic
+    ArcGISMap map = new ArcGISMap(Basemap.Type.IMAGERY, 2.0, 18.0, 3);
+    // set the map to be displayed in this view
+    mMapView.setMap(map);
 
-        // hold a list of uniquely-identifying WMS layer names to display
-        List<String> wmsLayerNames = new ArrayList<>();
-        wmsLayerNames.add("0");
+    // hold a list of uniquely-identifying WMS layer names to display
+    List<String> wmsLayerNames = new ArrayList<>();
+    wmsLayerNames.add("0");
 
-        // create a new WMS layer displaying the specified layers from the service
-        WmsLayer wmsLayer = new WmsLayer(getString(R.string.wms_layer_url), wmsLayerNames);
+    // create a new WMS layer displaying the specified layers from the service
+    WmsLayer wmsLayer = new WmsLayer(getString(R.string.wms_layer_url), wmsLayerNames);
 
-        // add the layer to the map
-        map.getOperationalLayers().add(wmsLayer);
-    }
+    // add the layer to the map
+    map.getOperationalLayers().add(wmsLayer);
+  }
 
-    @Override
-    protected void onPause(){
-        super.onPause();
-        mMapView.pause();
-    }
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mMapView.pause();
+  }
 
-    @Override
-    protected void onResume(){
-        super.onResume();
-        mMapView.resume();
-    }
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mMapView.resume();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mMapView.dispose();
+  }
 }

--- a/kotlin/analyze-hotspots/src/main/AndroidManifest.xml
+++ b/kotlin/analyze-hotspots/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name"
-            android:configChanges="orientation|screenSize|uiMode">
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/kotlin/analyze-hotspots/src/main/java/com/esri/arcgisruntime/sample/analyzehotspots/MainActivity.kt
+++ b/kotlin/analyze-hotspots/src/main/java/com/esri/arcgisruntime/sample/analyzehotspots/MainActivity.kt
@@ -231,4 +231,9 @@ class MainActivity : AppCompatActivity() {
         super.onResume()
         mapView.resume()
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView.dispose()
+    }
 }

--- a/kotlin/attribution-view-change/src/main/java/com/esri/arcgisruntime/sample/attributionchange/MainActivity.kt
+++ b/kotlin/attribution-view-change/src/main/java/com/esri/arcgisruntime/sample/attributionchange/MainActivity.kt
@@ -61,4 +61,9 @@ class MainActivity : AppCompatActivity() {
         super.onResume()
         mapView.resume()
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView.dispose()
+    }
 }

--- a/kotlin/display-map/src/main/java/com/esri/arcgisruntime/sample/displaymap/MainActivity.kt
+++ b/kotlin/display-map/src/main/java/com/esri/arcgisruntime/sample/displaymap/MainActivity.kt
@@ -16,16 +16,16 @@
 
 package com.esri.arcgisruntime.sample.displaymap
 
+import android.support.v7.app.AppCompatActivity
+import android.os.Bundle
+
 //[DocRef: Name=Import map types-Android, Category=Get started, Topic=Develop your first map app with Kotlin]
+import com.esri.arcgisruntime.mapping.ArcGISMap
+import com.esri.arcgisruntime.mapping.Basemap
 //[DocRef: END]
 
 //[DocRef: Name=Import kotlinx-Android, Category=Get started, Topic=Develop your first map app with Kotlin]
-import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
-import com.esri.arcgisruntime.mapping.ArcGISMap
-import com.esri.arcgisruntime.mapping.Basemap
 import kotlinx.android.synthetic.main.activity_main.*
-
 //[DocRef: END]
 
 class MainActivity : AppCompatActivity() {

--- a/kotlin/display-map/src/main/java/com/esri/arcgisruntime/sample/displaymap/MainActivity.kt
+++ b/kotlin/display-map/src/main/java/com/esri/arcgisruntime/sample/displaymap/MainActivity.kt
@@ -16,45 +16,50 @@
 
 package com.esri.arcgisruntime.sample.displaymap
 
-import android.support.v7.app.AppCompatActivity
-import android.os.Bundle
-
 //[DocRef: Name=Import map types-Android, Category=Get started, Topic=Develop your first map app with Kotlin]
-import com.esri.arcgisruntime.mapping.ArcGISMap
-import com.esri.arcgisruntime.mapping.Basemap
 //[DocRef: END]
 
 //[DocRef: Name=Import kotlinx-Android, Category=Get started, Topic=Develop your first map app with Kotlin]
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import com.esri.arcgisruntime.mapping.ArcGISMap
+import com.esri.arcgisruntime.mapping.Basemap
 import kotlinx.android.synthetic.main.activity_main.*
+
 //[DocRef: END]
 
 class MainActivity : AppCompatActivity() {
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    setContentView(R.layout.activity_main)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
 
-    //[DocRef: Name=Create map-Android, Category=Get started, Topic=Develop your first map app with Kotlin]
-    // create a map with the BasemapType topographic
-    val map = ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 16)
+        //[DocRef: Name=Create map-Android, Category=Get started, Topic=Develop your first map app with Kotlin]
+        // create a map with the BasemapType topographic
+        val map = ArcGISMap(Basemap.Type.TOPOGRAPHIC, 34.056295, -117.195800, 16)
+        //[DocRef: END]
+
+        //[DocRef: Name=Set map-Android, Category=Get started, Topic=Develop your first map app with Kotlin]
+        // set the map to be displayed in the layout's MapView
+        mapView.map = map
+        //[DocRef: END]
+
+    }
+
+    //[DocRef: Name=Pause and resume-Android, Category=Get started, Topic=Develop your first map app with Kotlin]
+    override fun onPause() {
+        super.onPause()
+        mapView.pause()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        mapView.resume()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView.dispose()
+    }
     //[DocRef: END]
-
-    //[DocRef: Name=Set map-Android, Category=Get started, Topic=Develop your first map app with Kotlin]
-    // set the map to be displayed in the layout's MapView
-    mapView.map = map
-    //[DocRef: END]
-
-  }
-
-  //[DocRef: Name=Pause and resume-Android, Category=Get started, Topic=Develop your first map app with Kotlin]
-  override fun onPause() {
-    super.onPause()
-    mapView.pause()
-  }
-
-  override fun onResume() {
-    super.onResume()
-    mapView.resume()
-  }
-  //[DocRef: END]
 }

--- a/kotlin/feature-layer-extrusion/src/main/java/com/esri/arcgisruntime/sample/featurelayerextrusion/MainActivity.kt
+++ b/kotlin/feature-layer-extrusion/src/main/java/com/esri/arcgisruntime/sample/featurelayerextrusion/MainActivity.kt
@@ -104,4 +104,9 @@ class MainActivity : AppCompatActivity() {
     super.onResume()
     sceneView.resume()
   }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    sceneView.dispose()
+  }
 }

--- a/kotlin/raster-function-service/src/main/java/com/esri/arcgisruntime/samples/rasterfunctionservice/MainActivity.kt
+++ b/kotlin/raster-function-service/src/main/java/com/esri/arcgisruntime/samples/rasterfunctionservice/MainActivity.kt
@@ -85,4 +85,9 @@ class MainActivity : AppCompatActivity() {
         super.onResume()
         mapView.resume()
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView.dispose()
+    }
 }

--- a/kotlin/raster-rendering-rule/src/main/java/com/esri/arcgisruntime/samples/renderingrule/MainActivity.kt
+++ b/kotlin/raster-rendering-rule/src/main/java/com/esri/arcgisruntime/samples/renderingrule/MainActivity.kt
@@ -111,4 +111,9 @@ class MainActivity : AppCompatActivity() {
         super.onResume()
         mapView.resume()
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView.dispose()
+    }
 }

--- a/kotlin/wmts-layer/src/main/java/com/esri/arcgisruntime/sample/wmtslayer/MainActivity.kt
+++ b/kotlin/wmts-layer/src/main/java/com/esri/arcgisruntime/sample/wmtslayer/MainActivity.kt
@@ -63,4 +63,9 @@ class MainActivity : AppCompatActivity() {
         super.onResume()
         mapView.resume()
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView.dispose()
+    }
 }


### PR DESCRIPTION
This PR covers the following code fixes:
- Remove `android:configChanges="..."` from all modules EXCEPT 'Feature layer rendering mode map' and 'Feature layer rendering mode scene' because of hard crash on device rotation during zoom events
- Adds `MapView/SceneView.dispose()`to the `onDestroy()` callback in all modules with a `SceneView/MapView`
- Unifies all samples to ESRI preferred code formatting (ie two spaces instead of tab, enums or inner classes at bottom, etc)
- Makes all TAGs derived from `= CLASSNAME.class.getSimpleName();`

During the course of this PR all modules were tested for rotation handling and for general functionality.