### PR TITLE
Add multidex dependency

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -29,12 +29,16 @@ subprojects{
                 implementation "com.android.support:appcompat-v7:$andSupportLibVersion"
                 implementation "com.android.support:design:$andSupportLibVersion"
                 implementation "com.esri.arcgisruntime:arcgis-android:$arcgisVersion"
+                implementation "androidx.multidex:multidex:$multidexVersion"
             }
         }
         project.android {
             compileOptions {
                 sourceCompatibility rootProject.ext.javaVersion
                 targetCompatibility rootProject.ext.javaVersion
+            }
+            defaultConfig {
+                multiDexEnabled true
             }
         }
     }

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -29,12 +29,16 @@ subprojects {
                 implementation "com.android.support:appcompat-v7:$andSupportLibVersion"
                 implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
                 implementation "com.esri.arcgisruntime:arcgis-android:$arcgisVersion"
+                implementation "androidx.multidex:multidex:$multidexVersion"
             }
         }
         project.android {
             compileOptions {
                 sourceCompatibility rootProject.ext.javaVersion
                 targetCompatibility rootProject.ext.javaVersion
+            }
+            defaultConfig {
+                multiDexEnabled true
             }
         }
     }

--- a/version.gradle
+++ b/version.gradle
@@ -10,6 +10,7 @@ ext {
     ankoVersion = '0.10.8'
     andSupportLibVersion = '28.0.0'
     constraintLayoutVersion = '1.1.3'
+    multidexVersion = "2.0.1"
     arcgisVersion = '100.7.0'
     arcgisToolkitVersion = '100.6.1'
     // plugin versions


### PR DESCRIPTION
Android has a limit of 64k methods in a single app (including all libraries on which it depends). Some samples have started to hit that number and Android's way around it (pre API 21) is with multidex. This PR adds multidex dependency at the project level build.gradle script to catch any samples where this might occur. We will remove this when our min API is 21. 