### PR TITLE
Update top-level README.md for Update 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Overview
-ArcGIS Runtime SDK for Android v100.7.0 samples.  The `master` branch of this repository contains sample app modules for the latest available version of the [ArcGIS Runtime SDK for Android](https://developers.arcgis.com/android/). Samples released under older versions can be found through the [git tags](https://github.com/Esri/arcgis-runtime-samples-android/tags).  Please read our [wiki](https://github.com/Esri/arcgis-runtime-samples-android/wiki) for help with working with this repository.  
+ArcGIS Runtime SDK for Android v100.8.0 samples.  The `master` branch of this repository contains sample app modules for the latest available version of the [ArcGIS Runtime SDK for Android](https://developers.arcgis.com/android/). Samples released under older versions can be found through the [git tags](https://github.com/Esri/arcgis-runtime-samples-android/tags).  Please read our [wiki](https://github.com/Esri/arcgis-runtime-samples-android/wiki) for help with working with this repository.  
 
 # Prerequisites
 * The samples are building with `compileSdkVersion 28`
@@ -8,7 +8,7 @@ ArcGIS Runtime SDK for Android v100.7.0 samples.  The `master` branch of this re
 ## SDK Maven repo
 The SDK is available through the Bintray Maven repo, you can take a look at the repository with the link below: 
 
-[ ![Download](https://api.bintray.com/packages/esri/arcgis/arcgis-android/images/download.svg?version=100.7.0) ](https://bintray.com/esri/arcgis/arcgis-android/100.7.0/link)
+[ ![Download](https://api.bintray.com/packages/esri/arcgis/arcgis-android/images/download.svg?version=100.8.0) ](https://bintray.com/esri/arcgis/arcgis-android/100.8.0/link)
 
 ## Developer Instructions
 Please read our [developer instructions wiki page](https://github.com/Esri/arcgis-runtime-samples-android/wiki/dev-instructions) to set up your developer environment with Android Studio.  Instructions include forking and cloning the repository for those new to Git.
@@ -62,7 +62,7 @@ Anyone and everyone is welcome to [contribute](.github/CONTRIBUTING.md). We do a
 Please see our [guidelines for contributing doc](https://github.com/Esri/contributing/blob/master/README.md)
 
 ## Licensing
-Copyright 2018 Esri
+Copyright 2020 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 


### PR DESCRIPTION
**DONE IN THIS PR:**
Edit top-level README.md to use Update 8 in visible text and links of **Overview** and **SDK Maven repo** sections.

**TO DO:** 
- Lines 39, 42: Does team want to change text in **Run samples through the sample viewer** section so it says `ArcGIS_Runtime_Sample_Viewer_Android_1008.apk`, instead of `ArcGIS_Runtime_Sample_Viewer_Android_1007.apk`? If you decide on Update 8, make sure you upload that version to Google Play Store.
- Line38: Change the URL for [on ArcGIS Online](https://arcgisruntime.maps.arcgis.com/home/item.html?id=6a214d1f4a374a9a873891707c0411ec) link so it points to Update 7 or Update 8 version of viewer, as appropriate.  _Currently_, URL points to the Update 4 item in the arcgisruntime.maps.arcgis.com org:
`[on ArcGIS Online](https://arcgisruntime.maps.arcgis.com/home/item.html?id=6a214d1f4a374a9a873891707c0411ec)` .

**Note**: I could not find any version of viewer later than version 6 in the arcgisruntime.maps.arcigs.com org: https://arcgisruntime.maps.arcgis.com/home/item.html?id=99ba5b13cfba41ec8bf246e1093156f1

