### PR TITLE
Hud10837/garbage collection fixes

### DIFF
--- a/java/add-enc-exchange-set/src/main/java/com/esri/arcgisruntime/sample/addencexchangeset/MainActivity.java
+++ b/java/add-enc-exchange-set/src/main/java/com/esri/arcgisruntime/sample/addencexchangeset/MainActivity.java
@@ -44,6 +44,7 @@ public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
   private Envelope mCompleteExtent;
+  private EncExchangeSet mEncExchangeSet;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -65,13 +66,13 @@ public class MainActivity extends AppCompatActivity {
     EncEnvironmentSettings.setSencDataPath(getExternalCacheDir().getPath());
 
     // create the Exchange Set passing an array of paths. Update sets can be loaded alongside base data
-    EncExchangeSet encExchangeSet = new EncExchangeSet(
+    mEncExchangeSet = new EncExchangeSet(
         Collections.singleton(getExternalFilesDir(null) + getString(R.string.enc_path)));
-    encExchangeSet.loadAsync();
-    encExchangeSet.addDoneLoadingListener(() -> {
-      if (encExchangeSet.getLoadStatus() == LoadStatus.LOADED) {
+    mEncExchangeSet.loadAsync();
+    mEncExchangeSet.addDoneLoadingListener(() -> {
+      if (mEncExchangeSet.getLoadStatus() == LoadStatus.LOADED) {
         // add each data set's Enc cell as an ENC layer
-        for (EncDataset encDataset : encExchangeSet.getDatasets()) {
+        for (EncDataset encDataset : mEncExchangeSet.getDatasets()) {
           // create an ENC layer with an ENC cell using the dataset
           EncLayer encLayer = new EncLayer(new EncCell(encDataset));
           // add the ENC layer to the map's operational layers
@@ -95,7 +96,7 @@ public class MainActivity extends AppCompatActivity {
           });
         }
       } else {
-        String error = "Error loading ENC exchange set: " + encExchangeSet.getLoadError().getMessage();
+        String error = "Error loading ENC exchange set: " + mEncExchangeSet.getLoadError().getMessage();
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
         Log.e(TAG, error);
       }

--- a/java/add-enc-exchange-set/src/main/java/com/esri/arcgisruntime/sample/addencexchangeset/MainActivity.java
+++ b/java/add-enc-exchange-set/src/main/java/com/esri/arcgisruntime/sample/addencexchangeset/MainActivity.java
@@ -44,6 +44,7 @@ public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
   private Envelope mCompleteExtent;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private EncExchangeSet mEncExchangeSet;
 
   @Override

--- a/java/apply-scheduled-updates-to-preplanned-map-area/src/main/java/com/esri/arcgisruntime/sample/applyscheduledupdatestopreplannedmaparea/MainActivity.java
+++ b/java/apply-scheduled-updates-to-preplanned-map-area/src/main/java/com/esri/arcgisruntime/sample/applyscheduledupdatestopreplannedmaparea/MainActivity.java
@@ -54,6 +54,7 @@ public class MainActivity extends AppCompatActivity {
   private TextView mUpdateAvailableTextView;
   private TextView mUpdateSizeTextView;
   private Button mApplyScheduledUpdatesButton;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private MobileMapPackage mMobileMapPackage;
   private MobileMapPackage mUpdatedMobileMapPackage;
 

--- a/java/apply-scheduled-updates-to-preplanned-map-area/src/main/java/com/esri/arcgisruntime/sample/applyscheduledupdatestopreplannedmaparea/MainActivity.java
+++ b/java/apply-scheduled-updates-to-preplanned-map-area/src/main/java/com/esri/arcgisruntime/sample/applyscheduledupdatestopreplannedmaparea/MainActivity.java
@@ -54,6 +54,8 @@ public class MainActivity extends AppCompatActivity {
   private TextView mUpdateAvailableTextView;
   private TextView mUpdateSizeTextView;
   private Button mApplyScheduledUpdatesButton;
+  private MobileMapPackage mMobileMapPackage;
+  private MobileMapPackage mUpdatedMobileMapPackage;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -81,12 +83,12 @@ public class MainActivity extends AppCompatActivity {
     }
 
     // load the offline map as a mobile map package
-    MobileMapPackage mobileMapPackage = new MobileMapPackage(mCopyOfMmpk.getPath());
-    mobileMapPackage.loadAsync();
-    mobileMapPackage.addDoneLoadingListener(() -> {
-      if (mobileMapPackage.getLoadStatus() == LoadStatus.LOADED && !mobileMapPackage.getMaps().isEmpty()) {
+    mMobileMapPackage = new MobileMapPackage(mCopyOfMmpk.getPath());
+    mMobileMapPackage.loadAsync();
+    mMobileMapPackage.addDoneLoadingListener(() -> {
+      if (mMobileMapPackage.getLoadStatus() == LoadStatus.LOADED && !mMobileMapPackage.getMaps().isEmpty()) {
         // add the map from the mobile map package to the map view
-        ArcGISMap offlineMap = mobileMapPackage.getMaps().get(0);
+        ArcGISMap offlineMap = mMobileMapPackage.getMaps().get(0);
         mMapView.setMap(offlineMap);
         // create an offline map sync task with the preplanned area
         OfflineMapSyncTask offlineMapSyncTask = new OfflineMapSyncTask(offlineMap);
@@ -131,19 +133,20 @@ public class MainActivity extends AppCompatActivity {
                           // release the mobile map package maps from the map view
                           mMapView.setMap(null);
                           // close the old mobile map package
-                          mobileMapPackage.close();
+                          mMobileMapPackage.close();
                           // create a new instance of the now updated mobile map package
-                          MobileMapPackage updatedMobileMapPackage = new MobileMapPackage(mCopyOfMmpk.getPath());
-                          updatedMobileMapPackage.loadAsync();
+                          mUpdatedMobileMapPackage = new MobileMapPackage(mCopyOfMmpk.getPath());
+                          mUpdatedMobileMapPackage.loadAsync();
                           // wait for the new instance of the mobile map package to load
-                          updatedMobileMapPackage.addDoneLoadingListener(() -> {
-                            if (updatedMobileMapPackage.getLoadStatus() == LoadStatus.LOADED && !updatedMobileMapPackage
+                          mUpdatedMobileMapPackage.addDoneLoadingListener(() -> {
+                            if (mUpdatedMobileMapPackage
+                                .getLoadStatus() == LoadStatus.LOADED && !mUpdatedMobileMapPackage
                                 .getMaps().isEmpty()) {
                               // add the map from the mobile map package to the map view
-                              mMapView.setMap(updatedMobileMapPackage.getMaps().get(0));
+                              mMapView.setMap(mUpdatedMobileMapPackage.getMaps().get(0));
                             } else {
                               String error =
-                                  "Failed to load mobile map package: " + mobileMapPackage.getLoadError().getMessage();
+                                  "Failed to load mobile map package: " + mMobileMapPackage.getLoadError().getMessage();
                               Toast.makeText(this, error, Toast.LENGTH_LONG).show();
                               Log.e(TAG, error);
                             }
@@ -193,7 +196,7 @@ public class MainActivity extends AppCompatActivity {
           }
         });
       } else {
-        String error = "Failed to load the mobile map package: " + mobileMapPackage.getLoadError().getMessage();
+        String error = "Failed to load the mobile map package: " + mMobileMapPackage.getLoadError().getMessage();
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
         Log.e(TAG, error);
       }

--- a/java/browse-wfs-layers/src/main/java/com/esri/arcgisruntime/sample/browsewfslayers/MainActivity.java
+++ b/java/browse-wfs-layers/src/main/java/com/esri/arcgisruntime/sample/browsewfslayers/MainActivity.java
@@ -67,6 +67,7 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
   private BottomSheetBehavior<View> mBottomSheetBehavior;
 
   private WfsLayerInfo mSelectedWfsLayerInfo;
+  private WfsService mWfsService;
 
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -101,15 +102,15 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
     mMapView.setMap(map);
 
     // create WFS service
-    WfsService service = new WfsService(getString(R.string.wfs_service_url));
-    service.addDoneLoadingListener(() -> {
-      if (service.getLoadStatus() == LoadStatus.FAILED_TO_LOAD) {
-        logErrorToUser(getString(R.string.error_wfs_service_load_failure, service.getLoadError().getMessage()));
+    mWfsService = new WfsService(getString(R.string.wfs_service_url));
+    mWfsService.addDoneLoadingListener(() -> {
+      if (mWfsService.getLoadStatus() == LoadStatus.FAILED_TO_LOAD) {
+        logErrorToUser(getString(R.string.error_wfs_service_load_failure, mWfsService.getLoadError().getMessage()));
       } else {
-        setupRecyclerView(service.getServiceInfo().getLayerInfos());
+        setupRecyclerView(mWfsService.getServiceInfo().getLayerInfos());
       }
     });
-    service.loadAsync();
+    mWfsService.loadAsync();
   }
 
   @Override public void onItemSelected(WfsLayerInfo wfsLayerInfo) {

--- a/java/browse-wfs-layers/src/main/java/com/esri/arcgisruntime/sample/browsewfslayers/MainActivity.java
+++ b/java/browse-wfs-layers/src/main/java/com/esri/arcgisruntime/sample/browsewfslayers/MainActivity.java
@@ -67,6 +67,7 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
   private BottomSheetBehavior<View> mBottomSheetBehavior;
 
   private WfsLayerInfo mSelectedWfsLayerInfo;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private WfsService mWfsService;
 
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/java/choose-camera-controller/src/main/java/com/esri/arcgisruntime/sample/choosecameracontroller/MainActivity.java
+++ b/java/choose-camera-controller/src/main/java/com/esri/arcgisruntime/sample/choosecameracontroller/MainActivity.java
@@ -55,6 +55,7 @@ public class MainActivity extends AppCompatActivity {
   private GraphicsOverlay mSceneOverlay;
   private OrbitGeoElementCameraController mOrbitPlaneCameraController;
   private OrbitLocationCameraController mOrbitLocationCameraController;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private ModelSceneSymbol mModelSceneSymbol;
 
   @Override

--- a/java/choose-camera-controller/src/main/java/com/esri/arcgisruntime/sample/choosecameracontroller/MainActivity.java
+++ b/java/choose-camera-controller/src/main/java/com/esri/arcgisruntime/sample/choosecameracontroller/MainActivity.java
@@ -55,8 +55,6 @@ public class MainActivity extends AppCompatActivity {
   private GraphicsOverlay mSceneOverlay;
   private OrbitGeoElementCameraController mOrbitPlaneCameraController;
   private OrbitLocationCameraController mOrbitLocationCameraController;
-  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
-  private ModelSceneSymbol mModelSceneSymbol;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -96,8 +94,7 @@ public class MainActivity extends AppCompatActivity {
     mOrbitLocationCameraController.setCameraPitchOffset(3);
     mOrbitLocationCameraController.setCameraHeadingOffset(150);
 
-    mModelSceneSymbol = loadModel();
-    mModelSceneSymbol.addDoneLoadingListener(() -> {
+    loadModel().addDoneLoadingListener(() -> {
       // instantiate a new camera controller which orbits the plane at a set distance
       mOrbitPlaneCameraController = new OrbitGeoElementCameraController(mPlane3D, 100.0);
       mOrbitPlaneCameraController.setCameraPitchOffset(30);
@@ -138,7 +135,6 @@ public class MainActivity extends AppCompatActivity {
     // create a graphic with a ModelSceneSymbol of a plane to add to the scene
     String pathToModel = getCacheDir() + File.separator + getString(R.string.bristol_model);
     ModelSceneSymbol plane3DSymbol = new ModelSceneSymbol(pathToModel, 1.0);
-    plane3DSymbol.loadAsync();
     plane3DSymbol.setHeading(45);
     mPlane3D = new Graphic(new Point(-109.937516, 38.456714, 5000, SpatialReferences.getWgs84()), plane3DSymbol);
     mSceneOverlay.getGraphics().add(mPlane3D);

--- a/java/choose-camera-controller/src/main/java/com/esri/arcgisruntime/sample/choosecameracontroller/MainActivity.java
+++ b/java/choose-camera-controller/src/main/java/com/esri/arcgisruntime/sample/choosecameracontroller/MainActivity.java
@@ -55,6 +55,7 @@ public class MainActivity extends AppCompatActivity {
   private GraphicsOverlay mSceneOverlay;
   private OrbitGeoElementCameraController mOrbitPlaneCameraController;
   private OrbitLocationCameraController mOrbitLocationCameraController;
+  private ModelSceneSymbol mModelSceneSymbol;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -94,7 +95,8 @@ public class MainActivity extends AppCompatActivity {
     mOrbitLocationCameraController.setCameraPitchOffset(3);
     mOrbitLocationCameraController.setCameraHeadingOffset(150);
 
-    loadModel().addDoneLoadingListener(() -> {
+    mModelSceneSymbol = loadModel();
+    mModelSceneSymbol.addDoneLoadingListener(() -> {
       // instantiate a new camera controller which orbits the plane at a set distance
       mOrbitPlaneCameraController = new OrbitGeoElementCameraController(mPlane3D, 100.0);
       mOrbitPlaneCameraController.setCameraPitchOffset(30);

--- a/java/control-annotation-sublayer-visibility/src/main/java/com/esri/arcgisruntime/sample/annotationsublayer/MainActivity.java
+++ b/java/control-annotation-sublayer-visibility/src/main/java/com/esri/arcgisruntime/sample/annotationsublayer/MainActivity.java
@@ -36,6 +36,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private MobileMapPackage mMobileMapPackage;
 
   @Override

--- a/java/control-annotation-sublayer-visibility/src/main/java/com/esri/arcgisruntime/sample/annotationsublayer/MainActivity.java
+++ b/java/control-annotation-sublayer-visibility/src/main/java/com/esri/arcgisruntime/sample/annotationsublayer/MainActivity.java
@@ -36,6 +36,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  private MobileMapPackage mMobileMapPackage;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -55,13 +56,12 @@ public class MainActivity extends AppCompatActivity {
     CheckBox openCheckBox = findViewById(R.id.openCheckBox);
 
     // load the mobile map package
-    MobileMapPackage mobileMapPackage = new MobileMapPackage(
-        getExternalFilesDir(null) + getString(R.string.gas_device_anno_mmpk_path));
-    mobileMapPackage.loadAsync();
-    mobileMapPackage.addDoneLoadingListener(() -> {
-      if (mobileMapPackage.getLoadStatus() == LoadStatus.LOADED) {
+    mMobileMapPackage = new MobileMapPackage(getExternalFilesDir(null) + getString(R.string.gas_device_anno_mmpk_path));
+    mMobileMapPackage.loadAsync();
+    mMobileMapPackage.addDoneLoadingListener(() -> {
+      if (mMobileMapPackage.getLoadStatus() == LoadStatus.LOADED) {
         // set the mobile map package's map to the map view
-        mMapView.setMap(mobileMapPackage.getMaps().get(0));
+        mMapView.setMap(mMobileMapPackage.getMaps().get(0));
         // find the annotation layer within the map
         for (Layer layer : mMapView.getMap().getOperationalLayers()) {
           if (layer instanceof AnnotationLayer) {
@@ -96,7 +96,7 @@ public class MainActivity extends AppCompatActivity {
           }
         }
       } else {
-        String error = "Mobile map package failed load: " + mobileMapPackage.getLoadError().getMessage();
+        String error = "Mobile map package failed load: " + mMobileMapPackage.getLoadError().getMessage();
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
         Log.e(TAG, error);
       }

--- a/java/create-save-map/src/main/java/com/esri/arcgisruntime/sample/createsavemap/MainActivity.java
+++ b/java/create-save-map/src/main/java/com/esri/arcgisruntime/sample/createsavemap/MainActivity.java
@@ -61,6 +61,7 @@ public class MainActivity extends AppCompatActivity {
   private ListView mLayerListView;
   private CharSequence mDrawerTitle;
   private ActionBarDrawerToggle mDrawerToggle;
+  private Portal mPortal;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -228,20 +229,20 @@ public class MainActivity extends AppCompatActivity {
    */
   private void saveMap(String title, Iterable<String> tags, String description) {
     // create a portal to arcgis
-    Portal portal = new Portal("https://www.arcgis.com", true);
-    portal.addDoneLoadingListener(() -> {
-      if (portal.getLoadStatus() == LoadStatus.LOADED) {
+    mPortal = new Portal("https://www.arcgis.com", true);
+    mPortal.addDoneLoadingListener(() -> {
+      if (mPortal.getLoadStatus() == LoadStatus.LOADED) {
         // call save as async and pass portal info, as well as details of the map including title, tags and description
         ListenableFuture<PortalItem> saveAsAsyncFuture = mMapView.getMap()
-            .saveAsAsync(portal, null, title, tags, description, null, true);
+            .saveAsAsync(mPortal, null, title, tags, description, null, true);
         saveAsAsyncFuture.addDoneListener(() -> Toast.makeText(this, "Map saved to portal!", Toast.LENGTH_LONG).show());
       } else {
-        String error = "Error loading portal: " + portal.getLoadError().getMessage();
+        String error = "Error loading portal: " + mPortal.getLoadError().getMessage();
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
         Log.e(TAG, error);
       }
     });
-    portal.loadAsync();
+    mPortal.loadAsync();
   }
 
   @Override

--- a/java/create-save-map/src/main/java/com/esri/arcgisruntime/sample/createsavemap/MainActivity.java
+++ b/java/create-save-map/src/main/java/com/esri/arcgisruntime/sample/createsavemap/MainActivity.java
@@ -61,6 +61,7 @@ public class MainActivity extends AppCompatActivity {
   private ListView mLayerListView;
   private CharSequence mDrawerTitle;
   private ActionBarDrawerToggle mDrawerToggle;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private Portal mPortal;
 
   @Override

--- a/java/display-scene-in-tabletop-ar/src/main/java/com/esri/arcgisruntime/sample/displaysceneintabletopar/MainActivity.java
+++ b/java/display-scene-in-tabletop-ar/src/main/java/com/esri/arcgisruntime/sample/displaysceneintabletopar/MainActivity.java
@@ -49,6 +49,7 @@ public class MainActivity extends AppCompatActivity {
   private boolean mHasConfiguredScene = false;
 
   private ArcGISArView mArView;
+  private MobileScenePackage mMobileScenePackage;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -117,16 +118,16 @@ public class MainActivity extends AppCompatActivity {
    */
   private void loadSceneFromPackage(Plane plane) {
     // create a mobile scene package from a path a local .mspk
-    MobileScenePackage mobileScenePackage = new MobileScenePackage(
+    mMobileScenePackage = new MobileScenePackage(
         getExternalFilesDir(null) + getString(R.string.philadelphia_mobile_scene_package_path));
     // load the mobile scene package
-    mobileScenePackage.loadAsync();
-    mobileScenePackage.addDoneLoadingListener(() -> {
+    mMobileScenePackage.loadAsync();
+    mMobileScenePackage.addDoneLoadingListener(() -> {
       // if it loaded successfully and the mobile scene package contains a scene
-      if (mobileScenePackage.getLoadStatus() == LoadStatus.LOADED && !mobileScenePackage.getScenes()
+      if (mMobileScenePackage.getLoadStatus() == LoadStatus.LOADED && !mMobileScenePackage.getScenes()
           .isEmpty()) {
         // get a reference to the first scene in the mobile scene package, which is of a section of philadelphia
-        ArcGISScene philadelphiaScene = mobileScenePackage.getScenes().get(0);
+        ArcGISScene philadelphiaScene = mMobileScenePackage.getScenes().get(0);
         // set the clipping distance for the scene
         mArView.setClippingDistance(400);
         // add the scene to the AR view's scene view
@@ -139,7 +140,7 @@ public class MainActivity extends AppCompatActivity {
         // set translation factor and origin camera for scene placement in AR
         updateTranslationFactorAndOriginCamera(philadelphiaScene, plane);
       } else {
-        String error = "Failed to load mobile scene package: " + mobileScenePackage.getLoadError()
+        String error = "Failed to load mobile scene package: " + mMobileScenePackage.getLoadError()
             .getMessage();
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
         Log.e(TAG, error);

--- a/java/display-scene-in-tabletop-ar/src/main/java/com/esri/arcgisruntime/sample/displaysceneintabletopar/MainActivity.java
+++ b/java/display-scene-in-tabletop-ar/src/main/java/com/esri/arcgisruntime/sample/displaysceneintabletopar/MainActivity.java
@@ -49,6 +49,7 @@ public class MainActivity extends AppCompatActivity {
   private boolean mHasConfiguredScene = false;
 
   private ArcGISArView mArView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private MobileScenePackage mMobileScenePackage;
 
   @Override

--- a/java/edit-and-sync-features/src/main/java/com/esri/arcgisruntime/sample/editandsyncfeatures/MainActivity.java
+++ b/java/edit-and-sync-features/src/main/java/com/esri/arcgisruntime/sample/editandsyncfeatures/MainActivity.java
@@ -67,6 +67,7 @@ public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
   private GraphicsOverlay mGraphicsOverlay;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private GeodatabaseSyncTask mGeodatabaseSyncTask;
   private Geodatabase mGeodatabase;
 

--- a/java/feature-layer-dictionary-renderer/src/main/java/com/esri/arcgisruntime/sample/featurelayerdictionaryrenderer/MainActivity.java
+++ b/java/feature-layer-dictionary-renderer/src/main/java/com/esri/arcgisruntime/sample/featurelayerdictionaryrenderer/MainActivity.java
@@ -37,6 +37,7 @@ public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
   private Geodatabase mGeodatabase;
+  private DictionarySymbolStyle mSymbolDictionary;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -56,9 +57,8 @@ public class MainActivity extends AppCompatActivity {
     mGeodatabase.loadAsync();
 
     // render tells layer what symbols to apply to what features
-    DictionarySymbolStyle symbolDictionary = DictionarySymbolStyle
-        .createFromFile(getExternalFilesDir(null) + getString(R.string.mil2525d_stylx));
-    symbolDictionary.loadAsync();
+    mSymbolDictionary = DictionarySymbolStyle.createFromFile(getExternalFilesDir(null) + getString(R.string.mil2525d_stylx));
+    mSymbolDictionary.loadAsync();
 
     mGeodatabase.addDoneLoadingListener(() -> {
       if (mGeodatabase.getLoadStatus() == LoadStatus.LOADED) {
@@ -71,10 +71,10 @@ public class MainActivity extends AppCompatActivity {
           featureLayer.setMinScale(1000000);
           mMapView.getMap().getOperationalLayers().add(featureLayer);
 
-          symbolDictionary.addDoneLoadingListener(() -> {
-            if (symbolDictionary.getLoadStatus() == LoadStatus.LOADED) {
+          mSymbolDictionary.addDoneLoadingListener(() -> {
+            if (mSymbolDictionary.getLoadStatus() == LoadStatus.LOADED) {
               // displays features from layer using mil2525d symbols
-              DictionaryRenderer dictionaryRenderer = new DictionaryRenderer(symbolDictionary);
+              DictionaryRenderer dictionaryRenderer = new DictionaryRenderer(mSymbolDictionary);
               featureLayer.setRenderer(dictionaryRenderer);
 
               featureLayer.addDoneLoadingListener(() -> {
@@ -88,7 +88,7 @@ public class MainActivity extends AppCompatActivity {
                 }
               });
             } else {
-              String error = "Dictionary Symbol Failed to Load: " + symbolDictionary.getLoadError().getMessage();
+              String error = "Dictionary Symbol Failed to Load: " + mSymbolDictionary.getLoadError().getMessage();
               Toast.makeText(this, error, Toast.LENGTH_LONG).show();
               Log.e(TAG, error);
             }

--- a/java/feature-layer-dictionary-renderer/src/main/java/com/esri/arcgisruntime/sample/featurelayerdictionaryrenderer/MainActivity.java
+++ b/java/feature-layer-dictionary-renderer/src/main/java/com/esri/arcgisruntime/sample/featurelayerdictionaryrenderer/MainActivity.java
@@ -36,6 +36,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private Geodatabase mGeodatabase;
   private DictionarySymbolStyle mSymbolDictionary;
 

--- a/java/feature-layer-dictionary-renderer/src/main/java/com/esri/arcgisruntime/sample/featurelayerdictionaryrenderer/MainActivity.java
+++ b/java/feature-layer-dictionary-renderer/src/main/java/com/esri/arcgisruntime/sample/featurelayerdictionaryrenderer/MainActivity.java
@@ -36,6 +36,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  private Geodatabase mGeodatabase;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -50,19 +51,19 @@ public class MainActivity extends AppCompatActivity {
     mMapView.setMap(map);
 
     // load geo-database from local location
-    Geodatabase geodatabase = new Geodatabase(
+    mGeodatabase = new Geodatabase(
         getExternalFilesDir(null) + getString(R.string.militaryoverlay_geodatabase));
-    geodatabase.loadAsync();
+    mGeodatabase.loadAsync();
 
     // render tells layer what symbols to apply to what features
     DictionarySymbolStyle symbolDictionary = DictionarySymbolStyle
         .createFromFile(getExternalFilesDir(null) + getString(R.string.mil2525d_stylx));
     symbolDictionary.loadAsync();
 
-    geodatabase.addDoneLoadingListener(() -> {
-      if (geodatabase.getLoadStatus() == LoadStatus.LOADED) {
+    mGeodatabase.addDoneLoadingListener(() -> {
+      if (mGeodatabase.getLoadStatus() == LoadStatus.LOADED) {
 
-        for (GeodatabaseFeatureTable table : geodatabase.getGeodatabaseFeatureTables()) {
+        for (GeodatabaseFeatureTable table : mGeodatabase.getGeodatabaseFeatureTables()) {
           // add each layer to map
           FeatureLayer featureLayer = new FeatureLayer(table);
           featureLayer.loadAsync();
@@ -94,7 +95,7 @@ public class MainActivity extends AppCompatActivity {
           });
         }
       } else {
-        String error = "Geodatabase Failed to Load: " + geodatabase.getLoadError().getMessage();
+        String error = "Geodatabase Failed to Load: " + mGeodatabase.getLoadError().getMessage();
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
         Log.e(TAG, error);
       }

--- a/java/feature-layer-geodatabase/src/main/java/com/esri/arcgisruntime/sample/featurelayergeodatabase/MainActivity.java
+++ b/java/feature-layer-geodatabase/src/main/java/com/esri/arcgisruntime/sample/featurelayergeodatabase/MainActivity.java
@@ -35,6 +35,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  private Geodatabase mGeodatabase;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -50,16 +51,16 @@ public class MainActivity extends AppCompatActivity {
     String path = getExternalFilesDir(null) + getString(R.string.config_geodb_name);
 
     // create a new geodatabase from local path
-    final Geodatabase geodatabase = new Geodatabase(path);
+    mGeodatabase = new Geodatabase(path);
 
     // load the geodatabase
-    geodatabase.loadAsync();
+    mGeodatabase.loadAsync();
 
     // create feature layer from geodatabase and add to the map
-    geodatabase.addDoneLoadingListener(() -> {
-      if (geodatabase.getLoadStatus() == LoadStatus.LOADED) {
+    mGeodatabase.addDoneLoadingListener(() -> {
+      if (mGeodatabase.getLoadStatus() == LoadStatus.LOADED) {
         // access the geodatabase's feature table Trailheads
-        GeodatabaseFeatureTable geodatabaseFeatureTable = geodatabase.getGeodatabaseFeatureTable("Trailheads");
+        GeodatabaseFeatureTable geodatabaseFeatureTable = mGeodatabase.getGeodatabaseFeatureTable("Trailheads");
         geodatabaseFeatureTable.loadAsync();
         // create a layer from the geodatabase feature table and add to map
         final FeatureLayer featureLayer = new FeatureLayer(geodatabaseFeatureTable);

--- a/java/feature-layer-geodatabase/src/main/java/com/esri/arcgisruntime/sample/featurelayergeodatabase/MainActivity.java
+++ b/java/feature-layer-geodatabase/src/main/java/com/esri/arcgisruntime/sample/featurelayergeodatabase/MainActivity.java
@@ -35,6 +35,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private Geodatabase mGeodatabase;
 
   @Override

--- a/java/feature-layer-geopackage/src/main/java/com/esri/arcgisruntime/sample/featurelayergeopackage/MainActivity.java
+++ b/java/feature-layer-geopackage/src/main/java/com/esri/arcgisruntime/sample/featurelayergeopackage/MainActivity.java
@@ -35,6 +35,7 @@ public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
   private ArcGISMap mMap;
+  private GeoPackage mGeoPackage;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -52,12 +53,12 @@ public class MainActivity extends AppCompatActivity {
     String geoPackagePath = getExternalFilesDir(null) + getString(R.string.aurora_co_gpkg);
 
     // Open the GeoPackage
-    GeoPackage geoPackage = new GeoPackage(geoPackagePath);
-    geoPackage.loadAsync();
-    geoPackage.addDoneLoadingListener(() -> {
-      if (geoPackage.getLoadStatus() == LoadStatus.LOADED) {
+    mGeoPackage = new GeoPackage(geoPackagePath);
+    mGeoPackage.loadAsync();
+    mGeoPackage.addDoneLoadingListener(() -> {
+      if (mGeoPackage.getLoadStatus() == LoadStatus.LOADED) {
         // Read the feature tables and get the first one
-        FeatureTable geoPackageTable = geoPackage.getGeoPackageFeatureTables().get(0);
+        FeatureTable geoPackageTable = mGeoPackage.getGeoPackageFeatureTables().get(0);
 
         // Make sure a feature table was found in the package
         if (geoPackageTable == null) {
@@ -72,8 +73,8 @@ public class MainActivity extends AppCompatActivity {
         // Add the feature table as a layer to the map (with default symbology)
         mMap.getOperationalLayers().add(featureLayer);
       } else {
-        Toast.makeText(MainActivity.this, "GeoPackage failed to load! " + geoPackage.getLoadError(), Toast.LENGTH_LONG).show();
-        Log.e(TAG, "GeoPackage failed to load!" + geoPackage.getLoadError());
+        Toast.makeText(MainActivity.this, "GeoPackage failed to load! " + mGeoPackage.getLoadError(), Toast.LENGTH_LONG).show();
+        Log.e(TAG, "GeoPackage failed to load!" + mGeoPackage.getLoadError());
       }
     });
   }

--- a/java/feature-layer-geopackage/src/main/java/com/esri/arcgisruntime/sample/featurelayergeopackage/MainActivity.java
+++ b/java/feature-layer-geopackage/src/main/java/com/esri/arcgisruntime/sample/featurelayergeopackage/MainActivity.java
@@ -35,6 +35,7 @@ public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
   private ArcGISMap mMap;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private GeoPackage mGeoPackage;
 
   @Override

--- a/java/feature-layer-shapefile/src/main/java/com/esri/arcgisruntime/sample/featurelayershapefile/MainActivity.java
+++ b/java/feature-layer-shapefile/src/main/java/com/esri/arcgisruntime/sample/featurelayershapefile/MainActivity.java
@@ -34,8 +34,6 @@ public class MainActivity extends AppCompatActivity {
   private final static String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
-  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
-  private ShapefileFeatureTable mShapefileFeatureTable;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -48,22 +46,20 @@ public class MainActivity extends AppCompatActivity {
     mMapView.setMap(map);
 
     // load the shapefile with a local path
-    mShapefileFeatureTable = new ShapefileFeatureTable(
+    ShapefileFeatureTable shapefileFeatureTable = new ShapefileFeatureTable(
         getExternalFilesDir(null) + getString(R.string.shapefile_path));
 
     // create a feature layer to display the shapefile
-    FeatureLayer shapefileFeatureLayer = new FeatureLayer(mShapefileFeatureTable);
+    FeatureLayer shapefileFeatureLayer = new FeatureLayer(shapefileFeatureTable);
+    // add the feature layer to the map
+    mMapView.getMap().getOperationalLayers().add(shapefileFeatureLayer);
 
-    mShapefileFeatureTable.addDoneLoadingListener(() -> {
-      if (mShapefileFeatureTable.getLoadStatus() == LoadStatus.LOADED) {
-
-        // add the feature layer to the map
-        mMapView.getMap().getOperationalLayers().add(shapefileFeatureLayer);
-
+    shapefileFeatureTable.addDoneLoadingListener(() -> {
+      if (shapefileFeatureTable.getLoadStatus() == LoadStatus.LOADED) {
         // zoom the map to the extent of the shapefile
         mMapView.setViewpointAsync(new Viewpoint(shapefileFeatureLayer.getFullExtent()));
       } else {
-        String error = "Shapefile feature table failed to load: " + mShapefileFeatureTable.getLoadError().toString();
+        String error = "Shapefile feature table failed to load: " + shapefileFeatureTable.getLoadError().toString();
         Toast.makeText(MainActivity.this, error, Toast.LENGTH_LONG).show();
         Log.e(TAG, error);
       }

--- a/java/feature-layer-shapefile/src/main/java/com/esri/arcgisruntime/sample/featurelayershapefile/MainActivity.java
+++ b/java/feature-layer-shapefile/src/main/java/com/esri/arcgisruntime/sample/featurelayershapefile/MainActivity.java
@@ -34,6 +34,7 @@ public class MainActivity extends AppCompatActivity {
   private final static String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private ShapefileFeatureTable mShapefileFeatureTable;
 
   @Override

--- a/java/feature-layer-shapefile/src/main/java/com/esri/arcgisruntime/sample/featurelayershapefile/MainActivity.java
+++ b/java/feature-layer-shapefile/src/main/java/com/esri/arcgisruntime/sample/featurelayershapefile/MainActivity.java
@@ -51,12 +51,11 @@ public class MainActivity extends AppCompatActivity {
     mShapefileFeatureTable = new ShapefileFeatureTable(
         getExternalFilesDir(null) + getString(R.string.shapefile_path));
 
-    mShapefileFeatureTable.loadAsync();
+    // create a feature layer to display the shapefile
+    FeatureLayer shapefileFeatureLayer = new FeatureLayer(mShapefileFeatureTable);
+
     mShapefileFeatureTable.addDoneLoadingListener(() -> {
       if (mShapefileFeatureTable.getLoadStatus() == LoadStatus.LOADED) {
-
-        // create a feature layer to display the shapefile
-        FeatureLayer shapefileFeatureLayer = new FeatureLayer(mShapefileFeatureTable);
 
         // add the feature layer to the map
         mMapView.getMap().getOperationalLayers().add(shapefileFeatureLayer);

--- a/java/feature-layer-shapefile/src/main/java/com/esri/arcgisruntime/sample/featurelayershapefile/MainActivity.java
+++ b/java/feature-layer-shapefile/src/main/java/com/esri/arcgisruntime/sample/featurelayershapefile/MainActivity.java
@@ -34,6 +34,7 @@ public class MainActivity extends AppCompatActivity {
   private final static String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  private ShapefileFeatureTable mShapefileFeatureTable;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -46,15 +47,15 @@ public class MainActivity extends AppCompatActivity {
     mMapView.setMap(map);
 
     // load the shapefile with a local path
-    ShapefileFeatureTable shapefileFeatureTable = new ShapefileFeatureTable(
+    mShapefileFeatureTable = new ShapefileFeatureTable(
         getExternalFilesDir(null) + getString(R.string.shapefile_path));
 
-    shapefileFeatureTable.loadAsync();
-    shapefileFeatureTable.addDoneLoadingListener(() -> {
-      if (shapefileFeatureTable.getLoadStatus() == LoadStatus.LOADED) {
+    mShapefileFeatureTable.loadAsync();
+    mShapefileFeatureTable.addDoneLoadingListener(() -> {
+      if (mShapefileFeatureTable.getLoadStatus() == LoadStatus.LOADED) {
 
         // create a feature layer to display the shapefile
-        FeatureLayer shapefileFeatureLayer = new FeatureLayer(shapefileFeatureTable);
+        FeatureLayer shapefileFeatureLayer = new FeatureLayer(mShapefileFeatureTable);
 
         // add the feature layer to the map
         mMapView.getMap().getOperationalLayers().add(shapefileFeatureLayer);
@@ -62,7 +63,7 @@ public class MainActivity extends AppCompatActivity {
         // zoom the map to the extent of the shapefile
         mMapView.setViewpointAsync(new Viewpoint(shapefileFeatureLayer.getFullExtent()));
       } else {
-        String error = "Shapefile feature table failed to load: " + shapefileFeatureTable.getLoadError().toString();
+        String error = "Shapefile feature table failed to load: " + mShapefileFeatureTable.getLoadError().toString();
         Toast.makeText(MainActivity.this, error, Toast.LENGTH_LONG).show();
         Log.e(TAG, error);
       }

--- a/java/feature-layer-update-geometry/src/main/java/com/esri/arcgisruntime/samples/featurelayerupdategeometry/MainActivity.java
+++ b/java/feature-layer-update-geometry/src/main/java/com/esri/arcgisruntime/samples/featurelayerupdategeometry/MainActivity.java
@@ -44,6 +44,7 @@ public class MainActivity extends AppCompatActivity {
   private MapView mMapView;
   private FeatureLayer mFeatureLayer;
   private boolean mFeatureSelected = true;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private ArcGISFeature mIdentifiedFeature;
 
   @Override

--- a/java/find-closest-facility-to-multiple-incidents-service/src/main/java/com/esri/arcgisruntime/sample/findclosestfacilitytomultipleincidentsservice/MainActivity.java
+++ b/java/find-closest-facility-to-multiple-incidents-service/src/main/java/com/esri/arcgisruntime/sample/findclosestfacilitytomultipleincidentsservice/MainActivity.java
@@ -59,6 +59,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private ClosestFacilityTask mClosestFacilityTask;
 
   @Override

--- a/java/find-closest-facility-to-multiple-incidents-service/src/main/java/com/esri/arcgisruntime/sample/findclosestfacilitytomultipleincidentsservice/MainActivity.java
+++ b/java/find-closest-facility-to-multiple-incidents-service/src/main/java/com/esri/arcgisruntime/sample/findclosestfacilitytomultipleincidentsservice/MainActivity.java
@@ -59,6 +59,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  private ClosestFacilityTask mClosestFacilityTask;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -92,7 +93,7 @@ public class MainActivity extends AppCompatActivity {
     SimpleLineSymbol simpleLineSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.BLUE, 5.0f);
 
     // create a closest facility task from a network analysis service
-    ClosestFacilityTask closestFacilityTask = new ClosestFacilityTask(this,
+    mClosestFacilityTask = new ClosestFacilityTask(this,
         getString(R.string.san_diego_network_analysis_service_url));
 
     // create a table for facilities using the feature service
@@ -165,19 +166,19 @@ public class MainActivity extends AppCompatActivity {
               // disable the 'solve routes' button and show the progress indicator
               solveRoutesButton.setEnabled(false);
               // start the routing task
-              closestFacilityTask.loadAsync();
-              closestFacilityTask.addDoneLoadingListener(() -> {
-                if (closestFacilityTask.getLoadStatus() == LoadStatus.LOADED) {
+              mClosestFacilityTask.loadAsync();
+              mClosestFacilityTask.addDoneLoadingListener(() -> {
+                if (mClosestFacilityTask.getLoadStatus() == LoadStatus.LOADED) {
                   try {
                     // create default parameters for the task and add facilities and incidents to parameters
-                    ClosestFacilityParameters closestFacilityParameters = closestFacilityTask
+                    ClosestFacilityParameters closestFacilityParameters = mClosestFacilityTask
                         .createDefaultParametersAsync().get();
                     closestFacilityParameters.setFacilities(facilities);
                     closestFacilityParameters.setIncidents(incidents);
                     // solve closest facilities
                     try {
                       // use the task to solve for the closest facility
-                      ListenableFuture<ClosestFacilityResult> closestFacilityTaskResult = closestFacilityTask
+                      ListenableFuture<ClosestFacilityResult> closestFacilityTaskResult = mClosestFacilityTask
                           .solveClosestFacilityAsync(closestFacilityParameters);
                       closestFacilityTaskResult.addDoneListener(() -> {
                         try {
@@ -210,7 +211,7 @@ public class MainActivity extends AppCompatActivity {
                     Log.e(TAG, error);
                   }
                 } else {
-                  String error = "Error loading route task: " + closestFacilityTask.getLoadError().getMessage();
+                  String error = "Error loading route task: " + mClosestFacilityTask.getLoadError().getMessage();
                   Toast.makeText(this, error, Toast.LENGTH_LONG).show();
                   Log.e(TAG, error);
                 }

--- a/java/find-route/src/main/java/com/esri/arcgisruntime/sample/findroute/MainActivity.java
+++ b/java/find-route/src/main/java/com/esri/arcgisruntime/sample/findroute/MainActivity.java
@@ -76,6 +76,8 @@ public class MainActivity extends AppCompatActivity {
   private DrawerLayout mDrawerLayout;
   private ListView mDrawerList;
   private ActionBarDrawerToggle mDrawerToggle;
+  private PictureMarkerSymbol mPinSourceSymbol;
+  private PictureMarkerSymbol mPinDestinationSymbol;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -233,20 +235,19 @@ public class MainActivity extends AppCompatActivity {
     //[DocRef: Name=Picture Marker Symbol Drawable-android, Category=Fundamentals, Topic=Symbols and Renderers]
     //Create a picture marker symbol from an app resource
     BitmapDrawable startDrawable = (BitmapDrawable) ContextCompat.getDrawable(this, R.drawable.ic_source);
-    final PictureMarkerSymbol pinSourceSymbol;
     try {
-      pinSourceSymbol = PictureMarkerSymbol.createAsync(startDrawable).get();
-      pinSourceSymbol.loadAsync();
-      pinSourceSymbol.addDoneLoadingListener(new Runnable() {
+      mPinSourceSymbol = PictureMarkerSymbol.createAsync(startDrawable).get();
+      mPinSourceSymbol.loadAsync();
+      mPinSourceSymbol.addDoneLoadingListener(new Runnable() {
         @Override
         public void run() {
           //add a new graphic as start point
           mSourcePoint = new Point(-117.15083257944445, 32.741123367963446, SpatialReferences.getWgs84());
-          Graphic pinSourceGraphic = new Graphic(mSourcePoint, pinSourceSymbol);
+          Graphic pinSourceGraphic = new Graphic(mSourcePoint, mPinSourceSymbol);
           mGraphicsOverlay.getGraphics().add(pinSourceGraphic);
         }
       });
-      pinSourceSymbol.setOffsetY(20);
+      mPinSourceSymbol.setOffsetY(20);
     } catch (InterruptedException e) {
       e.printStackTrace();
     } catch (ExecutionException e) {
@@ -254,20 +255,19 @@ public class MainActivity extends AppCompatActivity {
     }
     //[DocRef: END]
     BitmapDrawable endDrawable = (BitmapDrawable) ContextCompat.getDrawable(this, R.drawable.ic_destination);
-    final PictureMarkerSymbol pinDestinationSymbol;
     try {
-      pinDestinationSymbol = PictureMarkerSymbol.createAsync(endDrawable).get();
-      pinDestinationSymbol.loadAsync();
-      pinDestinationSymbol.addDoneLoadingListener(new Runnable() {
+      mPinDestinationSymbol = PictureMarkerSymbol.createAsync(endDrawable).get();
+      mPinDestinationSymbol.loadAsync();
+      mPinDestinationSymbol.addDoneLoadingListener(new Runnable() {
         @Override
         public void run() {
           //add a new graphic as end point
           mDestinationPoint = new Point(-117.15557279683529, 32.703360305883045, SpatialReferences.getWgs84());
-          Graphic destinationGraphic = new Graphic(mDestinationPoint, pinDestinationSymbol);
+          Graphic destinationGraphic = new Graphic(mDestinationPoint, mPinDestinationSymbol);
           mGraphicsOverlay.getGraphics().add(destinationGraphic);
         }
       });
-      pinDestinationSymbol.setOffsetY(20);
+      mPinDestinationSymbol.setOffsetY(20);
     } catch (InterruptedException e) {
       e.printStackTrace();
     } catch (ExecutionException e) {

--- a/java/find-route/src/main/java/com/esri/arcgisruntime/sample/findroute/MainActivity.java
+++ b/java/find-route/src/main/java/com/esri/arcgisruntime/sample/findroute/MainActivity.java
@@ -76,6 +76,8 @@ public class MainActivity extends AppCompatActivity {
   private DrawerLayout mDrawerLayout;
   private ListView mDrawerList;
   private ActionBarDrawerToggle mDrawerToggle;
+
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private PictureMarkerSymbol mPinSourceSymbol;
   private PictureMarkerSymbol mPinDestinationSymbol;
 

--- a/java/find-route/src/main/java/com/esri/arcgisruntime/sample/findroute/MainActivity.java
+++ b/java/find-route/src/main/java/com/esri/arcgisruntime/sample/findroute/MainActivity.java
@@ -35,6 +35,8 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.FrameLayout;
 import android.widget.ListView;
+import android.widget.Toast;
+
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.geometry.Geometry;
 import com.esri.arcgisruntime.geometry.Point;
@@ -67,8 +69,6 @@ public class MainActivity extends AppCompatActivity {
   private MapView mMapView;
   private RouteTask mRouteTask;
   private RouteParameters mRouteParams;
-  private Point mSourcePoint;
-  private Point mDestinationPoint;
   private Route mRoute;
   private SimpleLineSymbol mRouteSymbol;
   private GraphicsOverlay mGraphicsOverlay;
@@ -76,10 +76,6 @@ public class MainActivity extends AppCompatActivity {
   private DrawerLayout mDrawerLayout;
   private ListView mDrawerList;
   private ActionBarDrawerToggle mDrawerToggle;
-
-  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
-  private PictureMarkerSymbol mPinSourceSymbol;
-  private PictureMarkerSymbol mPinDestinationSymbol;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -238,42 +234,31 @@ public class MainActivity extends AppCompatActivity {
     //Create a picture marker symbol from an app resource
     BitmapDrawable startDrawable = (BitmapDrawable) ContextCompat.getDrawable(this, R.drawable.ic_source);
     try {
-      mPinSourceSymbol = PictureMarkerSymbol.createAsync(startDrawable).get();
-      mPinSourceSymbol.loadAsync();
-      mPinSourceSymbol.addDoneLoadingListener(new Runnable() {
-        @Override
-        public void run() {
-          //add a new graphic as start point
-          mSourcePoint = new Point(-117.15083257944445, 32.741123367963446, SpatialReferences.getWgs84());
-          Graphic pinSourceGraphic = new Graphic(mSourcePoint, mPinSourceSymbol);
-          mGraphicsOverlay.getGraphics().add(pinSourceGraphic);
-        }
-      });
-      mPinSourceSymbol.setOffsetY(20);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    } catch (ExecutionException e) {
-      e.printStackTrace();
+      PictureMarkerSymbol pinSourceSymbol = PictureMarkerSymbol.createAsync(startDrawable).get();
+      pinSourceSymbol.setOffsetY(20);
+      //add a new graphic as start point
+      Point sourcePoint = new Point(-117.15083257944445, 32.741123367963446, SpatialReferences.getWgs84());
+      Graphic pinSourceGraphic = new Graphic(sourcePoint, pinSourceSymbol);
+      mGraphicsOverlay.getGraphics().add(pinSourceGraphic);
+    } catch (InterruptedException | ExecutionException e) {
+      String error = "Error creating picture marker symbol: " + e.getMessage();
+      Log.e(TAG, error);
+      Toast.makeText(this, error, Toast.LENGTH_SHORT).show();
     }
-    //[DocRef: END]
+
+      //[DocRef: END]
     BitmapDrawable endDrawable = (BitmapDrawable) ContextCompat.getDrawable(this, R.drawable.ic_destination);
     try {
-      mPinDestinationSymbol = PictureMarkerSymbol.createAsync(endDrawable).get();
-      mPinDestinationSymbol.loadAsync();
-      mPinDestinationSymbol.addDoneLoadingListener(new Runnable() {
-        @Override
-        public void run() {
-          //add a new graphic as end point
-          mDestinationPoint = new Point(-117.15557279683529, 32.703360305883045, SpatialReferences.getWgs84());
-          Graphic destinationGraphic = new Graphic(mDestinationPoint, mPinDestinationSymbol);
-          mGraphicsOverlay.getGraphics().add(destinationGraphic);
-        }
-      });
-      mPinDestinationSymbol.setOffsetY(20);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    } catch (ExecutionException e) {
-      e.printStackTrace();
+      PictureMarkerSymbol pinDestinationSymbol = PictureMarkerSymbol.createAsync(endDrawable).get();
+      pinDestinationSymbol.setOffsetY(20);
+      // add a new graphic as destination point
+      Point destinationPoint = new Point(-117.15557279683529, 32.703360305883045, SpatialReferences.getWgs84());
+      Graphic destinationGraphic = new Graphic(destinationPoint, pinDestinationSymbol);
+      mGraphicsOverlay.getGraphics().add(destinationGraphic);
+    } catch (InterruptedException | ExecutionException e) {
+      String error = "Error creating picture marker symbol: " + e.getMessage();
+      Log.e(TAG, error);
+      Toast.makeText(this, error, Toast.LENGTH_SHORT).show();
     }
     //[DocRef: END]
     mRouteSymbol = new SimpleLineSymbol(SimpleLineSymbol.Style.SOLID, Color.BLUE, 5);

--- a/java/generate-geodatabase/src/main/java/com/esri/arcgisruntime/sample/generategeodatabase/MainActivity.java
+++ b/java/generate-geodatabase/src/main/java/com/esri/arcgisruntime/sample/generategeodatabase/MainActivity.java
@@ -57,6 +57,8 @@ public class MainActivity extends AppCompatActivity {
 
   private TextView mProgressTextView;
   private RelativeLayout mProgressLayout;
+  
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private GeodatabaseSyncTask mGeodatabaseSyncTask;
   private Geodatabase mGeodatabase;
 

--- a/java/generate-geodatabase/src/main/java/com/esri/arcgisruntime/sample/generategeodatabase/MainActivity.java
+++ b/java/generate-geodatabase/src/main/java/com/esri/arcgisruntime/sample/generategeodatabase/MainActivity.java
@@ -57,6 +57,7 @@ public class MainActivity extends AppCompatActivity {
 
   private TextView mProgressTextView;
   private RelativeLayout mProgressLayout;
+  private GeodatabaseSyncTask mGeodatabaseSyncTask;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -84,9 +85,9 @@ public class MainActivity extends AppCompatActivity {
     mProgressTextView = (TextView) findViewById(R.id.progressTextView);
 
     // create a geodatabase sync task
-    final GeodatabaseSyncTask geodatabaseSyncTask = new GeodatabaseSyncTask(getString(R.string.wildfire_sync));
-    geodatabaseSyncTask.loadAsync();
-    geodatabaseSyncTask.addDoneLoadingListener(() -> {
+    mGeodatabaseSyncTask = new GeodatabaseSyncTask(getString(R.string.wildfire_sync));
+    mGeodatabaseSyncTask.loadAsync();
+    mGeodatabaseSyncTask.addDoneLoadingListener(() -> {
 
       // generate the geodatabase sync task
       genGeodatabaseButton.setOnClickListener(new View.OnClickListener() {
@@ -106,7 +107,7 @@ public class MainActivity extends AppCompatActivity {
           graphicsOverlay.getGraphics().add(boundary);
 
           // create generate geodatabase parameters for the current extent
-          final ListenableFuture<GenerateGeodatabaseParameters> defaultParameters = geodatabaseSyncTask
+          final ListenableFuture<GenerateGeodatabaseParameters> defaultParameters = mGeodatabaseSyncTask
               .createDefaultGenerateGeodatabaseParametersAsync(extent);
           defaultParameters.addDoneListener(new Runnable() {
             @Override public void run() {
@@ -120,7 +121,7 @@ public class MainActivity extends AppCompatActivity {
                     getCacheDir().toString() + File.separator + getString(R.string.wildfire_geodatabase);
 
                 // create and start the job
-                final GenerateGeodatabaseJob generateGeodatabaseJob = geodatabaseSyncTask
+                final GenerateGeodatabaseJob generateGeodatabaseJob = mGeodatabaseSyncTask
                     .generateGeodatabase(parameters, localGeodatabasePath);
                 generateGeodatabaseJob.start();
                 mProgressTextView.setText(getString(R.string.progress_started));
@@ -157,7 +158,7 @@ public class MainActivity extends AppCompatActivity {
                         }
                       });
                       // unregister since we're not syncing
-                      ListenableFuture unregisterGeodatabase = geodatabaseSyncTask
+                      ListenableFuture unregisterGeodatabase = mGeodatabaseSyncTask
                           .unregisterGeodatabaseAsync(geodatabase);
                       unregisterGeodatabase.addDoneListener(() -> {
                         Log.i(TAG, "Geodatabase unregistered since we wont be editing it in this sample.");

--- a/java/generate-geodatabase/src/main/java/com/esri/arcgisruntime/sample/generategeodatabase/MainActivity.java
+++ b/java/generate-geodatabase/src/main/java/com/esri/arcgisruntime/sample/generategeodatabase/MainActivity.java
@@ -58,6 +58,7 @@ public class MainActivity extends AppCompatActivity {
   private TextView mProgressTextView;
   private RelativeLayout mProgressLayout;
   private GeodatabaseSyncTask mGeodatabaseSyncTask;
+  private Geodatabase mGeodatabase;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -139,13 +140,13 @@ public class MainActivity extends AppCompatActivity {
                   @Override public void run() {
                     mProgressLayout.setVisibility(View.INVISIBLE);
                     if (generateGeodatabaseJob.getStatus() == Job.Status.SUCCEEDED) {
-                      final Geodatabase geodatabase = generateGeodatabaseJob.getResult();
-                      geodatabase.loadAsync();
-                      geodatabase.addDoneLoadingListener(new Runnable() {
+                      mGeodatabase = generateGeodatabaseJob.getResult();
+                      mGeodatabase.loadAsync();
+                      mGeodatabase.addDoneLoadingListener(new Runnable() {
                         @Override public void run() {
-                          if (geodatabase.getLoadStatus() == LoadStatus.LOADED) {
+                          if (mGeodatabase.getLoadStatus() == LoadStatus.LOADED) {
                             mProgressTextView.setText(getString(R.string.progress_done));
-                            for (GeodatabaseFeatureTable geodatabaseFeatureTable : geodatabase
+                            for (GeodatabaseFeatureTable geodatabaseFeatureTable : mGeodatabase
                                 .getGeodatabaseFeatureTables()) {
                               geodatabaseFeatureTable.loadAsync();
                               map.getOperationalLayers().add(new FeatureLayer(geodatabaseFeatureTable));
@@ -153,13 +154,13 @@ public class MainActivity extends AppCompatActivity {
                             genGeodatabaseButton.setVisibility(View.GONE);
                             Log.i(TAG, "Local geodatabase stored at: " + localGeodatabasePath);
                           } else {
-                            Log.e(TAG, "Error loading geodatabase: " + geodatabase.getLoadError().getMessage());
+                            Log.e(TAG, "Error loading geodatabase: " + mGeodatabase.getLoadError().getMessage());
                           }
                         }
                       });
                       // unregister since we're not syncing
                       ListenableFuture unregisterGeodatabase = mGeodatabaseSyncTask
-                          .unregisterGeodatabaseAsync(geodatabase);
+                          .unregisterGeodatabaseAsync(mGeodatabase);
                       unregisterGeodatabase.addDoneListener(() -> {
                         Log.i(TAG, "Geodatabase unregistered since we wont be editing it in this sample.");
                         Toast.makeText(MainActivity.this,

--- a/java/honor-mobile-map-package-expiration-date/src/main/java/com/esri/arcgisruntime/sample/honormobilemappackageexpirationdate/MainActivity.java
+++ b/java/honor-mobile-map-package-expiration-date/src/main/java/com/esri/arcgisruntime/sample/honormobilemappackageexpirationdate/MainActivity.java
@@ -33,6 +33,7 @@ public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
   private TextView mExpirationMessageTextView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private MobileMapPackage mMobileMapPackage;
 
   @Override

--- a/java/honor-mobile-map-package-expiration-date/src/main/java/com/esri/arcgisruntime/sample/honormobilemappackageexpirationdate/MainActivity.java
+++ b/java/honor-mobile-map-package-expiration-date/src/main/java/com/esri/arcgisruntime/sample/honormobilemappackageexpirationdate/MainActivity.java
@@ -33,6 +33,7 @@ public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
   private TextView mExpirationMessageTextView;
+  private MobileMapPackage mMobileMapPackage;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -46,31 +47,30 @@ public class MainActivity extends AppCompatActivity {
     mExpirationMessageTextView = findViewById(R.id.expirationMessageTextView);
 
     // create a mobile map package from a local mmpk
-    MobileMapPackage mobileMapPackage = new MobileMapPackage(
-        getExternalFilesDir(null) + getString(R.string.path_to_expired_mmpk));
+    mMobileMapPackage = new MobileMapPackage(getExternalFilesDir(null) + getString(R.string.path_to_expired_mmpk));
 
     // wait for the map package to load
-    mobileMapPackage.addDoneLoadingListener(() -> {
+    mMobileMapPackage.addDoneLoadingListener(() -> {
       // check if the map package has expiration information and if so, has it expired yet
-      if (mobileMapPackage.getExpiration() != null && mobileMapPackage.getExpiration().isExpired()) {
+      if (mMobileMapPackage.getExpiration() != null && mMobileMapPackage.getExpiration().isExpired()) {
         // define a format for the date
         SimpleDateFormat daysHoursFormat = new SimpleDateFormat("yyyy-MM-dd' at 'hh:mm:ss", Locale.US);
         // show the expiration text view
         mExpirationMessageTextView.setVisibility(View.VISIBLE);
         // set the expiration message and expiration date to the text view
         mExpirationMessageTextView.setText(getString(R.string.expiration_text,
-            mobileMapPackage.getExpiration().getMessage(),
-            daysHoursFormat.format(mobileMapPackage.getExpiration().getDateTime().getTime())));
-        if (mobileMapPackage.getExpiration().getType() == ExpirationType.ALLOW_EXPIRED_ACCESS) {
+            mMobileMapPackage.getExpiration().getMessage(),
+            daysHoursFormat.format(mMobileMapPackage.getExpiration().getDateTime().getTime())));
+        if (mMobileMapPackage.getExpiration().getType() == ExpirationType.ALLOW_EXPIRED_ACCESS) {
           // add the map to the map view
-          mMapView.setMap(mobileMapPackage.getMaps().get(0));
-        } else if (mobileMapPackage.getExpiration().getType() == ExpirationType.PREVENT_EXPIRED_ACCESS) {
+          mMapView.setMap(mMobileMapPackage.getMaps().get(0));
+        } else if (mMobileMapPackage.getExpiration().getType() == ExpirationType.PREVENT_EXPIRED_ACCESS) {
           Toast.makeText(this, "The author of this mobile map package has disallowed access after the expiration date.",
               Toast.LENGTH_LONG).show();
         }
       }
     });
-    mobileMapPackage.loadAsync();
+    mMobileMapPackage.loadAsync();
   }
 
   @Override

--- a/java/integrated-windows-authentication/src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/MainActivity.java
+++ b/java/integrated-windows-authentication/src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/MainActivity.java
@@ -65,7 +65,7 @@ public class MainActivity extends AppCompatActivity implements AuthenticationCha
   private MapView mMapView;
 
   private UserCredential mUserCredential;
-
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private Portal mPortal;
 
   @Override

--- a/java/integrated-windows-authentication/src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/MainActivity.java
+++ b/java/integrated-windows-authentication/src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/MainActivity.java
@@ -66,6 +66,8 @@ public class MainActivity extends AppCompatActivity implements AuthenticationCha
 
   private UserCredential mUserCredential;
 
+  private Portal mPortal;
+
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -85,11 +87,13 @@ public class MainActivity extends AppCompatActivity implements AuthenticationCha
     mRecyclerView = findViewById(R.id.recyclerView);
     mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
 
+    mPortal = new Portal(getString(R.string.arcgis_url));
+
     // set up search public button
     Button searchPublicButton = findViewById(R.id.searchPublicButton);
     searchPublicButton.setOnClickListener(v -> {
       // search the the public ArcGIS portal
-      searchPortal(new Portal(getString(R.string.arcgis_url)));
+      searchPortal(mPortal);
     });
 
     // get reference to load state UI elements

--- a/java/integrated-windows-authentication/src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/MainActivity.java
+++ b/java/integrated-windows-authentication/src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/MainActivity.java
@@ -87,13 +87,12 @@ public class MainActivity extends AppCompatActivity implements AuthenticationCha
     mRecyclerView = findViewById(R.id.recyclerView);
     mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
 
-    mPortal = new Portal(getString(R.string.arcgis_url));
-
     // set up search public button
     Button searchPublicButton = findViewById(R.id.searchPublicButton);
     searchPublicButton.setOnClickListener(v -> {
       // search the the public ArcGIS portal
-      searchPortal(mPortal);
+      mPortal = new Portal(getString(R.string.arcgis_url));
+      searchPortal();
     });
 
     // get reference to load state UI elements
@@ -109,7 +108,8 @@ public class MainActivity extends AppCompatActivity implements AuthenticationCha
       String securedPortalUrl = portalUrlEditText.getText().toString();
       if (!securedPortalUrl.isEmpty()) {
         // search an instance of the IWA-secured portal, the user may be challenged for access
-        searchPortal(new Portal(securedPortalUrl, true));
+        mPortal = new Portal(securedPortalUrl, true);
+        searchPortal();
       } else {
         String error = "Portal URL is empty. Please enter a portal URL.";
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
@@ -121,12 +121,11 @@ public class MainActivity extends AppCompatActivity implements AuthenticationCha
   /**
    * Search the given portal for its portal items and display them in a recycler view. On click, call AddMap().
    *
-   * @param portal
    */
-  private void searchPortal(Portal portal) {
+  private void searchPortal() {
 
     // check if the the portal is null
-    if (portal == null) {
+    if (mPortal == null) {
       Log.e(TAG, "Portal null");
       return;
     }
@@ -136,34 +135,34 @@ public class MainActivity extends AppCompatActivity implements AuthenticationCha
 
     // show portal load state
     mPortalLoadStateView.setVisibility(View.VISIBLE);
-    mLoadStateTextView.setText("Searching for web map items on the portal at " + portal.getUri());
+    mLoadStateTextView.setText("Searching for web map items on the portal at " + mPortal.getUri());
 
-    portal.loadAsync();
-    portal.addDoneLoadingListener(() -> {
-      if (portal.getLoadStatus() == LoadStatus.LOADED) {
+    mPortal.loadAsync();
+    mPortal.addDoneLoadingListener(() -> {
+      if (mPortal.getLoadStatus() == LoadStatus.LOADED) {
         try {
           // update load state in UI with the portal URI
-          mLoadStateTextView.setText("Connected to the portal on " + new URI(portal.getUri()).getHost());
+          mLoadStateTextView.setText("Connected to the portal on " + new URI(mPortal.getUri()).getHost());
         } catch (URISyntaxException e) {
           String error = "Error getting URI from portal: " + e.getMessage();
           Log.e(TAG, error);
         }
         // report the user name used for this connection.
-        if (portal.getUser() != null) {
-          mLoadStateTextView.setText("Connected as: " + portal.getUser().getUsername());
+        if (mPortal.getUser() != null) {
+          mLoadStateTextView.setText("Connected as: " + mPortal.getUser().getUsername());
         } else {
           // for a secure portal, the user should never be anonymous
           mLoadStateTextView.setText("Connected as: Anonymous");
         }
 
         // search the portal for web maps
-        ListenableFuture<PortalQueryResultSet<PortalItem>> portalItemResult = portal
+        ListenableFuture<PortalQueryResultSet<PortalItem>> portalItemResult = mPortal
             .findItemsAsync(new PortalQueryParameters("type:(\"web map\" NOT \"web mapping application\")"));
         portalItemResult.addDoneListener(() -> {
           try {
             PortalQueryResultSet<PortalItem> portalItemSet = portalItemResult.get();
             PortalItemAdapter portalItemAdapter = new PortalItemAdapter(portalItemSet.getResults(),
-                portalItem -> addMap(portal, portalItem.getItemId()));
+                portalItem -> addMap(mPortal, portalItem.getItemId()));
             mRecyclerView.setAdapter(portalItemAdapter);
             mPortalLoadStateView.setVisibility(View.GONE);
           } catch (ExecutionException | InterruptedException e) {
@@ -179,7 +178,7 @@ public class MainActivity extends AppCompatActivity implements AuthenticationCha
         // hide load state view
         mPortalLoadStateView.setVisibility(View.GONE);
         // report error
-        ArcGISRuntimeException loadError = portal.getLoadError();
+        ArcGISRuntimeException loadError = mPortal.getLoadError();
         String error = "Portal sign in failed: " + loadError.getCause() == null ?
             loadError.getMessage() :
             loadError.getCause().getMessage();

--- a/java/map-image-layer-tables/src/main/java/com/esri/arcgisruntime/sample/mapimagelayertables/MainActivity.java
+++ b/java/map-image-layer-tables/src/main/java/com/esri/arcgisruntime/sample/mapimagelayertables/MainActivity.java
@@ -56,6 +56,7 @@ public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
   private ListView mCommentListView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private ArcGISFeature mServiceRequestFeature;
 
   @Override

--- a/java/navigate-in-ar/src/main/java/com/esri/arcgisruntime/sample/navigateinar/MainActivity.java
+++ b/java/navigate-in-ar/src/main/java/com/esri/arcgisruntime/sample/navigateinar/MainActivity.java
@@ -74,6 +74,8 @@ public class MainActivity extends AppCompatActivity {
 
   private Point mStartPoint;
   private Point mEndPoint;
+
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private RouteTask mRouteTask;
 
   @Override

--- a/java/navigate-in-ar/src/main/java/com/esri/arcgisruntime/sample/navigateinar/MainActivity.java
+++ b/java/navigate-in-ar/src/main/java/com/esri/arcgisruntime/sample/navigateinar/MainActivity.java
@@ -74,6 +74,7 @@ public class MainActivity extends AppCompatActivity {
 
   private Point mStartPoint;
   private Point mEndPoint;
+  private RouteTask mRouteTask;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -117,11 +118,11 @@ public class MainActivity extends AppCompatActivity {
     // set the challenge handler onto the AuthenticationManager
     AuthenticationManager.setAuthenticationChallengeHandler(authenticationChallengeHandler);
     // create and load a route task from the world routing service. This will trigger logging in to your AGOL account
-    RouteTask routeTask = new RouteTask(this, getString(R.string.world_routing_service_url));
-    routeTask.loadAsync();
+    mRouteTask = new RouteTask(this, getString(R.string.world_routing_service_url));
+    mRouteTask.loadAsync();
     // enable the user to specify a route once the service is ready
-    routeTask.addDoneLoadingListener(() -> {
-      if (routeTask.getLoadStatus() == LoadStatus.LOADED) {
+    mRouteTask.addDoneLoadingListener(() -> {
+      if (mRouteTask.getLoadStatus() == LoadStatus.LOADED) {
         // notify the user to place start point
         mHelpLabel.setText(R.string.place_start_message);
         // listen for a single tap
@@ -147,7 +148,7 @@ public class MainActivity extends AppCompatActivity {
               // solve the route between the two points
               // update UI
               mHelpLabel.setText(R.string.solving_route_message);
-              final ListenableFuture<RouteParameters> listenableFuture = routeTask.createDefaultParametersAsync();
+              final ListenableFuture<RouteParameters> listenableFuture = mRouteTask.createDefaultParametersAsync();
               listenableFuture.addDoneListener(() -> {
                 try {
                   RouteParameters routeParameters = listenableFuture.get();
@@ -156,7 +157,7 @@ public class MainActivity extends AppCompatActivity {
                   routeParameters.setReturnDirections(true);
                   routeParameters.setReturnRoutes(true);
                   // this sample is intended for navigating while walking only
-                  List<TravelMode> travelModes = routeTask.getRouteTaskInfo().getTravelModes();
+                  List<TravelMode> travelModes = mRouteTask.getRouteTaskInfo().getTravelModes();
                   TravelMode walkingMode = travelModes.get(0);
                   routeParameters.setTravelMode(walkingMode);
                   // add stops
@@ -167,7 +168,7 @@ public class MainActivity extends AppCompatActivity {
                   // set return directions as true to return turn-by-turn directions in the result of
                   routeParameters.setReturnDirections(true);
                   // solve the route
-                  ListenableFuture<RouteResult> routeResultFuture = routeTask.solveRouteAsync(routeParameters);
+                  ListenableFuture<RouteResult> routeResultFuture = mRouteTask.solveRouteAsync(routeParameters);
                   routeResultFuture.addDoneListener(() -> {
                     try {
                       // get the route result
@@ -205,7 +206,7 @@ public class MainActivity extends AppCompatActivity {
           }
         });
       } else {
-        String error = "Error connecting to route service: " + routeTask.getLoadError().getCause();
+        String error = "Error connecting to route service: " + mRouteTask.getLoadError().getCause();
         Toast.makeText(this, error, Toast.LENGTH_SHORT).show();
         Log.e(TAG, error);
         mHelpLabel.setText(getString(R.string.route_failed_error_message));

--- a/java/open-mobile-map-package/src/main/java/com/esri/arcgisruntime/sample/openmobilemappackage/MainActivity.java
+++ b/java/open-mobile-map-package/src/main/java/com/esri/arcgisruntime/sample/openmobilemappackage/MainActivity.java
@@ -30,6 +30,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private MobileMapPackage mMapPackage;
 
   @Override

--- a/java/open-mobile-map-package/src/main/java/com/esri/arcgisruntime/sample/openmobilemappackage/MainActivity.java
+++ b/java/open-mobile-map-package/src/main/java/com/esri/arcgisruntime/sample/openmobilemappackage/MainActivity.java
@@ -30,7 +30,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
-  private MobileMapPackage mapPackage;
+  private MobileMapPackage mMapPackage;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -42,18 +42,18 @@ public class MainActivity extends AppCompatActivity {
 
     //[DocRef: Name=Open Mobile Map Package-android, Category=Work with maps, Topic=Create an offline map]
     // create the mobile map package
-    mapPackage = new MobileMapPackage(getExternalFilesDir(null) + getString(R.string.yellowstone_mmpk));
+    mMapPackage = new MobileMapPackage(getExternalFilesDir(null) + getString(R.string.yellowstone_mmpk));
     // load the mobile map package asynchronously
-    mapPackage.loadAsync();
+    mMapPackage.loadAsync();
 
     // add done listener which will invoke when mobile map package has loaded
-    mapPackage.addDoneLoadingListener(() -> {
+    mMapPackage.addDoneLoadingListener(() -> {
       // check load status and that the mobile map package has maps
-      if (mapPackage.getLoadStatus() == LoadStatus.LOADED && !mapPackage.getMaps().isEmpty()) {
+      if (mMapPackage.getLoadStatus() == LoadStatus.LOADED && !mMapPackage.getMaps().isEmpty()) {
         // add the map from the mobile map package to the MapView
-        mMapView.setMap(mapPackage.getMaps().get(0));
+        mMapView.setMap(mMapPackage.getMaps().get(0));
       } else {
-        String error = "Error loading mobile map package: " + mapPackage.getLoadError().getMessage();
+        String error = "Error loading mobile map package: " + mMapPackage.getLoadError().getMessage();
         Log.e(TAG, error);
         Toast.makeText(this, error, Toast.LENGTH_SHORT).show();
       }

--- a/java/open-mobile-scene-package/src/main/java/com/esri/arcgisruntime/sample/openmobilescenepackage/MainActivity.java
+++ b/java/open-mobile-scene-package/src/main/java/com/esri/arcgisruntime/sample/openmobilescenepackage/MainActivity.java
@@ -34,6 +34,7 @@ public class MainActivity extends AppCompatActivity {
 
   private static final String TAG = MainActivity.class.getSimpleName();
   private SceneView mSceneView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private MobileScenePackage mMobileScenePackage;
 
   @Override

--- a/java/open-mobile-scene-package/src/main/java/com/esri/arcgisruntime/sample/openmobilescenepackage/MainActivity.java
+++ b/java/open-mobile-scene-package/src/main/java/com/esri/arcgisruntime/sample/openmobilescenepackage/MainActivity.java
@@ -34,6 +34,7 @@ public class MainActivity extends AppCompatActivity {
 
   private static final String TAG = MainActivity.class.getSimpleName();
   private SceneView mSceneView;
+  private MobileScenePackage mMobileScenePackage;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -52,18 +53,17 @@ public class MainActivity extends AppCompatActivity {
     scene.setBaseSurface(surface);
 
     // create a mobile scene package from a path to the mspk
-    MobileScenePackage mobileScenePackage = new MobileScenePackage(
-        getExternalFilesDir(null) + getString(R.string.philadelphia_mspk));
-    mobileScenePackage.addDoneLoadingListener(() -> {
-      if (mobileScenePackage.getLoadStatus() == LoadStatus.LOADED && !mobileScenePackage.getScenes().isEmpty()) {
-        mSceneView.setScene(mobileScenePackage.getScenes().get(0));
+    mMobileScenePackage = new MobileScenePackage(getExternalFilesDir(null) + getString(R.string.philadelphia_mspk));
+    mMobileScenePackage.addDoneLoadingListener(() -> {
+      if (mMobileScenePackage.getLoadStatus() == LoadStatus.LOADED && !mMobileScenePackage.getScenes().isEmpty()) {
+        mSceneView.setScene(mMobileScenePackage.getScenes().get(0));
       } else {
-        String error = "Failed to load mobile scene package: " + mobileScenePackage.getLoadError().getMessage();
+        String error = "Failed to load mobile scene package: " + mMobileScenePackage.getLoadError().getMessage();
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
         Log.e(TAG, error);
       }
     });
-    mobileScenePackage.loadAsync();
+    mMobileScenePackage.loadAsync();
   }
 
   @Override

--- a/java/picture-marker-symbols/src/main/java/com/esri/arcgisruntime/sample/picturemarkersymbols/MainActivity.java
+++ b/java/picture-marker-symbols/src/main/java/com/esri/arcgisruntime/sample/picturemarkersymbols/MainActivity.java
@@ -53,6 +53,9 @@ public class MainActivity extends AppCompatActivity {
   GraphicsOverlay mGraphicsOverlay;
   String mArcGISTempFolderPath;
   String mPinBlankOrangeFilePath;
+  private PictureMarkerSymbol mCampsiteSymbol;
+  private PictureMarkerSymbol mPinStarBlueSymbol;
+  private PictureMarkerSymbol mPinBlankOrangeSymbol;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -81,21 +84,21 @@ public class MainActivity extends AppCompatActivity {
     //[DocRef: Name=Picture Marker Symbol URL, Category=Fundamentals, Topic=Symbols and Renderers]
     //Create a picture marker symbol from a URL resource
     //When using a URL, you need to call load to fetch the remote resource
-    final PictureMarkerSymbol campsiteSymbol = new PictureMarkerSymbol(
+    mCampsiteSymbol = new PictureMarkerSymbol(
         "http://sampleserver6.arcgisonline"
             + ".com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae");
     //Optionally set the size, if not set the image will be auto sized based on its size in pixels,
     //its appearance would then differ across devices with different resolutions.
-    campsiteSymbol.setHeight(18);
-    campsiteSymbol.setWidth(18);
-    campsiteSymbol.loadAsync();
+    mCampsiteSymbol.setHeight(18);
+    mCampsiteSymbol.setWidth(18);
+    mCampsiteSymbol.loadAsync();
     //[DocRef: END]
-    campsiteSymbol.addDoneLoadingListener(new Runnable() {
+    mCampsiteSymbol.addDoneLoadingListener(new Runnable() {
       @Override
       public void run() {
         //Once the symbol has loaded, add a new graphic to the graphic overlay
         Point campsitePoint = new Point(-223560, 6552021, SpatialReferences.getWebMercator());
-        Graphic campsiteGraphic = new Graphic(campsitePoint, campsiteSymbol);
+        Graphic campsiteGraphic = new Graphic(campsitePoint, mCampsiteSymbol);
         mGraphicsOverlay.getGraphics().add(campsiteGraphic);
       }
     });
@@ -103,22 +106,22 @@ public class MainActivity extends AppCompatActivity {
     //[DocRef: Name=Picture Marker Symbol Drawable-android, Category=Fundamentals, Topic=Symbols and Renderers]
     //Create a picture marker symbol from an app resource
     BitmapDrawable pinStarBlueDrawable = (BitmapDrawable) ContextCompat.getDrawable(this, R.drawable.pin_star_blue);
-    final PictureMarkerSymbol pinStarBlueSymbol = new PictureMarkerSymbol(pinStarBlueDrawable);
+    mPinStarBlueSymbol = new PictureMarkerSymbol(pinStarBlueDrawable);
     //Optionally set the size, if not set the image will be auto sized based on its size in pixels,
     //its appearance would then differ across devices with different resolutions.
-    pinStarBlueSymbol.setHeight(40);
-    pinStarBlueSymbol.setWidth(40);
+    mPinStarBlueSymbol.setHeight(40);
+    mPinStarBlueSymbol.setWidth(40);
     //Optionally set the offset, to align the base of the symbol aligns with the point geometry
-    pinStarBlueSymbol.setOffsetY(
+    mPinStarBlueSymbol.setOffsetY(
         11); //The image used for the symbol has a transparent buffer around it, so the offset is not simply height/2
-    pinStarBlueSymbol.loadAsync();
+    mPinStarBlueSymbol.loadAsync();
     //[DocRef: END]
-    pinStarBlueSymbol.addDoneLoadingListener(new Runnable() {
+    mPinStarBlueSymbol.addDoneLoadingListener(new Runnable() {
       @Override
       public void run() {
         //add a new graphic with the same location as the initial viewpoint
         Point pinStarBluePoint = new Point(-226773, 6550477, SpatialReferences.getWebMercator());
-        Graphic pinStarBlueGraphic = new Graphic(pinStarBluePoint, pinStarBlueSymbol);
+        Graphic pinStarBlueGraphic = new Graphic(pinStarBluePoint, mPinStarBlueSymbol);
         mGraphicsOverlay.getGraphics().add(pinStarBlueGraphic);
       }
     });
@@ -138,21 +141,21 @@ public class MainActivity extends AppCompatActivity {
     //[DocRef: Name=Picture Marker Symbol File-android, Category=Fundamentals, Topic=Symbols and Renderers]
     //Create a picture marker symbol from a file on disk
     BitmapDrawable pinBlankOrangeDrawable = (BitmapDrawable) Drawable.createFromPath(mPinBlankOrangeFilePath);
-    final PictureMarkerSymbol pinBlankOrangeSymbol = new PictureMarkerSymbol(pinBlankOrangeDrawable);
+    mPinBlankOrangeSymbol = new PictureMarkerSymbol(pinBlankOrangeDrawable);
     //Optionally set the size, if not set the image will be auto sized based on its size in pixels,
     //its appearance would then differ across devices with different resolutions.
-    pinBlankOrangeSymbol.setHeight(20);
-    pinBlankOrangeSymbol.setWidth(20);
+    mPinBlankOrangeSymbol.setHeight(20);
+    mPinBlankOrangeSymbol.setWidth(20);
     //Optionally set the offset, to align the base of the symbol aligns with the point geometry
-    pinBlankOrangeSymbol.setOffsetY(10); //The image used has not buffer and therefore the Y offset is height/2
-    pinBlankOrangeSymbol.loadAsync();
+    mPinBlankOrangeSymbol.setOffsetY(10); //The image used has not buffer and therefore the Y offset is height/2
+    mPinBlankOrangeSymbol.loadAsync();
     //[DocRef: END]
-    pinBlankOrangeSymbol.addDoneLoadingListener(new Runnable() {
+    mPinBlankOrangeSymbol.addDoneLoadingListener(new Runnable() {
       @Override
       public void run() {
         //add a new graphic with the same location as the initial viewpoint
         Point pinBlankOrangePoint = new Point(-228835, 6550763, SpatialReferences.getWebMercator());
-        Graphic pinBlankOrangeGraphic = new Graphic(pinBlankOrangePoint, pinBlankOrangeSymbol);
+        Graphic pinBlankOrangeGraphic = new Graphic(pinBlankOrangePoint, mPinBlankOrangeSymbol);
         mGraphicsOverlay.getGraphics().add(pinBlankOrangeGraphic);
       }
     });

--- a/java/picture-marker-symbols/src/main/java/com/esri/arcgisruntime/sample/picturemarkersymbols/MainActivity.java
+++ b/java/picture-marker-symbols/src/main/java/com/esri/arcgisruntime/sample/picturemarkersymbols/MainActivity.java
@@ -24,6 +24,7 @@ import android.Manifest;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Picture;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
@@ -86,24 +87,18 @@ public class MainActivity extends AppCompatActivity {
     //[DocRef: Name=Picture Marker Symbol URL, Category=Fundamentals, Topic=Symbols and Renderers]
     //Create a picture marker symbol from a URL resource
     //When using a URL, you need to call load to fetch the remote resource
-    mCampsiteSymbol = new PictureMarkerSymbol(
+    PictureMarkerSymbol campsiteSymbol = new PictureMarkerSymbol(
         "http://sampleserver6.arcgisonline"
             + ".com/arcgis/rest/services/Recreation/FeatureServer/0/images/e82f744ebb069bb35b234b3fea46deae");
     //Optionally set the size, if not set the image will be auto sized based on its size in pixels,
     //its appearance would then differ across devices with different resolutions.
-    mCampsiteSymbol.setHeight(18);
-    mCampsiteSymbol.setWidth(18);
-    mCampsiteSymbol.loadAsync();
+    campsiteSymbol.setHeight(18);
+    campsiteSymbol.setWidth(18);
     //[DocRef: END]
-    mCampsiteSymbol.addDoneLoadingListener(new Runnable() {
-      @Override
-      public void run() {
-        //Once the symbol has loaded, add a new graphic to the graphic overlay
-        Point campsitePoint = new Point(-223560, 6552021, SpatialReferences.getWebMercator());
-        Graphic campsiteGraphic = new Graphic(campsitePoint, mCampsiteSymbol);
-        mGraphicsOverlay.getGraphics().add(campsiteGraphic);
-      }
-    });
+    // add a new graphic to the graphic overlay
+    Point campsitePoint = new Point(-223560, 6552021, SpatialReferences.getWebMercator());
+    Graphic campsiteGraphic = new Graphic(campsitePoint, mCampsiteSymbol);
+    mGraphicsOverlay.getGraphics().add(campsiteGraphic);
 
     //[DocRef: Name=Picture Marker Symbol Drawable-android, Category=Fundamentals, Topic=Symbols and Renderers]
     //Create a picture marker symbol from an app resource

--- a/java/picture-marker-symbols/src/main/java/com/esri/arcgisruntime/sample/picturemarkersymbols/MainActivity.java
+++ b/java/picture-marker-symbols/src/main/java/com/esri/arcgisruntime/sample/picturemarkersymbols/MainActivity.java
@@ -53,6 +53,8 @@ public class MainActivity extends AppCompatActivity {
   GraphicsOverlay mGraphicsOverlay;
   String mArcGISTempFolderPath;
   String mPinBlankOrangeFilePath;
+
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private PictureMarkerSymbol mCampsiteSymbol;
   private PictureMarkerSymbol mPinStarBlueSymbol;
   private PictureMarkerSymbol mPinBlankOrangeSymbol;

--- a/java/picture-marker-symbols/src/main/java/com/esri/arcgisruntime/sample/picturemarkersymbols/MainActivity.java
+++ b/java/picture-marker-symbols/src/main/java/com/esri/arcgisruntime/sample/picturemarkersymbols/MainActivity.java
@@ -55,11 +55,6 @@ public class MainActivity extends AppCompatActivity {
   String mArcGISTempFolderPath;
   String mPinBlankOrangeFilePath;
 
-  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
-  private PictureMarkerSymbol mCampsiteSymbol;
-  private PictureMarkerSymbol mPinStarBlueSymbol;
-  private PictureMarkerSymbol mPinBlankOrangeSymbol;
-
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -97,31 +92,26 @@ public class MainActivity extends AppCompatActivity {
     //[DocRef: END]
     // add a new graphic to the graphic overlay
     Point campsitePoint = new Point(-223560, 6552021, SpatialReferences.getWebMercator());
-    Graphic campsiteGraphic = new Graphic(campsitePoint, mCampsiteSymbol);
+    Graphic campsiteGraphic = new Graphic(campsitePoint, campsiteSymbol);
     mGraphicsOverlay.getGraphics().add(campsiteGraphic);
 
     //[DocRef: Name=Picture Marker Symbol Drawable-android, Category=Fundamentals, Topic=Symbols and Renderers]
     //Create a picture marker symbol from an app resource
     BitmapDrawable pinStarBlueDrawable = (BitmapDrawable) ContextCompat.getDrawable(this, R.drawable.pin_star_blue);
-    mPinStarBlueSymbol = new PictureMarkerSymbol(pinStarBlueDrawable);
+    PictureMarkerSymbol pinStarBlueSymbol = new PictureMarkerSymbol(pinStarBlueDrawable);
     //Optionally set the size, if not set the image will be auto sized based on its size in pixels,
     //its appearance would then differ across devices with different resolutions.
-    mPinStarBlueSymbol.setHeight(40);
-    mPinStarBlueSymbol.setWidth(40);
+    pinStarBlueSymbol.setHeight(40);
+    pinStarBlueSymbol.setWidth(40);
     //Optionally set the offset, to align the base of the symbol aligns with the point geometry
-    mPinStarBlueSymbol.setOffsetY(
+    pinStarBlueSymbol.setOffsetY(
         11); //The image used for the symbol has a transparent buffer around it, so the offset is not simply height/2
-    mPinStarBlueSymbol.loadAsync();
+    pinStarBlueSymbol.loadAsync();
     //[DocRef: END]
-    mPinStarBlueSymbol.addDoneLoadingListener(new Runnable() {
-      @Override
-      public void run() {
-        //add a new graphic with the same location as the initial viewpoint
-        Point pinStarBluePoint = new Point(-226773, 6550477, SpatialReferences.getWebMercator());
-        Graphic pinStarBlueGraphic = new Graphic(pinStarBluePoint, mPinStarBlueSymbol);
-        mGraphicsOverlay.getGraphics().add(pinStarBlueGraphic);
-      }
-    });
+    //add a new graphic with the same location as the initial viewpoint
+    Point pinStarBluePoint = new Point(-226773, 6550477, SpatialReferences.getWebMercator());
+    Graphic pinStarBlueGraphic = new Graphic(pinStarBluePoint, pinStarBlueSymbol);
+    mGraphicsOverlay.getGraphics().add(pinStarBlueGraphic);
 
     //see createPictureMarkerSymbolFromFile() method for implementation
     //first run checks for external storage and permissions,
@@ -138,24 +128,20 @@ public class MainActivity extends AppCompatActivity {
     //[DocRef: Name=Picture Marker Symbol File-android, Category=Fundamentals, Topic=Symbols and Renderers]
     //Create a picture marker symbol from a file on disk
     BitmapDrawable pinBlankOrangeDrawable = (BitmapDrawable) Drawable.createFromPath(mPinBlankOrangeFilePath);
-    mPinBlankOrangeSymbol = new PictureMarkerSymbol(pinBlankOrangeDrawable);
+    PictureMarkerSymbol pinBlankOrangeSymbol = new PictureMarkerSymbol(pinBlankOrangeDrawable);
     //Optionally set the size, if not set the image will be auto sized based on its size in pixels,
     //its appearance would then differ across devices with different resolutions.
-    mPinBlankOrangeSymbol.setHeight(20);
-    mPinBlankOrangeSymbol.setWidth(20);
+    pinBlankOrangeSymbol.setHeight(20);
+    pinBlankOrangeSymbol.setWidth(20);
     //Optionally set the offset, to align the base of the symbol aligns with the point geometry
-    mPinBlankOrangeSymbol.setOffsetY(10); //The image used has not buffer and therefore the Y offset is height/2
-    mPinBlankOrangeSymbol.loadAsync();
+    pinBlankOrangeSymbol.setOffsetY(10); //The image used has not buffer and therefore the Y offset is height/2
+    pinBlankOrangeSymbol.loadAsync();
     //[DocRef: END]
-    mPinBlankOrangeSymbol.addDoneLoadingListener(new Runnable() {
-      @Override
-      public void run() {
-        //add a new graphic with the same location as the initial viewpoint
-        Point pinBlankOrangePoint = new Point(-228835, 6550763, SpatialReferences.getWebMercator());
-        Graphic pinBlankOrangeGraphic = new Graphic(pinBlankOrangePoint, mPinBlankOrangeSymbol);
-        mGraphicsOverlay.getGraphics().add(pinBlankOrangeGraphic);
-      }
-    });
+
+    //add a new graphic with the same location as the initial viewpoint
+    Point pinBlankOrangePoint = new Point(-228835, 6550763, SpatialReferences.getWebMercator());
+    Graphic pinBlankOrangeGraphic = new Graphic(pinBlankOrangePoint, pinBlankOrangeSymbol);
+    mGraphicsOverlay.getGraphics().add(pinBlankOrangeGraphic);
 
   }
 

--- a/java/portal-user-info/src/main/java/com/esri/arcgisruntime/sample/portaluserinfo/MainActivity.java
+++ b/java/portal-user-info/src/main/java/com/esri/arcgisruntime/sample/portaluserinfo/MainActivity.java
@@ -47,6 +47,7 @@ public class MainActivity extends AppCompatActivity {
   private TextView mPortalNameText;
   private TextView mCreateDate;
   private ImageView mUserImage;
+  private Portal mPortal;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -63,19 +64,19 @@ public class MainActivity extends AppCompatActivity {
 
     // Set loginRequired to true always prompt for credential,
     // When set to false to only login if required by the portal
-    final Portal portal = new Portal(getString(R.string.portal_url), true);
-    portal.addDoneLoadingListener(() -> {
-      if (portal.getLoadStatus() == LoadStatus.LOADED) {
+    mPortal = new Portal(getString(R.string.portal_url), true);
+    mPortal.addDoneLoadingListener(() -> {
+      if (mPortal.getLoadStatus() == LoadStatus.LOADED) {
         // Get the portal information
-        PortalInfo portalInformation = portal.getPortalInfo();
+        PortalInfo portalInformation = mPortal.getPortalInfo();
         String portalName = portalInformation.getPortalName();
         mPortalNameText = (TextView) findViewById(R.id.portal);
         mPortalNameText.setText(portalName);
 
         // this portal does not require authentication, if null send toast message
-        if (portal.getUser() != null) {
+        if (mPortal.getUser() != null) {
           // Get the authenticated portal user
-          PortalUser user = portal.getUser();
+          PortalUser user = mPortal.getUser();
           // get the users full name
           String userName = user.getFullName();
           // update the textview
@@ -130,7 +131,7 @@ public class MainActivity extends AppCompatActivity {
         }
       }
     });
-    portal.loadAsync();
+    mPortal.loadAsync();
   }
 }
 

--- a/java/portal-user-info/src/main/java/com/esri/arcgisruntime/sample/portaluserinfo/MainActivity.java
+++ b/java/portal-user-info/src/main/java/com/esri/arcgisruntime/sample/portaluserinfo/MainActivity.java
@@ -47,6 +47,7 @@ public class MainActivity extends AppCompatActivity {
   private TextView mPortalNameText;
   private TextView mCreateDate;
   private ImageView mUserImage;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private Portal mPortal;
 
   @Override

--- a/java/raster-layer-geopackage/src/main/java/com/esri/arcgisruntime/sample/rasterlayergeopackage/MainActivity.java
+++ b/java/raster-layer-geopackage/src/main/java/com/esri/arcgisruntime/sample/rasterlayergeopackage/MainActivity.java
@@ -34,6 +34,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private GeoPackage mGeoPackage;
 
   @Override

--- a/java/raster-layer-geopackage/src/main/java/com/esri/arcgisruntime/sample/rasterlayergeopackage/MainActivity.java
+++ b/java/raster-layer-geopackage/src/main/java/com/esri/arcgisruntime/sample/rasterlayergeopackage/MainActivity.java
@@ -34,6 +34,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  private GeoPackage mGeoPackage;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -48,13 +49,13 @@ public class MainActivity extends AppCompatActivity {
     mMapView.setMap(map);
 
     // open the GeoPackage
-    GeoPackage geoPackage = new GeoPackage(getExternalFilesDir(null) + getString(R.string.geopackage_path));
-    geoPackage.loadAsync();
-    geoPackage.addDoneLoadingListener(() -> {
-      if (geoPackage.getLoadStatus() == LoadStatus.LOADED) {
-        if (!geoPackage.getGeoPackageRasters().isEmpty()) {
+    mGeoPackage = new GeoPackage(getExternalFilesDir(null) + getString(R.string.geopackage_path));
+    mGeoPackage.loadAsync();
+    mGeoPackage.addDoneLoadingListener(() -> {
+      if (mGeoPackage.getLoadStatus() == LoadStatus.LOADED) {
+        if (!mGeoPackage.getGeoPackageRasters().isEmpty()) {
           // read raster images and get the first one
-          Raster geoPackageRaster = geoPackage.getGeoPackageRasters().get(0);
+          Raster geoPackageRaster = mGeoPackage.getGeoPackageRasters().get(0);
           // create a layer to show the raster
           RasterLayer geoPackageRasterLayer = new RasterLayer(geoPackageRaster);
           // add the image as a raster layer to the map (with default symbology)

--- a/java/read-geopackage/src/main/java/com/esri/arcgisruntime/sample/readgeopackage/MainActivity.java
+++ b/java/read-geopackage/src/main/java/com/esri/arcgisruntime/sample/readgeopackage/MainActivity.java
@@ -37,6 +37,7 @@ public class MainActivity extends AppCompatActivity {
   private final static String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  private GeoPackage mGeoPackage;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -51,18 +52,18 @@ public class MainActivity extends AppCompatActivity {
     mMapView.setMap(map);
 
     // open and load the GeoPackage
-    GeoPackage geoPackage = new GeoPackage(getExternalFilesDir(null) + getString(R.string.geopackage_path));
-    geoPackage.loadAsync();
-    geoPackage.addDoneLoadingListener(() -> {
-      if (geoPackage.getLoadStatus() == LoadStatus.FAILED_TO_LOAD) {
-        String error = "Geopackage failed to load: " + geoPackage.getLoadError();
+    mGeoPackage = new GeoPackage(getExternalFilesDir(null) + getString(R.string.geopackage_path));
+    mGeoPackage.loadAsync();
+    mGeoPackage.addDoneLoadingListener(() -> {
+      if (mGeoPackage.getLoadStatus() == LoadStatus.FAILED_TO_LOAD) {
+        String error = "Geopackage failed to load: " + mGeoPackage.getLoadError();
         Log.e(TAG, error);
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
         return;
       }
 
       // loop through each GeoPackageRaster
-      for (GeoPackageRaster geoPackageRaster : geoPackage.getGeoPackageRasters()) {
+      for (GeoPackageRaster geoPackageRaster : mGeoPackage.getGeoPackageRasters()) {
         // create a RasterLayer from the GeoPackageRaster
         RasterLayer rasterLayer = new RasterLayer(geoPackageRaster);
 
@@ -74,7 +75,7 @@ public class MainActivity extends AppCompatActivity {
       }
 
       // loop through each GeoPackageFeatureTable
-      for (GeoPackageFeatureTable geoPackageFeatureTable : geoPackage.getGeoPackageFeatureTables()) {
+      for (GeoPackageFeatureTable geoPackageFeatureTable : mGeoPackage.getGeoPackageFeatureTables()) {
         // create a FeatureLayer from the GeoPackageFeatureLayer
         FeatureLayer featureLayer = new FeatureLayer(geoPackageFeatureTable);
 

--- a/java/read-geopackage/src/main/java/com/esri/arcgisruntime/sample/readgeopackage/MainActivity.java
+++ b/java/read-geopackage/src/main/java/com/esri/arcgisruntime/sample/readgeopackage/MainActivity.java
@@ -37,6 +37,7 @@ public class MainActivity extends AppCompatActivity {
   private final static String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private GeoPackage mGeoPackage;
 
   @Override

--- a/java/style-wms-layer/src/main/java/com/esri/arcgisruntime/stylewmslayer/MainActivity.java
+++ b/java/style-wms-layer/src/main/java/com/esri/arcgisruntime/stylewmslayer/MainActivity.java
@@ -36,6 +36,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private WmsLayer mWmsLayer;
 
   @Override

--- a/java/style-wms-layer/src/main/java/com/esri/arcgisruntime/stylewmslayer/MainActivity.java
+++ b/java/style-wms-layer/src/main/java/com/esri/arcgisruntime/stylewmslayer/MainActivity.java
@@ -36,6 +36,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
+  private WmsLayer mWmsLayer;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -49,34 +50,34 @@ public class MainActivity extends AppCompatActivity {
 
     // create a WMS layer
     List<String> wmsLayerNames = Collections.singletonList(getString(R.string.wms_layer_name_minnesota));
-    WmsLayer wmsLayer = new WmsLayer(getString(R.string.wms_layer_url_minnesota), wmsLayerNames);
-    wmsLayer.loadAsync();
-    wmsLayer.addDoneLoadingListener(() -> {
-      if (wmsLayer.getLoadStatus() == LoadStatus.LOADED) {
+    mWmsLayer = new WmsLayer(getString(R.string.wms_layer_url_minnesota), wmsLayerNames);
+    mWmsLayer.loadAsync();
+    mWmsLayer.addDoneLoadingListener(() -> {
+      if (mWmsLayer.getLoadStatus() == LoadStatus.LOADED) {
         // add the layer to the map
-        map.getOperationalLayers().add(wmsLayer);
+        map.getOperationalLayers().add(mWmsLayer);
 
         // zoom to the layer on the map
-        mMapView.setViewpoint(new Viewpoint(wmsLayer.getFullExtent()));
+        mMapView.setViewpoint(new Viewpoint(mWmsLayer.getFullExtent()));
 
         // get styles
-        List<String> styles = wmsLayer.getSublayers().get(0).getSublayerInfo().getStyles();
+        List<String> styles = mWmsLayer.getSublayers().get(0).getSublayerInfo().getStyles();
 
         // set the style when the button is toggled
         ToggleButton toggle = findViewById(R.id.toggleStyleButton);
         toggle.setOnCheckedChangeListener((buttonView, isChecked) -> {
           if (isChecked) {
             // set the sublayer's current style
-            wmsLayer.getSublayers().get(0).setCurrentStyle(styles.get(1));
+            mWmsLayer.getSublayers().get(0).setCurrentStyle(styles.get(1));
           } else {
             //[DocRef: Name=Set WMS Layer Style, Category=Fundamentals, Topic=Symbols and Renderers]
             // set the sublayer's current style
-            wmsLayer.getSublayers().get(0).setCurrentStyle(styles.get(0));
+            mWmsLayer.getSublayers().get(0).setCurrentStyle(styles.get(0));
             //[DocRef: END]
           }
         });
       } else {
-        String error = "Failed to load WMS layer: " + wmsLayer.getLoadError().getMessage();
+        String error = "Failed to load WMS layer: " + mWmsLayer.getLoadError().getMessage();
         Log.e(TAG, error);
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
       }

--- a/java/style-wms-layer/src/main/java/com/esri/arcgisruntime/stylewmslayer/MainActivity.java
+++ b/java/style-wms-layer/src/main/java/com/esri/arcgisruntime/stylewmslayer/MainActivity.java
@@ -36,8 +36,6 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private MapView mMapView;
-  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
-  private WmsLayer mWmsLayer;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -51,34 +49,32 @@ public class MainActivity extends AppCompatActivity {
 
     // create a WMS layer
     List<String> wmsLayerNames = Collections.singletonList(getString(R.string.wms_layer_name_minnesota));
-    mWmsLayer = new WmsLayer(getString(R.string.wms_layer_url_minnesota), wmsLayerNames);
-    mWmsLayer.loadAsync();
-    mWmsLayer.addDoneLoadingListener(() -> {
-      if (mWmsLayer.getLoadStatus() == LoadStatus.LOADED) {
-        // add the layer to the map
-        map.getOperationalLayers().add(mWmsLayer);
-
+    WmsLayer wmsLayer = new WmsLayer(getString(R.string.wms_layer_url_minnesota), wmsLayerNames);
+    // add the layer to the map
+    map.getOperationalLayers().add(wmsLayer);
+    wmsLayer.addDoneLoadingListener(() -> {
+      if (wmsLayer.getLoadStatus() == LoadStatus.LOADED) {
         // zoom to the layer on the map
-        mMapView.setViewpoint(new Viewpoint(mWmsLayer.getFullExtent()));
+        mMapView.setViewpoint(new Viewpoint(wmsLayer.getFullExtent()));
 
         // get styles
-        List<String> styles = mWmsLayer.getSublayers().get(0).getSublayerInfo().getStyles();
+        List<String> styles = wmsLayer.getSublayers().get(0).getSublayerInfo().getStyles();
 
         // set the style when the button is toggled
         ToggleButton toggle = findViewById(R.id.toggleStyleButton);
         toggle.setOnCheckedChangeListener((buttonView, isChecked) -> {
           if (isChecked) {
             // set the sublayer's current style
-            mWmsLayer.getSublayers().get(0).setCurrentStyle(styles.get(1));
+            wmsLayer.getSublayers().get(0).setCurrentStyle(styles.get(1));
           } else {
             //[DocRef: Name=Set WMS Layer Style, Category=Fundamentals, Topic=Symbols and Renderers]
             // set the sublayer's current style
-            mWmsLayer.getSublayers().get(0).setCurrentStyle(styles.get(0));
+            wmsLayer.getSublayers().get(0).setCurrentStyle(styles.get(0));
             //[DocRef: END]
           }
         });
       } else {
-        String error = "Failed to load WMS layer: " + mWmsLayer.getLoadError().getMessage();
+        String error = "Failed to load WMS layer: " + wmsLayer.getLoadError().getMessage();
         Log.e(TAG, error);
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
       }

--- a/java/view-content-beneath-the-terrain-surface/src/main/java/com/esri/arcgisruntime/sample/viewcontentbeneaththeterrainsurface/MainActivity.java
+++ b/java/view-content-beneath-the-terrain-surface/src/main/java/com/esri/arcgisruntime/sample/viewcontentbeneaththeterrainsurface/MainActivity.java
@@ -34,6 +34,9 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private SceneView mSceneView;
+  private Portal mPortal;
+  private PortalItem mPortalItem;
+  private ArcGISScene mScene;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -42,36 +45,36 @@ public class MainActivity extends AppCompatActivity {
 
     mSceneView = findViewById(R.id.sceneView);
 
-    Portal portal = new Portal(getString(R.string.arcgis_online_url));
-    portal.addDoneLoadingListener(() -> {
-      if (portal.getLoadStatus() == LoadStatus.LOADED) {
-        PortalItem portalItem = new PortalItem(portal, getString(R.string.subsurface_item_id));
-        portalItem.addDoneLoadingListener(() -> {
-          if (portalItem.getLoadStatus() == LoadStatus.LOADED) {
+    mPortal = new Portal(getString(R.string.arcgis_online_url));
+    mPortal.addDoneLoadingListener(() -> {
+      if (mPortal.getLoadStatus() == LoadStatus.LOADED) {
+        mPortalItem = new PortalItem(mPortal, getString(R.string.subsurface_item_id));
+        mPortalItem.addDoneLoadingListener(() -> {
+          if (mPortalItem.getLoadStatus() == LoadStatus.LOADED) {
             // create a scene from a web scene Url and set it to the scene view
-            ArcGISScene scene = new ArcGISScene(portalItem);
+            mScene = new ArcGISScene(mPortalItem);
             // when the scene has loaded, set navigation constraint and opacity to see below the surface
-            scene.addDoneLoadingListener(() -> {
+            mScene.addDoneLoadingListener(() -> {
               // ensure the navigation constraint is set to NONE
-              scene.getBaseSurface().setNavigationConstraint(NavigationConstraint.NONE);
+              mScene.getBaseSurface().setNavigationConstraint(NavigationConstraint.NONE);
               // set opacity to view content beneath the base surface
-              scene.getBaseSurface().setOpacity(0.5f);
+              mScene.getBaseSurface().setOpacity(0.5f);
             });
-            mSceneView.setScene(scene);
+            mSceneView.setScene(mScene);
           } else {
-            String error = "Portal item failed to load: " + portalItem.getLoadError().getMessage();
+            String error = "Portal item failed to load: " + mPortalItem.getLoadError().getMessage();
             Toast.makeText(this, error, Toast.LENGTH_LONG).show();
             Log.e(TAG, error);
           }
         });
-        portalItem.loadAsync();
+        mPortalItem.loadAsync();
       } else {
-        String error = "Portal failed to load: " + portal.getLoadError().getMessage();
+        String error = "Portal failed to load: " + mPortal.getLoadError().getMessage();
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
         Log.e(TAG, error);
       }
     });
-    portal.loadAsync();
+    mPortal.loadAsync();
   }
 
   @Override

--- a/java/view-content-beneath-the-terrain-surface/src/main/java/com/esri/arcgisruntime/sample/viewcontentbeneaththeterrainsurface/MainActivity.java
+++ b/java/view-content-beneath-the-terrain-surface/src/main/java/com/esri/arcgisruntime/sample/viewcontentbeneaththeterrainsurface/MainActivity.java
@@ -44,7 +44,14 @@ public class MainActivity extends AppCompatActivity {
 
     Portal portal = new Portal(getString(R.string.arcgis_online_url));
     PortalItem portalItem = new PortalItem(portal, getString(R.string.subsurface_item_id));
-
+    // catch any load errors from the portal items
+    portalItem.addDoneLoadingListener(() -> {
+      if (portalItem.getLoadStatus() != LoadStatus.LOADED) {
+        String error = "Portal item failed to load: " + portalItem.getLoadError();
+        Log.e(TAG, error);
+        Toast.makeText(this, error, Toast.LENGTH_LONG).show();
+      }
+    });
     // create a scene from a web scene Url and set it to the scene view
     ArcGISScene scene = new ArcGISScene(portalItem);
     // ensure the navigation constraint is set to NONE

--- a/java/view-content-beneath-the-terrain-surface/src/main/java/com/esri/arcgisruntime/sample/viewcontentbeneaththeterrainsurface/MainActivity.java
+++ b/java/view-content-beneath-the-terrain-surface/src/main/java/com/esri/arcgisruntime/sample/viewcontentbeneaththeterrainsurface/MainActivity.java
@@ -34,10 +34,6 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private SceneView mSceneView;
-  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
-  private Portal mPortal;
-  private PortalItem mPortalItem;
-  private ArcGISScene mScene;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -46,36 +42,17 @@ public class MainActivity extends AppCompatActivity {
 
     mSceneView = findViewById(R.id.sceneView);
 
-    mPortal = new Portal(getString(R.string.arcgis_online_url));
-    mPortal.addDoneLoadingListener(() -> {
-      if (mPortal.getLoadStatus() == LoadStatus.LOADED) {
-        mPortalItem = new PortalItem(mPortal, getString(R.string.subsurface_item_id));
-        mPortalItem.addDoneLoadingListener(() -> {
-          if (mPortalItem.getLoadStatus() == LoadStatus.LOADED) {
-            // create a scene from a web scene Url and set it to the scene view
-            mScene = new ArcGISScene(mPortalItem);
-            // when the scene has loaded, set navigation constraint and opacity to see below the surface
-            mScene.addDoneLoadingListener(() -> {
-              // ensure the navigation constraint is set to NONE
-              mScene.getBaseSurface().setNavigationConstraint(NavigationConstraint.NONE);
-              // set opacity to view content beneath the base surface
-              mScene.getBaseSurface().setOpacity(0.5f);
-            });
-            mSceneView.setScene(mScene);
-          } else {
-            String error = "Portal item failed to load: " + mPortalItem.getLoadError().getMessage();
-            Toast.makeText(this, error, Toast.LENGTH_LONG).show();
-            Log.e(TAG, error);
-          }
-        });
-        mPortalItem.loadAsync();
-      } else {
-        String error = "Portal failed to load: " + mPortal.getLoadError().getMessage();
-        Toast.makeText(this, error, Toast.LENGTH_LONG).show();
-        Log.e(TAG, error);
-      }
-    });
-    mPortal.loadAsync();
+    Portal portal = new Portal(getString(R.string.arcgis_online_url));
+    PortalItem portalItem = new PortalItem(portal, getString(R.string.subsurface_item_id));
+
+    // create a scene from a web scene Url and set it to the scene view
+    ArcGISScene scene = new ArcGISScene(portalItem);
+    // ensure the navigation constraint is set to NONE
+    scene.getBaseSurface().setNavigationConstraint(NavigationConstraint.NONE);
+    // set opacity to view content beneath the base surface
+    scene.getBaseSurface().setOpacity(0.5f);
+
+    mSceneView.setScene(scene);
   }
 
   @Override

--- a/java/view-content-beneath-the-terrain-surface/src/main/java/com/esri/arcgisruntime/sample/viewcontentbeneaththeterrainsurface/MainActivity.java
+++ b/java/view-content-beneath-the-terrain-surface/src/main/java/com/esri/arcgisruntime/sample/viewcontentbeneaththeterrainsurface/MainActivity.java
@@ -34,6 +34,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private SceneView mSceneView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private Portal mPortal;
   private PortalItem mPortalItem;
   private ArcGISScene mScene;

--- a/java/view-point-cloud-data-offline/src/main/java/com/esri/arcgisruntime/sample/viewpointclouddataoffline/MainActivity.java
+++ b/java/view-point-cloud-data-offline/src/main/java/com/esri/arcgisruntime/sample/viewpointclouddataoffline/MainActivity.java
@@ -36,8 +36,6 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private SceneView mSceneView;
-  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
-  private PointCloudLayer mPointCloudLayer;
 
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -61,24 +59,21 @@ public class MainActivity extends AppCompatActivity {
     scene.setBaseSurface(surface);
 
     // add a PointCloudLayer to the scene by passing the URI of the scene layer package to the constructor
-    mPointCloudLayer = new PointCloudLayer(
+    PointCloudLayer pointCloudLayer = new PointCloudLayer(
         getExternalFilesDir(null) + getString(R.string.scene_layer_package_location));
 
+    // add the PointCloudLayer to the operational layers of the scene
+    mSceneView.getScene().getOperationalLayers().add(pointCloudLayer);
+
     // add a listener to perform operations when the load status of the PointCloudLayer changes
-    mPointCloudLayer.addDoneLoadingListener(() -> {
-      if (mPointCloudLayer.getLoadStatus() == LoadStatus.LOADED) {
-        // add the PointCloudLayer to the operational layers of the scene
-        mSceneView.getScene().getOperationalLayers().add(mPointCloudLayer);
-      } else {
+    pointCloudLayer.addDoneLoadingListener(() -> {
+      if (pointCloudLayer.getLoadStatus() != LoadStatus.LOADED) {
         // notify user that the PointCloudLayer has failed to load
-        String error = "Point cloud layer failed to load: " + mPointCloudLayer.getLoadError().getMessage();
+        String error = "Point cloud layer failed to load: " + pointCloudLayer.getLoadError().getMessage();
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
         Log.e(TAG, error);
       }
     });
-
-    // load the PointCloudLayer asynchronously
-    mPointCloudLayer.loadAsync();
   }
 
   @Override protected void onResume() {

--- a/java/view-point-cloud-data-offline/src/main/java/com/esri/arcgisruntime/sample/viewpointclouddataoffline/MainActivity.java
+++ b/java/view-point-cloud-data-offline/src/main/java/com/esri/arcgisruntime/sample/viewpointclouddataoffline/MainActivity.java
@@ -36,6 +36,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private SceneView mSceneView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private PointCloudLayer mPointCloudLayer;
 
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/java/view-point-cloud-data-offline/src/main/java/com/esri/arcgisruntime/sample/viewpointclouddataoffline/MainActivity.java
+++ b/java/view-point-cloud-data-offline/src/main/java/com/esri/arcgisruntime/sample/viewpointclouddataoffline/MainActivity.java
@@ -36,6 +36,7 @@ public class MainActivity extends AppCompatActivity {
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private SceneView mSceneView;
+  private PointCloudLayer mPointCloudLayer;
 
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -59,24 +60,24 @@ public class MainActivity extends AppCompatActivity {
     scene.setBaseSurface(surface);
 
     // add a PointCloudLayer to the scene by passing the URI of the scene layer package to the constructor
-    PointCloudLayer pointCloudLayer = new PointCloudLayer(
+    mPointCloudLayer = new PointCloudLayer(
         getExternalFilesDir(null) + getString(R.string.scene_layer_package_location));
 
     // add a listener to perform operations when the load status of the PointCloudLayer changes
-    pointCloudLayer.addDoneLoadingListener(() -> {
-      if (pointCloudLayer.getLoadStatus() == LoadStatus.LOADED) {
+    mPointCloudLayer.addDoneLoadingListener(() -> {
+      if (mPointCloudLayer.getLoadStatus() == LoadStatus.LOADED) {
         // add the PointCloudLayer to the operational layers of the scene
-        mSceneView.getScene().getOperationalLayers().add(pointCloudLayer);
+        mSceneView.getScene().getOperationalLayers().add(mPointCloudLayer);
       } else {
         // notify user that the PointCloudLayer has failed to load
-        String error = "Point cloud layer failed to load: " + pointCloudLayer.getLoadError().getMessage();
+        String error = "Point cloud layer failed to load: " + mPointCloudLayer.getLoadError().getMessage();
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
         Log.e(TAG, error);
       }
     });
 
     // load the PointCloudLayer asynchronously
-    pointCloudLayer.loadAsync();
+    mPointCloudLayer.loadAsync();
   }
 
   @Override protected void onResume() {

--- a/java/viewshed-geoprocessing/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoprocessing/MainActivity.java
+++ b/java/viewshed-geoprocessing/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoprocessing/MainActivity.java
@@ -59,6 +59,7 @@ public class MainActivity extends AppCompatActivity {
 
   private GraphicsOverlay mInputGraphicsOverlay;
   private GraphicsOverlay mResultGraphicsOverlay;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private FeatureCollectionTable mFeatureCollectionTable;
 
   @Override

--- a/java/viewshed-geoprocessing/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoprocessing/MainActivity.java
+++ b/java/viewshed-geoprocessing/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoprocessing/MainActivity.java
@@ -59,6 +59,7 @@ public class MainActivity extends AppCompatActivity {
 
   private GraphicsOverlay mInputGraphicsOverlay;
   private GraphicsOverlay mResultGraphicsOverlay;
+  private FeatureCollectionTable mFeatureCollectionTable;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -137,20 +138,19 @@ public class MainActivity extends AppCompatActivity {
     fields.add(field);
 
     // create feature collection table for point geometry
-    final FeatureCollectionTable featureCollectionTable = new FeatureCollectionTable(fields, GeometryType.POINT,
-        point.getSpatialReference());
-    featureCollectionTable.loadAsync();
+    mFeatureCollectionTable = new FeatureCollectionTable(fields, GeometryType.POINT, point.getSpatialReference());
+    mFeatureCollectionTable.loadAsync();
 
     // create a new feature and assign the geometry
-    Feature newFeature = featureCollectionTable.createFeature();
+    Feature newFeature = mFeatureCollectionTable.createFeature();
     newFeature.setGeometry(point);
 
     // add newFeature and call performGeoprocessing on done loading
-    featureCollectionTable.addFeatureAsync(newFeature);
-    featureCollectionTable.addDoneLoadingListener(new Runnable() {
+    mFeatureCollectionTable.addFeatureAsync(newFeature);
+    mFeatureCollectionTable.addDoneLoadingListener(new Runnable() {
       @Override public void run() {
-        if (featureCollectionTable.getLoadStatus() == LoadStatus.LOADED) {
-          performGeoprocessing(featureCollectionTable);
+        if (mFeatureCollectionTable.getLoadStatus() == LoadStatus.LOADED) {
+          performGeoprocessing(mFeatureCollectionTable);
         }
       }
     });

--- a/java/web-tiledlayer/src/main/java/com/esri/arcgisruntime/sample/webtiledlayer/MainActivity.java
+++ b/java/web-tiledlayer/src/main/java/com/esri/arcgisruntime/sample/webtiledlayer/MainActivity.java
@@ -31,6 +31,7 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
+  private WebTiledLayer mWebTiledLayer;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -44,15 +45,15 @@ public class MainActivity extends AppCompatActivity {
     List<String> subDomains = Arrays.asList("a", "b", "c", "d");
 
     // build the web tiled layer from stamen
-    final WebTiledLayer webTiledLayer = new WebTiledLayer(getString(R.string.template_uri_stamen), subDomains);
-    webTiledLayer.loadAsync();
-    webTiledLayer.addDoneLoadingListener(() -> {
-      if (webTiledLayer.getLoadStatus() == LoadStatus.LOADED) {
+    mWebTiledLayer = new WebTiledLayer(getString(R.string.template_uri_stamen), subDomains);
+    mWebTiledLayer.loadAsync();
+    mWebTiledLayer.addDoneLoadingListener(() -> {
+      if (mWebTiledLayer.getLoadStatus() == LoadStatus.LOADED) {
         // use web tiled layer as Basemap
-        ArcGISMap map = new ArcGISMap(new Basemap(webTiledLayer));
+        ArcGISMap map = new ArcGISMap(new Basemap(mWebTiledLayer));
         mMapView.setMap(map);
         // custom attributes
-        webTiledLayer.setAttribution(getString(R.string.stamen_attribution));
+        mWebTiledLayer.setAttribution(getString(R.string.stamen_attribution));
       }
     });
   }

--- a/java/web-tiledlayer/src/main/java/com/esri/arcgisruntime/sample/webtiledlayer/MainActivity.java
+++ b/java/web-tiledlayer/src/main/java/com/esri/arcgisruntime/sample/webtiledlayer/MainActivity.java
@@ -31,6 +31,7 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private WebTiledLayer mWebTiledLayer;
 
   @Override

--- a/java/web-tiledlayer/src/main/java/com/esri/arcgisruntime/sample/webtiledlayer/MainActivity.java
+++ b/java/web-tiledlayer/src/main/java/com/esri/arcgisruntime/sample/webtiledlayer/MainActivity.java
@@ -31,8 +31,6 @@ import com.esri.arcgisruntime.mapping.view.MapView;
 public class MainActivity extends AppCompatActivity {
 
   private MapView mMapView;
-  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
-  private WebTiledLayer mWebTiledLayer;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -46,17 +44,12 @@ public class MainActivity extends AppCompatActivity {
     List<String> subDomains = Arrays.asList("a", "b", "c", "d");
 
     // build the web tiled layer from stamen
-    mWebTiledLayer = new WebTiledLayer(getString(R.string.template_uri_stamen), subDomains);
-    mWebTiledLayer.loadAsync();
-    mWebTiledLayer.addDoneLoadingListener(() -> {
-      if (mWebTiledLayer.getLoadStatus() == LoadStatus.LOADED) {
-        // use web tiled layer as Basemap
-        ArcGISMap map = new ArcGISMap(new Basemap(mWebTiledLayer));
-        mMapView.setMap(map);
-        // custom attributes
-        mWebTiledLayer.setAttribution(getString(R.string.stamen_attribution));
-      }
-    });
+    WebTiledLayer webTiledLayer = new WebTiledLayer(getString(R.string.template_uri_stamen), subDomains);
+    // use web tiled layer as Basemap
+    ArcGISMap map = new ArcGISMap(new Basemap(webTiledLayer));
+    mMapView.setMap(map);
+    // custom attributes
+    webTiledLayer.setAttribution(getString(R.string.stamen_attribution));
   }
 
   @Override

--- a/java/wmts-layer/src/main/java/com/esri/arcgisruntime/sample/wmtslayer/MainActivity.java
+++ b/java/wmts-layer/src/main/java/com/esri/arcgisruntime/sample/wmtslayer/MainActivity.java
@@ -35,6 +35,7 @@ public class MainActivity extends AppCompatActivity {
 
   private final String TAG = MainActivity.class.getSimpleName();
   private MapView mMapView;
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private WmtsService mWmtsService;
 
   @Override

--- a/java/wmts-layer/src/main/java/com/esri/arcgisruntime/sample/wmtslayer/MainActivity.java
+++ b/java/wmts-layer/src/main/java/com/esri/arcgisruntime/sample/wmtslayer/MainActivity.java
@@ -35,6 +35,7 @@ public class MainActivity extends AppCompatActivity {
 
   private final String TAG = MainActivity.class.getSimpleName();
   private MapView mMapView;
+  private WmtsService mWmtsService;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -47,11 +48,11 @@ public class MainActivity extends AppCompatActivity {
     ArcGISMap map = new ArcGISMap();
     mMapView.setMap(map);
     // create wmts service from url string
-    WmtsService wmtsService = new WmtsService(getString(R.string.wmts_url));
-    wmtsService.addDoneLoadingListener(() -> {
-      if (wmtsService.getLoadStatus() == LoadStatus.LOADED) {
+    mWmtsService = new WmtsService(getString(R.string.wmts_url));
+    mWmtsService.addDoneLoadingListener(() -> {
+      if (mWmtsService.getLoadStatus() == LoadStatus.LOADED) {
         // get service info
-        WmtsServiceInfo wmtsServiceInfo = wmtsService.getServiceInfo();
+        WmtsServiceInfo wmtsServiceInfo = mWmtsService.getServiceInfo();
         // get the first layer id
         List<WmtsLayerInfo> layerInfoList = wmtsServiceInfo.getLayerInfos();
         // create WMTS layer from layer info
@@ -59,12 +60,12 @@ public class MainActivity extends AppCompatActivity {
         // set the basemap of the map with WMTS layer
         map.setBasemap(new Basemap(wmtsLayer));
       } else {
-        String error = "Error loading WMTS Service: " + wmtsService.getLoadError();
+        String error = "Error loading WMTS Service: " + mWmtsService.getLoadError();
         Log.e(TAG, error);
         Toast.makeText(this, error, Toast.LENGTH_LONG).show();
       }
     });
-    wmtsService.loadAsync();
+    mWmtsService.loadAsync();
   }
 
   @Override

--- a/kotlin/choose-camera-controller/src/main/java/com/esri/arcgisruntime/sample/choosecameracontroller/MainActivity.kt
+++ b/kotlin/choose-camera-controller/src/main/java/com/esri/arcgisruntime/sample/choosecameracontroller/MainActivity.kt
@@ -49,8 +49,6 @@ class MainActivity : AppCompatActivity() {
   private lateinit var plane3d: Graphic
   private lateinit var orbitLocationCameraController: OrbitLocationCameraController
   private lateinit var orbitPlaneCameraController: OrbitGeoElementCameraController
-  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
-  private val modelSceneSymbol: ModelSceneSymbol by lazy { loadModel() }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -93,7 +91,7 @@ class MainActivity : AppCompatActivity() {
       }
     }
 
-    modelSceneSymbol.addDoneLoadingListener {
+    loadModel().addDoneLoadingListener {
       // instantiate a new camera controller which orbits the plane at a set distance
       orbitPlaneCameraController = OrbitGeoElementCameraController(plane3d, 100.0).apply {
         this.cameraPitchOffset = 30.0

--- a/kotlin/choose-camera-controller/src/main/java/com/esri/arcgisruntime/sample/choosecameracontroller/MainActivity.kt
+++ b/kotlin/choose-camera-controller/src/main/java/com/esri/arcgisruntime/sample/choosecameracontroller/MainActivity.kt
@@ -49,6 +49,8 @@ class MainActivity : AppCompatActivity() {
   private lateinit var plane3d: Graphic
   private lateinit var orbitLocationCameraController: OrbitLocationCameraController
   private lateinit var orbitPlaneCameraController: OrbitGeoElementCameraController
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
+  private val modelSceneSymbol: ModelSceneSymbol by lazy { loadModel() }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -91,7 +93,7 @@ class MainActivity : AppCompatActivity() {
       }
     }
 
-    loadModel().addDoneLoadingListener {
+    modelSceneSymbol.addDoneLoadingListener {
       // instantiate a new camera controller which orbits the plane at a set distance
       orbitPlaneCameraController = OrbitGeoElementCameraController(plane3d, 100.0).apply {
         this.cameraPitchOffset = 30.0

--- a/kotlin/choose-camera-controller/src/main/java/com/esri/arcgisruntime/sample/choosecameracontroller/MainActivity.kt
+++ b/kotlin/choose-camera-controller/src/main/java/com/esri/arcgisruntime/sample/choosecameracontroller/MainActivity.kt
@@ -122,7 +122,6 @@ class MainActivity : AppCompatActivity() {
     // create a graphic with a ModelSceneSymbol of a plane to add to the scene
     val pathToModel = cacheDir.toString() + File.separator + getString(R.string.file_bristol_model)
     val plane3DSymbol = ModelSceneSymbol(pathToModel, 1.0)
-    plane3DSymbol.loadAsync()
     plane3DSymbol.heading = 45.0
     plane3d =
       Graphic(Point(-109.937516, 38.456714, 5000.0, SpatialReferences.getWgs84()), plane3DSymbol)

--- a/kotlin/feature-layer-geodatabase/src/main/java/com/esri/arcgisruntime/sample/featurelayergeodatabase/MainActivity.kt
+++ b/kotlin/feature-layer-geodatabase/src/main/java/com/esri/arcgisruntime/sample/featurelayergeodatabase/MainActivity.kt
@@ -31,6 +31,11 @@ class MainActivity : AppCompatActivity() {
   private val TAG =
     MainActivity::class.java.simpleName
 
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
+  private val geodatabase: Geodatabase by lazy {
+    Geodatabase(getExternalFilesDir(null)?.path + getString(R.string.geodb_name))
+  }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
@@ -38,8 +43,6 @@ class MainActivity : AppCompatActivity() {
     val map = ArcGISMap(Basemap.createStreets())
     mapView.map = map
 
-    val path: String = getExternalFilesDir(null)?.path + getString(R.string.geodb_name)
-    val geodatabase = Geodatabase(path)
     geodatabase.loadAsync()
     geodatabase.addDoneLoadingListener {
       if (geodatabase.loadStatus == LoadStatus.LOADED) {

--- a/kotlin/generate-geodatabase/src/main/java/com/esri/arcgisruntime/sample/generategeodatabase/MainActivity.kt
+++ b/kotlin/generate-geodatabase/src/main/java/com/esri/arcgisruntime/sample/generategeodatabase/MainActivity.kt
@@ -24,6 +24,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.esri.arcgisruntime.concurrent.Job
+import com.esri.arcgisruntime.data.Geodatabase
 import com.esri.arcgisruntime.data.TileCache
 import com.esri.arcgisruntime.layers.ArcGISTiledLayer
 import com.esri.arcgisruntime.layers.FeatureLayer
@@ -44,6 +45,10 @@ class MainActivity : AppCompatActivity() {
 
   // define the local path where the geodatabase will be stored
   private val localGeodatabasePath: String by lazy { externalCacheDir?.path + getString(R.string.wildfire_geodatabase) }
+
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
+  private val geodatabaseSyncTask: GeodatabaseSyncTask by lazy { GeodatabaseSyncTask(getString(R.string.wildfire_sync)) }
+  private lateinit var geodatabase: Geodatabase
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -68,10 +73,8 @@ class MainActivity : AppCompatActivity() {
    * @param view the button which calls this function
    */
   fun generateGeodatabase(view: View) {
-    // create a geodatabase sync task and load it
-    val geodatabaseSyncTask = GeodatabaseSyncTask(getString(R.string.wildfire_sync))
+    // load the geodatabase sync task
     geodatabaseSyncTask.loadAsync()
-
     geodatabaseSyncTask.addDoneLoadingListener {
       // draw a box around the extent
       mapView.apply {
@@ -135,7 +138,7 @@ class MainActivity : AppCompatActivity() {
       return
     }
     // if the job succeeded, load the resulting geodatabase
-    val geodatabase = generateGeodatabaseJob.result
+    geodatabase = generateGeodatabaseJob.result
     geodatabase.loadAsync()
     geodatabase.addDoneLoadingListener {
       // return if the geodatabase failed to load

--- a/kotlin/integrated-windows-authentication/src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/MainActivity.kt
+++ b/kotlin/integrated-windows-authentication/src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/MainActivity.kt
@@ -53,6 +53,8 @@ class MainActivity : AppCompatActivity(), AuthenticationChallengeHandler,
 
   // Instance of CountDownLatch used to block the thread that handles authentication
   private var authLatch: CountDownLatch? = null
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
+  private lateinit var portal: Portal
 
   companion object {
     private val TAG: String = MainActivity::class.java.simpleName
@@ -78,8 +80,9 @@ class MainActivity : AppCompatActivity(), AuthenticationChallengeHandler,
     }
 
     searchPublicButton.setOnClickListener {
+      portal = Portal(getString(R.string.arcgis_url))
       // Search the the public ArcGIS portal
-      searchPortal(Portal(getString(R.string.arcgis_url)))
+      searchPortal(portal)
     }
 
     searchSecureButton.setOnClickListener {
@@ -87,7 +90,8 @@ class MainActivity : AppCompatActivity(), AuthenticationChallengeHandler,
       portalUrlEditText.text?.toString()?.let {
         // If the entered URL is a valid URL
         if (Patterns.WEB_URL.matcher(it).matches()) {
-          searchPortal(Portal(portalUrlEditText.text.toString(), true))
+          portal = Portal(portalUrlEditText.text.toString())
+          searchPortal(portal, true)
         } else {
           getString(R.string.error_portal_url).let { errorString ->
             Toast.makeText(this, errorString, Toast.LENGTH_LONG).show()

--- a/kotlin/integrated-windows-authentication/src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/MainActivity.kt
+++ b/kotlin/integrated-windows-authentication/src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/MainActivity.kt
@@ -90,8 +90,8 @@ class MainActivity : AppCompatActivity(), AuthenticationChallengeHandler,
       portalUrlEditText.text?.toString()?.let {
         // If the entered URL is a valid URL
         if (Patterns.WEB_URL.matcher(it).matches()) {
-          portal = Portal(portalUrlEditText.text.toString())
-          searchPortal(portal, true)
+          portal = Portal(portalUrlEditText.text.toString(), true)
+          searchPortal(portal)
         } else {
           getString(R.string.error_portal_url).let { errorString ->
             Toast.makeText(this, errorString, Toast.LENGTH_LONG).show()

--- a/kotlin/perform-valve-isolation-trace/src/main/java/com/esri/arcgisruntime/sample/performvalveisolationtrace/MainActivity.kt
+++ b/kotlin/perform-valve-isolation-trace/src/main/java/com/esri/arcgisruntime/sample/performvalveisolationtrace/MainActivity.kt
@@ -62,6 +62,8 @@ class MainActivity : AppCompatActivity() {
 
   // create a graphics overlay for the starting location and add it to the map view
   private val startingLocationGraphicsOverlay: GraphicsOverlay by lazy { GraphicsOverlay() }
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
+  private lateinit var utilityNetwork: UtilityNetwork
 
   // create and apply renderers for the starting point graphics overlay
   private val startingPointSymbol: SimpleMarkerSymbol by lazy {
@@ -129,7 +131,7 @@ class MainActivity : AppCompatActivity() {
   private fun createUtilityNetwork(
   ) {
     // create a utility network from the url and load it
-    val utilityNetwork = UtilityNetwork(getString(R.string.utility_network_url), mapView.map)
+    utilityNetwork = UtilityNetwork(getString(R.string.utility_network_url), mapView.map)
     utilityNetwork.loadAsync()
     utilityNetwork.addDoneLoadingListener {
       if (utilityNetwork.loadStatus == LoadStatus.LOADED) {

--- a/kotlin/portal-user-info/src/main/java/com/esri/arcgisruntime/sample/portaluserinfo/MainActivity.kt
+++ b/kotlin/portal-user-info/src/main/java/com/esri/arcgisruntime/sample/portaluserinfo/MainActivity.kt
@@ -43,7 +43,7 @@ class MainActivity : AppCompatActivity() {
     AuthenticationManager.setAuthenticationChallengeHandler(handler)
     // Set loginRequired to true always prompt for credential,
     // When set to false to only login if required by the portal
-    portal = Portal("http://www.arcgis.com", true)
+    portal = Portal("https://www.arcgis.com", true)
 
     portal.addDoneLoadingListener {
       when (portal.loadStatus) {

--- a/kotlin/portal-user-info/src/main/java/com/esri/arcgisruntime/sample/portaluserinfo/MainActivity.kt
+++ b/kotlin/portal-user-info/src/main/java/com/esri/arcgisruntime/sample/portaluserinfo/MainActivity.kt
@@ -31,6 +31,9 @@ import java.util.Locale
 
 class MainActivity : AppCompatActivity() {
 
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
+  private lateinit var portal: Portal
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
@@ -40,7 +43,7 @@ class MainActivity : AppCompatActivity() {
     AuthenticationManager.setAuthenticationChallengeHandler(handler)
     // Set loginRequired to true always prompt for credential,
     // When set to false to only login if required by the portal
-    val portal = Portal("http://www.arcgis.com", true)
+    portal = Portal("http://www.arcgis.com", true)
 
     portal.addDoneLoadingListener {
       when (portal.loadStatus) {

--- a/kotlin/view-point-cloud-data-offline/src/main/java/com/esri/arcgisruntime/samples/viewpointclouddataoffline/MainActivity.kt
+++ b/kotlin/view-point-cloud-data-offline/src/main/java/com/esri/arcgisruntime/samples/viewpointclouddataoffline/MainActivity.kt
@@ -56,23 +56,11 @@ class MainActivity : AppCompatActivity() {
       scene = sceneWithSurface
     }
 
-    // add a PointCloudLayer to the scene by passing the URI of the scene layer package to the constructor
+    // create a PointCloudLayer by passing the URI of the scene layer package to the constructor
     val pointCloudLayer =
       PointCloudLayer(getExternalFilesDir(null)?.path + getString(R.string.scene_layer_package_location))
-
-    // load the layer
-    pointCloudLayer.loadAsync()
-    pointCloudLayer.addDoneLoadingListener {
-      // when PointCloudLayer loads
-      if (pointCloudLayer.loadStatus == LoadStatus.LOADED) {
-        // add the PointCloudLayer to the operational layers of the scene
-        sceneView.scene.operationalLayers.add(pointCloudLayer)
-      } else {
-        val error = "Error loading point cloud layer: " + pointCloudLayer.loadError
-        Toast.makeText(this, error, Toast.LENGTH_LONG).show()
-        Log.e(TAG, error)
-      }
-    }
+    // add the PointCloudLayer to the scene
+    sceneView.scene.operationalLayers.add(pointCloudLayer)
   }
 
   override fun onResume() {

--- a/kotlin/view-point-cloud-data-offline/src/main/java/com/esri/arcgisruntime/samples/viewpointclouddataoffline/MainActivity.kt
+++ b/kotlin/view-point-cloud-data-offline/src/main/java/com/esri/arcgisruntime/samples/viewpointclouddataoffline/MainActivity.kt
@@ -61,6 +61,14 @@ class MainActivity : AppCompatActivity() {
       PointCloudLayer(getExternalFilesDir(null)?.path + getString(R.string.scene_layer_package_location))
     // add the PointCloudLayer to the scene
     sceneView.scene.operationalLayers.add(pointCloudLayer)
+
+    pointCloudLayer.addDoneLoadingListener {
+      if (pointCloudLayer.loadStatus != LoadStatus.LOADED) {
+        val error = "Point cloud layer failed to load: ${pointCloudLayer.loadError.message}"
+        Log.e(TAG, error)
+        Toast.makeText(this, error, Toast.LENGTH_LONG).show()
+      }
+    }
   }
 
   override fun onResume() {

--- a/kotlin/viewshed-geoprocessing/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoprocessing/MainActivity.kt
+++ b/kotlin/viewshed-geoprocessing/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoprocessing/MainActivity.kt
@@ -54,6 +54,8 @@ class MainActivity : AppCompatActivity() {
 
   private val inputGraphicsOverlay: GraphicsOverlay by lazy { GraphicsOverlay() }
   private val resultGraphicsOverlay: GraphicsOverlay by lazy { GraphicsOverlay() }
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
+  private lateinit var featureCollectionTable: FeatureCollectionTable
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -124,8 +126,7 @@ class MainActivity : AppCompatActivity() {
     val field = Field.createString("observer", "", 8)
 
     // create feature collection table for point geometry
-    val featureCollectionTable =
-      FeatureCollectionTable(listOf(field), GeometryType.POINT, point.spatialReference)
+    featureCollectionTable = FeatureCollectionTable(listOf(field), GeometryType.POINT, point.spatialReference)
     featureCollectionTable.loadAsync()
 
     // create a new feature and assign the geometry

--- a/kotlin/wmts-layer/src/main/java/com/esri/arcgisruntime/sample/wmtslayer/MainActivity.kt
+++ b/kotlin/wmts-layer/src/main/java/com/esri/arcgisruntime/sample/wmtslayer/MainActivity.kt
@@ -29,6 +29,9 @@ import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity() {
 
+  // objects that implement Loadable must be class fields to prevent being garbage collected before loading
+  private val wmtsService: WmtsService by lazy { WmtsService(getString(R.string.wmts_url)) }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
@@ -37,9 +40,8 @@ class MainActivity : AppCompatActivity() {
     val map = ArcGISMap()
     // set the map to be displayed in this view
     mapView.map = map
-    // create wmts service from url string
-    val wmtsService = WmtsService(getString(R.string.wmts_url))
-    wmtsService.addDoneLoadingListener({
+    // display wmts data on the map
+    wmtsService.addDoneLoadingListener {
       if (wmtsService.loadStatus == LoadStatus.LOADED) {
         // get service info
         val wmtsServiceInfo = wmtsService.serviceInfo
@@ -50,7 +52,7 @@ class MainActivity : AppCompatActivity() {
         // set the basemap of the map with WMTS layer
         map.basemap = Basemap(wmtsLayer)
       }
-    })
+    }
     wmtsService.loadAsync()
   }
 


### PR DESCRIPTION
This PR covers the issue with Loadables being garbage collected on Android in both java and kotlin (#1886). The changes made here were to move any loadables created within the local scope of a function out of the local scope and into the scope of the class. On Java, this was fairly straightforward; on kotlin, I tried to evaluated case-by-case what type of val or var the class field should be.

I left comments next to the member fields that I added. However, these may be inconsistent given that some loadables were already class-level and some loadables were not moved to the class-level because they were added (indirectly or directly) to a geoview. 

@TADraeseke can you take a first look?