### PR TITLE
Gradle: Fix buildConfigField API_KEY syntax

### DIFF
--- a/java/add-enc-exchange-set/build.gradle
+++ b/java/add-enc-exchange-set/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/add-features-feature-service/build.gradle
+++ b/java/add-features-feature-service/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/add-graphics-renderer/build.gradle
+++ b/java/add-graphics-renderer/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/add-graphics-with-symbols/build.gradle
+++ b/java/add-graphics-with-symbols/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/analyze-hotspots/build.gradle
+++ b/java/analyze-hotspots/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/attribution-view-change/build.gradle
+++ b/java/attribution-view-change/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/browse-wfs-layers/build.gradle
+++ b/java/browse-wfs-layers/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/buffer/build.gradle
+++ b/java/buffer/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/change-basemaps/build.gradle
+++ b/java/change-basemaps/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/change-feature-layer-renderer/build.gradle
+++ b/java/change-feature-layer-renderer/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/change-sublayer-renderer/build.gradle
+++ b/java/change-sublayer-renderer/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/change-viewpoint/build.gradle
+++ b/java/change-viewpoint/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/clip-geometry/build.gradle
+++ b/java/clip-geometry/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/colormap-renderer/build.gradle
+++ b/java/colormap-renderer/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/create-and-save-map/build.gradle
+++ b/java/create-and-save-map/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/create-geometries/build.gradle
+++ b/java/create-geometries/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/cut-geometry/build.gradle
+++ b/java/cut-geometry/build.gradle
@@ -9,7 +9,7 @@ android {
             targetSdkVersion rootProject.ext.targetSdkVersion
             versionCode rootProject.ext.versionCode
             versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
         }
 
     buildTypes {

--- a/java/delete-features-feature-service/build.gradle
+++ b/java/delete-features-feature-service/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/densify-and-generalize/build.gradle
+++ b/java/densify-and-generalize/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/dictionary-renderer-graphics-overlay/build.gradle
+++ b/java/dictionary-renderer-graphics-overlay/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/display-device-location/build.gradle
+++ b/java/display-device-location/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/display-drawing-status/build.gradle
+++ b/java/display-drawing-status/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/display-grid/build.gradle
+++ b/java/display-grid/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/display-kml-network-links/build.gradle
+++ b/java/display-kml-network-links/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/display-kml/build.gradle
+++ b/java/display-kml/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/display-layer-view-state/build.gradle
+++ b/java/display-layer-view-state/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/display-map/build.gradle
+++ b/java/display-map/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/display-wfs-layer/build.gradle
+++ b/java/display-wfs-layer/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/edit-feature-attachments/build.gradle
+++ b/java/edit-feature-attachments/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/feature-collection-layer-query/build.gradle
+++ b/java/feature-collection-layer-query/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/feature-collection-layer/build.gradle
+++ b/java/feature-collection-layer/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/feature-layer-definition-expression/build.gradle
+++ b/java/feature-layer-definition-expression/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/feature-layer-dictionary-renderer/build.gradle
+++ b/java/feature-layer-dictionary-renderer/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/feature-layer-feature-service/build.gradle
+++ b/java/feature-layer-feature-service/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/feature-layer-geodatabase/build.gradle
+++ b/java/feature-layer-geodatabase/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     
     buildTypes {

--- a/java/feature-layer-geopackage/build.gradle
+++ b/java/feature-layer-geopackage/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/feature-layer-query/build.gradle
+++ b/java/feature-layer-query/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/feature-layer-selection/build.gradle
+++ b/java/feature-layer-selection/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/feature-layer-shapefile/build.gradle
+++ b/java/feature-layer-shapefile/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/feature-layer-show-attributes/build.gradle
+++ b/java/feature-layer-show-attributes/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/feature-layer-update-attributes/build.gradle
+++ b/java/feature-layer-update-attributes/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/feature-layer-update-geometry/build.gradle
+++ b/java/feature-layer-update-geometry/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/find-address/build.gradle
+++ b/java/find-address/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/find-closest-facility-to-an-incident-interactive/build.gradle
+++ b/java/find-closest-facility-to-an-incident-interactive/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/find-closest-facility-to-multiple-incidents-service/build.gradle
+++ b/java/find-closest-facility-to-multiple-incidents-service/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/find-place/build.gradle
+++ b/java/find-place/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/find-service-area-interactive/build.gradle
+++ b/java/find-service-area-interactive/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/geodesic-operations/build.gradle
+++ b/java/geodesic-operations/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/identify-graphics/build.gradle
+++ b/java/identify-graphics/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/identify-kml-features/build.gradle
+++ b/java/identify-kml-features/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/identify-layers/build.gradle
+++ b/java/identify-layers/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/integrated-windows-authentication/build.gradle
+++ b/java/integrated-windows-authentication/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/manage-bookmarks/build.gradle
+++ b/java/manage-bookmarks/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/manage-operational-layers/build.gradle
+++ b/java/manage-operational-layers/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/map-load-status/build.gradle
+++ b/java/map-load-status/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/map-rotation/build.gradle
+++ b/java/map-rotation/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/navigate-route/build.gradle
+++ b/java/navigate-route/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/openstreetmap-layer/build.gradle
+++ b/java/openstreetmap-layer/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/perform-spatial-operations/build.gradle
+++ b/java/perform-spatial-operations/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/picture-marker-symbols/build.gradle
+++ b/java/picture-marker-symbols/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/project/build.gradle
+++ b/java/project/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/query-map-image-sublayer/build.gradle
+++ b/java/query-map-image-sublayer/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/raster-function-service/build.gradle
+++ b/java/raster-function-service/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/raster-layer-file/build.gradle
+++ b/java/raster-layer-file/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/raster-layer-geopackage/build.gradle
+++ b/java/raster-layer-geopackage/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/raster-layer-service/build.gradle
+++ b/java/raster-layer-service/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/raster-rendering-rule/build.gradle
+++ b/java/raster-rendering-rule/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/read-geopackage/build.gradle
+++ b/java/read-geopackage/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/read-symbols-mobile-style-file/build.gradle
+++ b/java/read-symbols-mobile-style-file/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/service-feature-table-cache/build.gradle
+++ b/java/service-feature-table-cache/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/service-feature-table-manual-cache/build.gradle
+++ b/java/service-feature-table-manual-cache/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/service-feature-table-no-cache/build.gradle
+++ b/java/service-feature-table-no-cache/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/set-initial-map-area/build.gradle
+++ b/java/set-initial-map-area/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/set-initial-map-location/build.gradle
+++ b/java/set-initial-map-location/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/set-min-max-scale/build.gradle
+++ b/java/set-min-max-scale/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/show-callout/build.gradle
+++ b/java/show-callout/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/show-labels-on-layer/build.gradle
+++ b/java/show-labels-on-layer/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/show-magnifier/build.gradle
+++ b/java/show-magnifier/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/simple-marker-symbol/build.gradle
+++ b/java/simple-marker-symbol/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/simple-renderer/build.gradle
+++ b/java/simple-renderer/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/sketch-editor/build.gradle
+++ b/java/sketch-editor/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/spatial-relationships/build.gradle
+++ b/java/spatial-relationships/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/statistical-query/build.gradle
+++ b/java/statistical-query/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/symbolize-shapefile/build.gradle
+++ b/java/symbolize-shapefile/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/take-screenshot/build.gradle
+++ b/java/take-screenshot/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/time-based-query/build.gradle
+++ b/java/time-based-query/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/transforms-by-suitability/build.gradle
+++ b/java/transforms-by-suitability/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/unique-value-renderer/build.gradle
+++ b/java/unique-value-renderer/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/update-related-features/build.gradle
+++ b/java/update-related-features/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/viewshed-geoprocessing/build.gradle
+++ b/java/viewshed-geoprocessing/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/java/wfs-xml-query/build.gradle
+++ b/java/wfs-xml-query/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/java/wms-layer-url/build.gradle
+++ b/java/wms-layer-url/build.gradle
@@ -9,7 +9,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/kotlin/add-features-feature-service/build.gradle
+++ b/kotlin/add-features-feature-service/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/add-graphics-renderer/build.gradle
+++ b/kotlin/add-graphics-renderer/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/add-graphics-with-symbols/build.gradle
+++ b/kotlin/add-graphics-with-symbols/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/analyze-hotspots/build.gradle
+++ b/kotlin/analyze-hotspots/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/kotlin/apply-mosaic-rule-to-rasters/build.gradle
+++ b/kotlin/apply-mosaic-rule-to-rasters/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/attribution-view-change/build.gradle
+++ b/kotlin/attribution-view-change/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/kotlin/buffer/build.gradle
+++ b/kotlin/buffer/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField 'String', 'API_KEY', API_KEY
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/change-basemaps/build.gradle
+++ b/kotlin/change-basemaps/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/kotlin/change-viewpoint/build.gradle
+++ b/kotlin/change-viewpoint/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/convex-hull/build.gradle
+++ b/kotlin/convex-hull/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/create-and-save-kml-file/build.gradle
+++ b/kotlin/create-and-save-kml-file/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/create-symbol-styles-from-web-styles/build.gradle
+++ b/kotlin/create-symbol-styles-from-web-styles/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField('String', 'API_KEY', API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/custom-dictionary-style/build.gradle
+++ b/kotlin/custom-dictionary-style/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/delete-features-feature-service/build.gradle
+++ b/kotlin/delete-features-feature-service/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/display-annotation/build.gradle
+++ b/kotlin/display-annotation/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/kotlin/display-device-location/build.gradle
+++ b/kotlin/display-device-location/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/display-grid/build.gradle
+++ b/kotlin/display-grid/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/display-kml/build.gradle
+++ b/kotlin/display-kml/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/display-layer-view-state/build.gradle
+++ b/kotlin/display-layer-view-state/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/display-map/build.gradle
+++ b/kotlin/display-map/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/display-subtype-feature-layer/build.gradle
+++ b/kotlin/display-subtype-feature-layer/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/display-utility-associations/build.gradle
+++ b/kotlin/display-utility-associations/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/kotlin/edit-features-with-feature-linked-annotation/build.gradle
+++ b/kotlin/edit-features-with-feature-linked-annotation/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/edit-with-branch-versioning/build.gradle
+++ b/kotlin/edit-with-branch-versioning/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/feature-collection-layer-portal-item/build.gradle
+++ b/kotlin/feature-collection-layer-portal-item/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/feature-layer-definition-expression/build.gradle
+++ b/kotlin/feature-layer-definition-expression/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/feature-layer-feature-service/build.gradle
+++ b/kotlin/feature-layer-feature-service/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/feature-layer-geodatabase/build.gradle
+++ b/kotlin/feature-layer-geodatabase/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/feature-layer-query/build.gradle
+++ b/kotlin/feature-layer-query/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/feature-layer-selection/build.gradle
+++ b/kotlin/feature-layer-selection/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/find-address/build.gradle
+++ b/kotlin/find-address/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/geodesic-operations/build.gradle
+++ b/kotlin/geodesic-operations/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/identify-layers/build.gradle
+++ b/kotlin/identify-layers/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/identify-raster-cell/build.gradle
+++ b/kotlin/identify-raster-cell/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/kotlin/integrated-windows-authentication/build.gradle
+++ b/kotlin/integrated-windows-authentication/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/manage-operational-layers/build.gradle
+++ b/kotlin/manage-operational-layers/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/map-rotation/build.gradle
+++ b/kotlin/map-rotation/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/navigate-route/build.gradle
+++ b/kotlin/navigate-route/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/nearest-vertex/build.gradle
+++ b/kotlin/nearest-vertex/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/perform-spatial-operations/build.gradle
+++ b/kotlin/perform-spatial-operations/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/perform-valve-isolation-trace/build.gradle
+++ b/kotlin/perform-valve-isolation-trace/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/raster-function-service/build.gradle
+++ b/kotlin/raster-function-service/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
     buildTypes {
         release {

--- a/kotlin/raster-layer-file/build.gradle
+++ b/kotlin/raster-layer-file/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/raster-rendering-rule/build.gradle
+++ b/kotlin/raster-rendering-rule/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/route-around-barriers/build.gradle
+++ b/kotlin/route-around-barriers/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/set-initial-map-area/build.gradle
+++ b/kotlin/set-initial-map-area/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/set-min-max-scale/build.gradle
+++ b/kotlin/set-min-max-scale/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/show-callout/build.gradle
+++ b/kotlin/show-callout/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/show-labels-on-layer/build.gradle
+++ b/kotlin/show-labels-on-layer/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/trace-utility-network/build.gradle
+++ b/kotlin/trace-utility-network/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {

--- a/kotlin/viewshed-geoprocessing/build.gradle
+++ b/kotlin/viewshed-geoprocessing/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
-        buildConfigField("String", "API_KEY", API_KEY)
+        buildConfigField "String", "API_KEY", "\" API_KEY\""
     }
 
     buildTypes {


### PR DESCRIPTION
I noticed a build error in Gradle when creating a CI config, which could be resolved by updating the `buildConfigField` syntax in the `build.gradle` files.

- Old syntax: `buildConfigField("String", "API_KEY", API_KEY)`
- New syntax: `buildConfigField "String", "API_KEY", "\" API_KEY\""`

Tested it both locally and with GitHub Actions:
- [CI run before](https://github.com/EwoutH/arcgis-runtime-samples-android/actions/runs/665451856)
- [CI run after](https://github.com/EwoutH/arcgis-runtime-samples-android/actions/runs/665498953)

See also https://stackoverflow.com/questions/49047492/error-gradle-sync-failed-could-not-get-unknown-property-api-key-for-defaultc/52716781