### PR TITLE
'Job did not succeed' fix for Export Tiles

### DIFF
--- a/kotlin/export-tiles/src/main/java/com/esri/arcgisruntime/sample/exporttiles/MainActivity.kt
+++ b/kotlin/export-tiles/src/main/java/com/esri/arcgisruntime/sample/exporttiles/MainActivity.kt
@@ -269,8 +269,6 @@ class MainActivity : AppCompatActivity() {
   override fun onPause() {
     mapView.pause()
     previewMapView.pause()
-    // delete app cache when the app loses focus
-    cacheDir.deleteRecursively()
     super.onPause()
   }
 


### PR DESCRIPTION
PR to address the error received `Job did not succeed` when running export tiles. The error occurs when sample is launched from the Android Sample Viewer, exited, and launched again. As the error only occurs when the user leaves the app running in the background and resumes. 

Fix: 
- Removed the line `cacheDir.deleteRecursively()` when `onPause` is called. As `error.getCause` says the cache directory is not found. 
- Upon testing it on the individual sample and on the Android sample viewer the sample works find without the error being shown. 