### PR TITLE
fix name conflict to prevent sample viewer crash

### DIFF
--- a/java/distance-composite-symbol/src/main/AndroidManifest.xml
+++ b/java/distance-composite-symbol/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.esri.arcgisruntime.distancecompositesymbol">
+    package="com.esri.arcgisruntime.sample.distancecompositesymbol">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/java/distance-composite-symbol/src/main/java/com/esri/arcgisruntime/sample/distancecompositesymbol/MainActivity.java
+++ b/java/distance-composite-symbol/src/main/java/com/esri/arcgisruntime/sample/distancecompositesymbol/MainActivity.java
@@ -14,7 +14,7 @@
  *
  */
 
-package com.esri.arcgisruntime.distancecompositesymbol;
+package com.esri.arcgisruntime.sample.distancecompositesymbol;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -69,7 +69,7 @@ public class MainActivity extends AppCompatActivity {
 
     // add base surface for elevation data
     Surface surface = new Surface();
-    surface.getElevationSources().add(new ArcGISTiledElevationSource(getString(R.string.world_elevation_service)));
+    surface.getElevationSources().add(new ArcGISTiledElevationSource(getString(R.string.world_elevation_service_3D)));
     scene.setBaseSurface(surface);
 
     // add a graphics overlay

--- a/java/distance-composite-symbol/src/main/res/values/strings.xml
+++ b/java/distance-composite-symbol/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Distance Composite Symbol</string>
-    <string name="world_elevation_service">https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer</string>
+    <string name="world_elevation_service_3D">https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer</string>
     <string name="bristol_dae">Bristol.dae</string>
     <string name="bristol_png">Bristol.png</string>
     <string name="logo_jpg">logo.jpg</string>


### PR DESCRIPTION
Finally figured out what was causing the scene view crash when hitting back on Distance Composite Symbol! Can you review please @LDuncAndroid ?

Thanks!