### PR TITLE
Fix path for honor mmpk exp date

### DIFF
--- a/java/honor-mobile-map-package-expiration-date/README.metadata.json
+++ b/java/honor-mobile-map-package-expiration-date/README.metadata.json
@@ -15,7 +15,7 @@
         "MobileMapPackage"
     ],
     "snippets": [
-        "src/main/java/com/esri/arcgisruntime/sample/honormmpkexpiration/MainActivity.java"
+        "src/main/java/com/esri/arcgisruntime/sample/honormobilemappackageexpirationdate/MainActivity.java"
     ],
     "title": "Honor mobile map package expiration date"
 }


### PR DESCRIPTION
Fixed path in metadata json file for `snippets` property. 

Inaccurate path prevent code file from appearing.

**To reproduce:**
1. Go to https://mark9880-android-java-samples-test-preview-dev.developers.arcgis.com/android/latest/java/sample-code/honor-mobile-map-package-expiration-date/

1. Scroll to **Sample Code**.

1. `MainActivity.java` code file is missing.

I tested the fix on my local machine. Works great.