### PR TITLE
Hud10837/fixes for sample viewer release

### DIFF
--- a/java/attribution-view-change/src/main/java/com/esri/arcgisruntime/sample/attributionviewchange/MainActivity.java
+++ b/java/attribution-view-change/src/main/java/com/esri/arcgisruntime/sample/attributionviewchange/MainActivity.java
@@ -44,14 +44,13 @@ public class MainActivity extends AppCompatActivity {
 
     // create a FAB to respond to attribution bar
     FloatingActionButton mFab = findViewById(R.id.floatingActionButton);
-    mFab.setOnClickListener(v -> Snackbar.make(v, "Button responds to attribution bar", Snackbar.LENGTH_LONG)
-        .setAction("Action", null).show());
+    mFab.setOnClickListener(v -> Toast.makeText(this, "Tap the attribution bar to expand it.", Toast.LENGTH_LONG).show());
 
     // set attribution bar listener
     mMapView.addAttributionViewLayoutChangeListener(
         (v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
           int heightDelta = oldBottom - bottom;
-          mFab.animate().translationYBy(heightDelta);
+          mFab.setY(mFab.getY() + heightDelta);
           Toast.makeText(MainActivity.this, "new bounds [" + left + ',' + top + ',' + right + ',' + bottom + ']' +
               " old bounds [" + oldLeft + ',' + oldTop + ',' + oldRight + ',' + oldBottom + ']', Toast.LENGTH_SHORT)
               .show();

--- a/kotlin/attribution-view-change/src/main/java/com/esri/arcgisruntime/sample/attributionviewchange/MainActivity.kt
+++ b/kotlin/attribution-view-change/src/main/java/com/esri/arcgisruntime/sample/attributionviewchange/MainActivity.kt
@@ -45,7 +45,7 @@ class MainActivity : AppCompatActivity() {
     // set attribution bar listener
     mapView.addAttributionViewLayoutChangeListener { _, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
       val heightDelta = oldBottom - bottom
-      fab.animate().translationYBy(heightDelta.toFloat())
+      fab.y += heightDelta
       Toast.makeText(
         this@MainActivity,
         "new bounds [$left,$top,$right,$bottom] old bounds [$oldLeft,$oldTop,$oldRight,$oldBottom]",

--- a/kotlin/attribution-view-change/src/main/java/com/esri/arcgisruntime/sample/attributionviewchange/MainActivity.kt
+++ b/kotlin/attribution-view-change/src/main/java/com/esri/arcgisruntime/sample/attributionviewchange/MainActivity.kt
@@ -38,9 +38,8 @@ class MainActivity : AppCompatActivity() {
     mapView.map = map
 
     // create a FAB to respond to attribution bar
-    fab.setOnClickListener { view ->
-      Snackbar.make(view, resources.getString(R.string.message), Snackbar.LENGTH_LONG)
-        .setAction("Action", null).show()
+    fab.setOnClickListener {
+      Toast.makeText(this@MainActivity, "Tap the attribution bar to expand it.", Toast.LENGTH_LONG).show()
     }
 
     // set attribution bar listener

--- a/kotlin/attribution-view-change/src/main/res/layout/activity_main.xml
+++ b/kotlin/attribution-view-change/src/main/res/layout/activity_main.xml
@@ -4,9 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.esri.arcgisruntime.sample.attributionchange.MainActivity">
+    tools:context="com.esri.arcgisruntime.sample.attributionviewchange.MainActivity">
 
-    <!-- MapView -->
     <com.esri.arcgisruntime.mapping.view.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"

--- a/kotlin/show-location-history/src/main/java/com/esri/arcgisruntime/sample/showlocationhistory/MainActivity.kt
+++ b/kotlin/show-location-history/src/main/java/com/esri/arcgisruntime/sample/showlocationhistory/MainActivity.kt
@@ -102,8 +102,14 @@ class MainActivity : AppCompatActivity() {
       initialZoomScale = 7000.0
     }
 
-    // change the isTrackLocation flag and the button's icon
+    // reset location display and change the isTrackLocation flag and the button's icon
     button.setOnClickListener {
+      // if the user has panned away from the location display, turn it on again
+      if (mapView.locationDisplay.autoPanMode == LocationDisplay.AutoPanMode.OFF) {
+        mapView.locationDisplay.autoPanMode = LocationDisplay.AutoPanMode.RECENTER
+        // don't change the isTrackLocation status if the button is recentering
+        return@setOnClickListener
+      }
       if (isTrackLocation) {
         isTrackLocation = false
         button.setImageResource(R.drawable.ic_my_location_white_24dp)

--- a/kotlin/show-location-history/src/main/java/com/esri/arcgisruntime/sample/showlocationhistory/MainActivity.kt
+++ b/kotlin/show-location-history/src/main/java/com/esri/arcgisruntime/sample/showlocationhistory/MainActivity.kt
@@ -107,9 +107,8 @@ class MainActivity : AppCompatActivity() {
       // if the user has panned away from the location display, turn it on again
       if (mapView.locationDisplay.autoPanMode == LocationDisplay.AutoPanMode.OFF) {
         mapView.locationDisplay.autoPanMode = LocationDisplay.AutoPanMode.RECENTER
-        // don't change the isTrackLocation status if the button is recentering
-        return@setOnClickListener
       }
+
       if (isTrackLocation) {
         isTrackLocation = false
         button.setImageResource(R.drawable.ic_my_location_white_24dp)


### PR DESCRIPTION
This just changes the show location history behavior so that when the user has panned away, pressing the button turns on the auto pan mode again. I also changed the behavior of attribution view change to show a toast instead of a snackbar and to change position directly instead of animate