### PR TITLE
Add missing trailing quote marker in Surface placment metadata

### DIFF
--- a/java/surface-placement/README.metadata.json
+++ b/java/surface-placement/README.metadata.json
@@ -15,7 +15,7 @@
         "Relative",
         "Scenes",
         "Sea level",
-		"Surface placement
+        "Surface placement"
     ],
     "redirect_from": "/android/latest/sample-code/surface-placement.htm",
     "relevant_apis": [


### PR DESCRIPTION
Fixes problem with loading the samples in the developers website