### PR TITLE
add intent flags and URI handling to fix edit feature attachments

### DIFF
--- a/java/edit-feature-attachments/src/main/AndroidManifest.xml
+++ b/java/edit-feature-attachments/src/main/AndroidManifest.xml
@@ -1,23 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.esri.arcgisruntime.sample.editfeatureattachments">
+        package="com.esri.arcgisruntime.sample.editfeatureattachments">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <uses-feature
-        android:glEsVersion="0x00020000"
-        android:required="true" />
+            android:glEsVersion="0x00020000"
+            android:required="true" />
 
     <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+            android:allowBackup="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name"
+            android:supportsRtl="true"
+            android:theme="@style/AppTheme">
+        <provider
+                android:name="androidx.core.content.FileProvider"
+                android:authorities="${applicationId}.provider"
+                android:exported="false"
+                android:grantUriPermissions="true">
+            <meta-data
+                    android:name="android.support.FILE_PROVIDER_PATHS"
+                    android:resource="@xml/provider_paths" />
+        </provider>
+
         <activity
-            android:name=".MainActivity"
-            android:label="@string/app_name">
+                android:name=".MainActivity"
+                android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -25,8 +35,8 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".EditAttachmentActivity"
-            android:label="@string/edit_attachments" />
+                android:name=".EditAttachmentActivity"
+                android:label="@string/edit_attachments" />
     </application>
 
 </manifest>

--- a/java/edit-feature-attachments/src/main/java/com/esri/arcgisruntime/sample/editfeatureattachments/EditAttachmentActivity.java
+++ b/java/edit-feature-attachments/src/main/java/com/esri/arcgisruntime/sample/editfeatureattachments/EditAttachmentActivity.java
@@ -30,6 +30,7 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.FileProvider;
 
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.ArcGISFeature;
@@ -158,8 +159,11 @@ public class EditAttachmentActivity extends AppCompatActivity {
         }
         // open the file in gallery
         Intent i = new Intent();
+        i.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         i.setAction(Intent.ACTION_VIEW);
-        i.setDataAndType(Uri.fromFile(file), "image/png");
+        Uri contentUri = FileProvider
+            .getUriForFile(getApplicationContext(), getApplicationContext().getPackageName() + ".provider", file);
+        i.setDataAndType(contentUri, "image/png");
         startActivity(i);
 
       } catch (Exception e) {

--- a/java/edit-feature-attachments/src/main/res/xml/provider_paths.xml
+++ b/java/edit-feature-attachments/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="external_files" path="."/>
+</paths>


### PR DESCRIPTION
Another bug fix for review when you can @shubham7109!

This fixes a case where when attempting to view an attachment it would not start the gallery view due to Uri's going beyond permission scope of the app.