### PR TITLE
Rach9955 showlabels datafix

### DIFF
--- a/java/show-labels-on-layer/src/main/res/values/strings.xml
+++ b/java/show-labels-on-layer/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="app_name">Show Labels on Layer</string>
-    <string name="congressional_districts_url">https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_115th_Congressional_Districts/FeatureServer/0</string>
+    <string name="congressional_districts_url">https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_116th_Congressional_Districts/FeatureServer/0</string>
 </resources>

--- a/kotlin/show-labels-on-layer/src/main/java/com/esri/arcgisruntime/showlabelsonlayer/MainActivity.kt
+++ b/kotlin/show-labels-on-layer/src/main/java/com/esri/arcgisruntime/showlabelsonlayer/MainActivity.kt
@@ -48,7 +48,7 @@ class MainActivity : AppCompatActivity() {
     mapView.map = map
 
     // create a feature layer from an online feature service of US Highways and add it to the map
-    val serviceFeatureTable = ServiceFeatureTable(getString(R.string.us_highways_1))
+    val serviceFeatureTable = ServiceFeatureTable(getString(R.string.congressional_districts_url))
     val featureLayer = FeatureLayer(serviceFeatureTable)
     map.operationalLayers.add(featureLayer)
 
@@ -58,9 +58,7 @@ class MainActivity : AppCompatActivity() {
         // set viewpoint to the center of the US
         mapView.setViewpointAsync(
           Viewpoint(
-            Point(-10974490.0, 4814376.0, 0.0, SpatialReferences.getWebMercator()),
-            20000000.0
-          )
+            featureLayer.fullExtent)
         )
       } else {
         Toast.makeText(

--- a/kotlin/show-labels-on-layer/src/main/res/values/strings.xml
+++ b/kotlin/show-labels-on-layer/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
     <string name="app_name">Show labels on layer</string>
-    <string name="us_highways_1">http://sampleserver6.arcgisonline.com/arcgis/rest/services/USA/MapServer/1</string>
+    <string name="congressional_districts_url">https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_116th_Congressional_Districts/FeatureServer/0</string>
     <string name="error_message">Error loading feature layer: </string>
 </resources>


### PR DESCRIPTION
This PR is to bring the Show Labels on Layer sample data up to date with the readme, which states we use the 116th Congressional District Data. I've updated both the Java and Kotlin sample, and when in the Kotlin sample I simplified the viewpoint logic to match the Java one. @hud10837 please could you take a first look? Thanks! 