### PR TITLE
Fixed incorrect image file name

### DIFF
--- a/kotlin/browse-ogc-api-feature-service/README.md
+++ b/kotlin/browse-ogc-api-feature-service/README.md
@@ -2,7 +2,7 @@
 
 Browse an OGC API feature service for layers and add them to the map.
 
-![Image of browse OGC API feature service](browse-ogc-api-feature-service.jpg)
+![Image of browse OGC API feature service](browse-ogc-api-feature-service.png)
 
 ## Use case
 


### PR DESCRIPTION
Smallest PR ever. The `README.md` file refers `browse-ogc-api-feature-service.jpg` instead of `browse-ogc-api-feature-service.png`. 
