### PR TITLE
Fix path to sample: displaysceneintabletopar

### DIFF
--- a/java/display-scene-in-tabletop-ar/README.metadata.json
+++ b/java/display-scene-in-tabletop-ar/README.metadata.json
@@ -25,7 +25,7 @@
 	"Surface.setOpacity(...)"
     ],
     "snippets": [
-        "src/main/java/com/esri/arcgisruntime/displaytabletopmapinar/MainActivity.java"
+        "src/main/java/com/esri/arcgisruntime/displaysceneintabletopar/MainActivity.java"
     ],
     "title": "Display scene in tabletop AR"
 }

--- a/java/display-scene-in-tabletop-ar/README.metadata.json
+++ b/java/display-scene-in-tabletop-ar/README.metadata.json
@@ -25,7 +25,7 @@
 	"Surface.setOpacity(...)"
     ],
     "snippets": [
-        "src/main/java/com/esri/arcgisruntime/displaysceneintabletopar/MainActivity.java"
+        "src/main/java/com/esri/arcgisruntime/sample/displaysceneintabletopar/MainActivity.java"
     ],
     "title": "Display scene in tabletop AR"
 }


### PR DESCRIPTION
Section titled **Sample Code** is missing in **Display scene in tabletop AR** sample:

https://master-stage.developers.arcgis.com/android/latest/java/sample-code/display-scene-in-tabletop-ar/.

I corrected code sample (aka snippet) path in  json metadata file so it matches the package path in `MainActivity.java`. Changed code from
```
"snippets": [
        "src/main/java/com/esri/arcgisruntime/displaytabletopmapinar/MainActivity.java"
    ],
```

to this
```
"snippets": [
        "src/main/java/com/esri/arcgisruntime/sample/displaysceneintabletopar/MainActivity.java"
    ],
```

At next publish to web, this sample should publish correctly from the sample repo to the Sample Code tab for Android SDK .