### PR TITLE
Remove line pointing to deleted file

### DIFF
--- a/kotlin/integrated-windows-authentication/README.metadata.json
+++ b/kotlin/integrated-windows-authentication/README.metadata.json
@@ -21,7 +21,6 @@
         "UserCredential"
     ],
     "snippets": [
-        "src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/CredentialDialogFragment.kt",
         "src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/MainActivity.kt",
         "src/main/java/com/esri/arcgisruntime/sample/integratedwindowsauthentication/PortalItemAdapter.kt"
     ],


### PR DESCRIPTION
One of the files (`CredentialDialogFragment.kt`) that the IWA sample previously relied upon was deleted in a recent commit (https://github.com/Esri/arcgis-runtime-samples-android/pull/888/commits/c05e2137cb91fa3325248c2a5d6ac61577340a81). Doing so caused an error in the ArcGIS Developer site build since that file couldn't be found when requested.

There's a parallel fix going in over there to make this check more robust, but this PR should address it more quickly in the meantime.