### PR TITLE
set android support versions to binary equivalent androidx versions. 

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -26,8 +26,8 @@ subprojects{
     afterEvaluate {project ->
         if(project.hasProperty("dependencies")){
             dependencies {
-                implementation "com.android.support:appcompat-v7:$andSupportLibVersion"
-                implementation "com.android.support:design:$andSupportLibVersion"
+                implementation "androidx.appcompat:appcompat:$andSupportLibVersion"
+                implementation "com.google.android.material:material:$andSupportLibVersion"
                 implementation "com.esri.arcgisruntime:arcgis-android:$arcgisVersion"
                 implementation "androidx.multidex:multidex:$multidexVersion"
             }

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -26,7 +26,7 @@ subprojects {
     afterEvaluate { project ->
         if (project.hasProperty("dependencies")) {
             dependencies {
-                implementation "com.android.support:appcompat-v7:$andSupportLibVersion"
+                implementation "androidx.appcompat:appcompat:$andSupportLibVersion"
                 implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
                 implementation "com.esri.arcgisruntime:arcgis-android:$arcgisVersion"
                 implementation "androidx.multidex:multidex:$multidexVersion"

--- a/version.gradle
+++ b/version.gradle
@@ -8,7 +8,7 @@ ext {
     // library versions
     kotlinVersion = '1.3.61'
     ankoVersion = '0.10.8'
-    andSupportLibVersion = '28.0.0'
+    andSupportLibVersion = '1.0.0'
     constraintLayoutVersion = '1.1.3'
     multidexVersion = "2.0.1"
     arcgisVersion = '100.7.0'


### PR DESCRIPTION
same libraries, updated names. 
com.android.support:appcompat-v7 v28.0.0 is androidx.appcompat:appcompat v1.0.0
and 
com.android.support:design v28.0.0 is com.google.android.material:material v1.0.0

…see https://developer.android.com/jetpack/androidx/migrate/artifact-mappings

Testing across older android versions seems necessary. Sorry to say I am not quite sure how to go about that other than alerting Hardik, any thoughts @TADraeseke ?