### PR TITLE
Use android.widget. to keep old UI behaviour where needed

### DIFF
--- a/java/animate-3d-graphic/src/main/res/layout/activity_main.xml
+++ b/java/animate-3d-graphic/src/main/res/layout/activity_main.xml
@@ -19,7 +19,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <Button
+    <android.widget.Button
         android:id="@+id/zoomInButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -29,7 +29,7 @@
         android:minHeight="40dip"
         android:minWidth="35dip"/>
 
-    <Button
+    <android.widget.Button
         android:id="@+id/zoomOutButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/java/feature-layer-rendering-mode-map/src/main/res/layout/activity_main.xml
+++ b/java/feature-layer-rendering-mode-map/src/main/res/layout/activity_main.xml
@@ -35,7 +35,7 @@
             android:orientation="horizontal"
             tools:layout_editor_absoluteY="256dp"
             tools:layout_editor_absoluteX="0dp"/>
-    <Button
+    <android.widget.Button
             android:text="@string/animated_zoom"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -48,7 +48,7 @@
             android:layout_marginTop="8dp"
             app:layout_constraintBottom_toBottomOf="parent"
             android:layout_marginBottom="8dp"/>
-    <TextView
+    <android.widget.TextView
             android:text="@string/renderingmode_static"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -58,7 +58,7 @@
             app:layout_constraintLeft_toLeftOf="parent"
             android:textStyle="bold"
             android:textColor="@android:color/background_dark"/>
-    <TextView
+    <android.widget.TextView
             android:text="@string/renderingmode_dynamic"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -68,7 +68,7 @@
             app:layout_constraintLeft_toLeftOf="parent"
             android:textStyle="bold"
             android:textColor="@android:color/background_dark"/>
-    <TextView
+    <android.widget.TextView
             android:text="@string/navigating"
             android:background="@color/colorPrimary"
             android:padding="8dp"

--- a/java/feature-layer-rendering-mode-scene/src/main/res/layout/activity_main.xml
+++ b/java/feature-layer-rendering-mode-scene/src/main/res/layout/activity_main.xml
@@ -35,7 +35,7 @@
             android:orientation="horizontal"
             tools:layout_editor_absoluteY="256dp"
             tools:layout_editor_absoluteX="0dp"/>
-    <Button
+    <android.widget.Button
             android:text="@string/animated_zoom"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -48,7 +48,7 @@
             android:layout_marginTop="8dp"
             app:layout_constraintBottom_toBottomOf="parent"
             android:layout_marginBottom="8dp"/>
-    <TextView
+    <android.widget.TextView
             android:text="@string/renderingmode_static"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -58,7 +58,7 @@
             app:layout_constraintLeft_toLeftOf="parent"
             android:textStyle="bold"
             android:textColor="@android:color/background_dark"/>
-    <TextView
+    <android.widget.TextView
             android:text="@string/renderingmode_dynamic"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -68,7 +68,7 @@
             app:layout_constraintLeft_toLeftOf="parent"
             android:textStyle="bold"
             android:textColor="@android:color/background_dark"/>
-    <TextView
+    <android.widget.TextView
             android:text="@string/navigating"
             android:background="@color/colorPrimary"
             android:padding="8dp"

--- a/java/format-coordinates/src/main/res/layout/activity_main.xml
+++ b/java/format-coordinates/src/main/res/layout/activity_main.xml
@@ -37,7 +37,7 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/mapView">
 
-        <TextView
+        <android.widget.TextView
             android:layout_column="0"
             android:layout_gravity="end|top"
             android:layout_margin="@dimen/coordinate_text_margin"
@@ -45,7 +45,7 @@
             android:text="@string/latlong_dd_label"
             android:textAlignment="textEnd"/>
 
-        <TextView
+        <android.widget.TextView
             android:layout_column="0"
             android:layout_gravity="end|top"
             android:layout_margin="@dimen/coordinate_text_margin"
@@ -53,7 +53,7 @@
             android:text="@string/latlong_dms_label"
             android:textAlignment="textEnd"/>
 
-        <TextView
+        <android.widget.TextView
             android:layout_column="0"
             android:layout_gravity="end|top"
             android:layout_margin="@dimen/coordinate_text_margin"
@@ -61,7 +61,7 @@
             android:text="@string/utm_label"
             android:textAlignment="textEnd"/>
 
-        <TextView
+        <android.widget.TextView
             android:layout_column="0"
             android:layout_gravity="end|top"
             android:layout_margin="@dimen/coordinate_text_margin"
@@ -69,7 +69,7 @@
             android:text="@string/usng_label"
             android:textAlignment="textEnd"/>
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/latLongDDNotation"
             android:layout_column="1"
             android:layout_gravity="start|top"
@@ -79,7 +79,7 @@
             android:textAppearance="@style/TextAppearance.AppCompat.Medium"
             />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/latLongDMSNotation"
             android:layout_column="1"
             android:layout_gravity="start|top"
@@ -89,7 +89,7 @@
             android:textAppearance="@style/TextAppearance.AppCompat.Medium"
             />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/utmNotation"
             android:layout_column="1"
             android:layout_gravity="start|top"
@@ -99,7 +99,7 @@
             android:textAppearance="@style/TextAppearance.AppCompat.Medium"
             />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/usngNotation"
             android:layout_column="1"
             android:layout_gravity="start|top"

--- a/java/format-coordinates/src/main/res/layout/dialog_coordinate.xml
+++ b/java/format-coordinates/src/main/res/layout/dialog_coordinate.xml
@@ -4,7 +4,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
-    <EditText
+    <android.widget.EditText
         android:id="@+id/coordinateNotation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/java/generate-offline-map-overrides/src/main/res/layout/override_parameters_dialog.xml
+++ b/java/generate-offline-map-overrides/src/main/res/layout/override_parameters_dialog.xml
@@ -3,12 +3,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/adjustBasemapTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -19,7 +18,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/minScaleLevelTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -28,7 +27,7 @@
             app:layout_constraintTop_toBottomOf="@+id/adjustBasemapTextView"
             app:layout_constraintEnd_toEndOf="@+id/maxScaleTextView" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/maxScaleTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -37,7 +36,7 @@
             app:layout_constraintTop_toBottomOf="@+id/minScaleLevelTextView"
             app:layout_constraintEnd_toEndOf="@+id/extentBufferDistanceTextView" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/extentBufferDistanceTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -46,7 +45,7 @@
             app:layout_constraintTop_toBottomOf="@+id/maxScaleTextView"
             app:layout_constraintEnd_toEndOf="@+id/minHydrantFlowRateTextView" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/includeLayersTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -57,7 +56,7 @@
             app:layout_constraintTop_toBottomOf="@+id/extentBufferDistanceTextView"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <CheckBox
+        <android.widget.CheckBox
             android:id="@+id/systemValvesCheckBox"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -66,7 +65,7 @@
             app:layout_constraintTop_toBottomOf="@+id/includeLayersTextView"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <CheckBox
+        <android.widget.CheckBox
             android:id="@+id/serviceConnectionsCheckBox"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -75,7 +74,7 @@
             app:layout_constraintTop_toBottomOf="@+id/systemValvesCheckBox"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/filterFeatureLayerTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -85,7 +84,7 @@
             app:layout_constraintTop_toBottomOf="@+id/serviceConnectionsCheckBox"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/minHydrantFlowRateTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -95,7 +94,7 @@
             app:layout_constraintTop_toBottomOf="@+id/filterFeatureLayerTextView"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/cropLayerToExtentTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -106,7 +105,7 @@
             app:layout_constraintTop_toBottomOf="@+id/minHydrantFlowRateTextView"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <CheckBox
+        <android.widget.CheckBox
             android:id="@+id/waterPipesCheckBox"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -115,7 +114,7 @@
             app:layout_constraintTop_toBottomOf="@+id/cropLayerToExtentTextView"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/currMinScaleTextView"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -123,7 +122,7 @@
             app:layout_constraintBottom_toBottomOf="@+id/minScaleLevelTextView"
             app:layout_constraintStart_toStartOf="@+id/currMinHydrantFlowRateTextView" />
 
-        <SeekBar
+        <android.widget.SeekBar
             android:id="@+id/minScaleSeekBar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -132,7 +131,7 @@
             app:layout_constraintTop_toTopOf="@+id/minScaleLevelTextView"
             app:layout_constraintBottom_toBottomOf="@+id/minScaleLevelTextView" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/currMaxScaleTextview"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -140,7 +139,7 @@
             app:layout_constraintTop_toTopOf="@+id/maxScaleTextView"
             app:layout_constraintStart_toStartOf="@+id/currMinHydrantFlowRateTextView" />
 
-        <SeekBar
+        <android.widget.SeekBar
             android:id="@+id/maxScaleSeekBar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -149,7 +148,7 @@
             app:layout_constraintTop_toTopOf="@+id/maxScaleTextView"
             app:layout_constraintBottom_toBottomOf="@+id/maxScaleTextView" />
 
-        <SeekBar
+        <android.widget.SeekBar
             android:id="@+id/extentBufferDistanceSeekBar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -158,7 +157,7 @@
             app:layout_constraintEnd_toStartOf="@+id/currExtentBufferDistanceTextView"
             app:layout_constraintStart_toEndOf="@+id/extentBufferDistanceTextView" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/currExtentBufferDistanceTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -168,7 +167,7 @@
             app:layout_constraintStart_toStartOf="@+id/currMinHydrantFlowRateTextView"
             app:layout_constraintEnd_toStartOf="@+id/metersTextView" />
 
-        <SeekBar
+        <android.widget.SeekBar
             android:id="@+id/minHydrantFlowRateSeekBar"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -177,7 +176,7 @@
             app:layout_constraintStart_toEndOf="@+id/minHydrantFlowRateTextView"
             app:layout_constraintEnd_toStartOf="@+id/currMinHydrantFlowRateTextView" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/currMinHydrantFlowRateTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -186,7 +185,7 @@
             app:layout_constraintBottom_toBottomOf="@+id/minHydrantFlowRateTextView"
             app:layout_constraintEnd_toStartOf="@+id/gpmTextView" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/metersTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -195,7 +194,7 @@
             app:layout_constraintBottom_toBottomOf="@+id/currExtentBufferDistanceTextView"
             app:layout_constraintStart_toEndOf="@+id/currExtentBufferDistanceTextView" />
 
-        <TextView
+        <android.widget.TextView
             android:id="@+id/gpmTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/java/map-reference-scale/src/main/res/layout/activity_main.xml
+++ b/java/map-reference-scale/src/main/res/layout/activity_main.xml
@@ -32,7 +32,7 @@
         app:layout_constraintTop_toBottomOf="@+id/referenceScaleLayout"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <Button
+    <android.widget.Button
         android:id="@+id/matchScalesButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/java/query-map-image-sublayer/src/main/java/com/esri/arcgisruntime/sample/querymapimagesublayer/MainActivity.java
+++ b/java/query-map-image-sublayer/src/main/java/com/esri/arcgisruntime/sample/querymapimagesublayer/MainActivity.java
@@ -16,14 +16,13 @@
 
 package com.esri.arcgisruntime.sample.querymapimagesublayer;
 
-import java.util.concurrent.ExecutionException;
-
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.Button;
 import android.widget.EditText;
 
 import androidx.appcompat.app.AppCompatActivity;
+
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment;
 import com.esri.arcgisruntime.concurrent.ListenableFuture;
 import com.esri.arcgisruntime.data.Feature;
@@ -45,6 +44,8 @@ import com.esri.arcgisruntime.symbology.SimpleFillSymbol;
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol;
 import com.esri.arcgisruntime.symbology.SimpleMarkerSymbol;
 import com.esri.arcgisruntime.symbology.Symbol;
+
+import java.util.concurrent.ExecutionException;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -94,7 +95,9 @@ public class MainActivity extends AppCompatActivity {
 
     // wait until the layer is loaded before enabling the query button
     imageLayer.addDoneLoadingListener(() -> {
-      if (imageLayer.getLoadStatus() == LoadStatus.LOADED) {
+      if (imageLayer.getSublayers().get(0).getLoadStatus() == LoadStatus.LOADED &&
+          imageLayer.getSublayers().get(2).getLoadStatus() == LoadStatus.LOADED &&
+          imageLayer.getSublayers().get(3).getLoadStatus() == LoadStatus.LOADED) {
         mQueryButton.setEnabled(true);
 
         // get and load each sublayer to query

--- a/java/statistical-query-group-and-sort/src/main/res/layout/field_checkbox_row.xml
+++ b/java/statistical-query-group-and-sort/src/main/res/layout/field_checkbox_row.xml
@@ -5,12 +5,12 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal">
 
-    <CheckBox
+    <android.widget.CheckBox
             android:id="@+id/rowCheckBox"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>
 
-    <TextView
+    <android.widget.TextView
             android:id="@+id/rowTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/java/statistical-query-group-and-sort/src/main/res/layout/field_row.xml
+++ b/java/statistical-query-group-and-sort/src/main/res/layout/field_row.xml
@@ -5,7 +5,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal">
 
-    <TextView
+    <android.widget.TextView
             android:id="@+id/rowTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/java/statistical-query-group-and-sort/src/main/res/layout/group_fields_view.xml
+++ b/java/statistical-query-group-and-sort/src/main/res/layout/group_fields_view.xml
@@ -5,7 +5,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-    <TextView
+    <android.widget.TextView
             android:text="@string/group_fields"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -15,7 +15,7 @@
             android:layout_marginStart="8dp"
             app:layout_constraintEnd_toEndOf="@+id/groupFieldRecyclerView"
             android:layout_marginLeft="8dp"/>
-    <TextView
+    <android.widget.TextView
             android:text="@string/order_by_field"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -25,7 +25,7 @@
             android:layout_marginEnd="8dp"
             app:layout_constraintStart_toStartOf="@+id/orderFieldRecyclerView"
             android:layout_marginStart="8dp"/>
-    <Button
+    <android.widget.Button
             android:text="@string/get_statistics"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -33,7 +33,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
-    <Button
+    <android.widget.Button
             android:text="@string/reverse_sort_order"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -41,7 +41,7 @@
             app:layout_constraintBottom_toTopOf="@+id/getStatisticsButton"
             app:layout_constraintEnd_toEndOf="@+id/orderFieldRecyclerView"
             app:layout_constraintStart_toStartOf="@+id/orderFieldRecyclerView"/>
-    <Button
+    <android.widget.Button
             android:text="@string/right"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -55,7 +55,7 @@
             android:layout_marginLeft="8dp"
             android:minHeight="0dp"
             android:minWidth="0dp"/>
-    <Button
+    <android.widget.Button
             android:text="@string/left"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/java/statistical-query-group-and-sort/src/main/res/layout/query_executing_dialog.xml
+++ b/java/statistical-query-group-and-sort/src/main/res/layout/query_executing_dialog.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent" android:layout_height="match_parent">
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-    <ProgressBar
+    <android.widget.ProgressBar
         android:id="@+id/progressBar"
         style="?android:attr/progressBarStyle"
         android:layout_width="75dp"
@@ -18,7 +18,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <TextView
+    <android.widget.TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="8dp"
@@ -32,4 +32,5 @@
         app:layout_constraintTop_toBottomOf="@+id/progressBar"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/java/statistical-query-group-and-sort/src/main/res/layout/results_expandablelistview.xml
+++ b/java/statistical-query-group-and-sort/src/main/res/layout/results_expandablelistview.xml
@@ -5,7 +5,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-    <ExpandableListView
+    <android.widget.ExpandableListView
             android:id="@+id/expandableListView"
             android:layout_width="0dp"
             android:layout_height="0dp"

--- a/java/statistical-query-group-and-sort/src/main/res/layout/statistics_view.xml
+++ b/java/statistical-query-group-and-sort/src/main/res/layout/statistics_view.xml
@@ -5,7 +5,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-    <TextView
+    <android.widget.TextView
             android:text="@string/field"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -15,14 +15,14 @@
             android:layout_marginStart="8dp"
             app:layout_constraintEnd_toEndOf="@+id/fieldSpinner"
             android:layout_marginEnd="8dp"/>
-    <TextView
+    <android.widget.TextView
             android:text="@string/type"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="@+id/typeSpinner"
             app:layout_constraintStart_toStartOf="@+id/typeSpinner"
             app:layout_constraintTop_toTopOf="parent"/>
-    <Button
+    <android.widget.Button
             android:text="@string/add"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -32,7 +32,7 @@
             app:layout_constraintBottom_toBottomOf="@+id/typeSpinner"
             app:layout_constraintTop_toTopOf="@+id/typeSpinner"
             android:layout_marginRight="8dp"/>
-    <Spinner
+    <android.widget.Spinner
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:id="@+id/fieldSpinner"
@@ -42,7 +42,7 @@
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintEnd_toStartOf="@+id/typeSpinner"
             android:layout_marginLeft="8dp"/>
-    <Spinner
+    <android.widget.Spinner
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:id="@+id/typeSpinner"
@@ -53,7 +53,7 @@
             app:layout_constraintTop_toTopOf="@+id/fieldSpinner"
             app:layout_constraintBottom_toBottomOf="@+id/fieldSpinner"
             app:layout_constraintHorizontal_bias="0.5"/>
-    <Button
+    <android.widget.Button
             android:text="@string/remove_statistic"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/java/statistical-query/src/main/res/layout/query_toolbar.xml
+++ b/java/statistical-query/src/main/res/layout/query_toolbar.xml
@@ -6,7 +6,7 @@
         android:layout_height="match_parent"
         android:background="@color/toolbar_background">
 
-    <Button
+    <android.widget.Button
             android:text="@string/get_statistics"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -19,7 +19,7 @@
             android:layout_marginBottom="8dp"
             app:layout_constraintStart_toEndOf="@+id/currentExtentCheckBox"
             android:layout_marginStart="8dp"/>
-    <CheckBox
+    <android.widget.CheckBox
             android:text="@string/only_cities_in_current_extent"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -29,7 +29,7 @@
             app:layout_constraintStart_toStartOf="parent"
             android:layout_marginStart="8dp"
             android:textColor="@android:color/background_light" android:layout_marginLeft="8dp"/>
-    <CheckBox
+    <android.widget.CheckBox
             android:text="@string/only_cities_greater_than_5m"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/java/surface-placement/src/main/java/com/esri/arcgisruntime/sample/surfaceplacement/MainActivity.java
+++ b/java/surface-placement/src/main/java/com/esri/arcgisruntime/sample/surfaceplacement/MainActivity.java
@@ -56,11 +56,11 @@ public class MainActivity extends AppCompatActivity {
 
     // add base surface for elevation data
     ArcGISTiledElevationSource elevationSource = new ArcGISTiledElevationSource(
-        getString(R.string.elevation_image_service));
+        getString(R.string.world_elevation_service));
     scene.getBaseSurface().getElevationSources().add(elevationSource);
 
     // create a scene layer from the Brest, France scene server
-    ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(getString(R.string.scene_layer_service));
+    ArcGISSceneLayer sceneLayer = new ArcGISSceneLayer(getString(R.string.brest_building_scene_service));
     scene.getOperationalLayers().add(sceneLayer);
 
     // set an initial viewpoint

--- a/java/surface-placement/src/main/res/values/strings.xml
+++ b/java/surface-placement/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Surface placement</string>
-    <string name="elevation_image_service">
+    <string name="world_elevation_service">
         https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer</string>
-    <string name="scene_layer_service">https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer</string>
+    <string name="brest_building_scene_service">https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer</string>
 </resources>

--- a/java/transforms-by-suitability/src/main/res/layout/activity_main.xml
+++ b/java/transforms-by-suitability/src/main/res/layout/activity_main.xml
@@ -16,9 +16,9 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintBottom_toTopOf="@id/order_by_check_box"
-        app:layout_constraintVertical_weight="3">
-    </com.esri.arcgisruntime.mapping.view.MapView>
-    <CheckBox
+        app:layout_constraintVertical_weight="3"/>
+
+    <android.widget.CheckBox
         android:id="@+id/order_by_check_box"
         android:text="@string/option_order_by"
         android:layout_width="0dp"
@@ -27,7 +27,8 @@
         app:layout_constraintTop_toBottomOf="@+id/mapView"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"/>
-    <ListView
+
+    <android.widget.ListView
         android:id="@+id/transforms_list"
         android:choiceMode="singleChoice"
         android:layout_width="0dp"
@@ -36,8 +37,7 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/order_by_check_box"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintVertical_weight="1"
-    />
+        app:layout_constraintVertical_weight="1" />
 
   </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/java/transforms-by-suitability/src/main/res/layout/custom_list_item.xml
+++ b/java/transforms-by-suitability/src/main/res/layout/custom_list_item.xml
@@ -5,13 +5,13 @@
               android:orientation="vertical"
               android:background="@drawable/list_item_background">
 
-  <TextView android:id="@android:id/text1"
+  <android.widget.TextView android:id="@android:id/text1"
             android:textSize="16sp"
             android:textColor="@android:color/black"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
 
-  <TextView android:id="@android:id/text2"
+  <android.widget.TextView android:id="@android:id/text2"
             android:textSize="14sp"
             android:textColor="@android:color/black"
             android:layout_width="match_parent"

--- a/kotlin/arcgis-vector-tiled-layer-custom-style/src/main/AndroidManifest.xml
+++ b/kotlin/arcgis-vector-tiled-layer-custom-style/src/main/AndroidManifest.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.esri.arcgisruntime.sample.arcgisvectortiledlayercustomstyle">
+        package="com.esri.arcgisruntime.sample.arcgisvectortiledlayercustomstyle">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <uses-feature
-        android:glEsVersion="0x00020000"
-        android:required="true" />
+            android:glEsVersion="0x00020000"
+            android:required="true" />
 
     <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+            android:allowBackup="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name"
+            android:roundIcon="@mipmap/ic_launcher_round"
+            android:supportsRtl="true"
+            android:theme="@style/AppTheme">
+        <activity
+                android:name=".MainActivity"
+                android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/kotlin/browse-ogc-api-feature-service/src/main/res/layout/activity_main.xml
+++ b/kotlin/browse-ogc-api-feature-service/src/main/res/layout/activity_main.xml
@@ -50,7 +50,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/instructionsTextView" />
 
-        <Button
+        <android.widget.Button
                 android:id="@+id/loadServiceButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/kotlin/configure-subnetwork-trace/src/main/res/layout/activity_main.xml
+++ b/kotlin/configure-subnetwork-trace/src/main/res/layout/activity_main.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
+    <android.widget.TextView
         android:id="@+id/traceOptionsTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -17,7 +17,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/barriersCheckBox" />
 
-    <CheckBox
+    <android.widget.CheckBox
         android:id="@+id/barriersCheckBox"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -27,7 +27,7 @@
         app:layout_constraintStart_toEndOf="@+id/traceOptionsTextView"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <CheckBox
+    <android.widget.CheckBox
         android:id="@+id/containersCheckbox"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -37,7 +37,7 @@
         app:layout_constraintStart_toEndOf="@+id/barriersCheckBox"
         app:layout_constraintTop_toTopOf="@+id/barriersCheckBox" />
 
-    <TextView
+    <android.widget.TextView
         android:id="@+id/defineConditionTextBox"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -48,7 +48,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/barriersCheckBox" />
 
-    <TextView
+    <android.widget.TextView
         android:id="@+id/exampleTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -59,7 +59,7 @@
         app:layout_constraintStart_toEndOf="@+id/defineConditionTextBox"
         app:layout_constraintTop_toTopOf="@+id/defineConditionTextBox" />
 
-    <RelativeLayout
+    <android.widget.RelativeLayout
         android:id="@+id/sourceBackgroundView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -72,13 +72,13 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/defineConditionTextBox">
 
-        <Spinner
+        <android.widget.Spinner
             android:id="@+id/sourceSpinner"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
-    </RelativeLayout>
+    </android.widget.RelativeLayout>
 
-    <RelativeLayout
+    <android.widget.RelativeLayout
         android:id="@+id/operatorBackgroundView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -90,13 +90,13 @@
         app:layout_constraintStart_toEndOf="@+id/sourceBackgroundView"
         app:layout_constraintTop_toTopOf="@+id/sourceBackgroundView">
 
-        <Spinner
+        <android.widget.Spinner
             android:id="@+id/operatorSpinner"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
-    </RelativeLayout>
+    </android.widget.RelativeLayout>
 
-    <RelativeLayout
+    <android.widget.RelativeLayout
         android:id="@+id/valuesBackgroundView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -109,13 +109,13 @@
         app:layout_constraintStart_toEndOf="@+id/operatorBackgroundView"
         app:layout_constraintTop_toTopOf="@+id/operatorBackgroundView">
 
-        <Spinner
+        <android.widget.Spinner
             android:id="@+id/valuesSpinner"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
-    </RelativeLayout>
+    </android.widget.RelativeLayout>
 
-    <EditText
+    <android.widget.EditText
         android:id="@+id/valuesEditText"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -126,7 +126,7 @@
         app:layout_constraintStart_toStartOf="@+id/valuesBackgroundView"
         app:layout_constraintTop_toTopOf="@+id/operatorBackgroundView" />
 
-    <ToggleButton
+    <android.widget.ToggleButton
         android:id="@+id/valueBooleanButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -137,7 +137,7 @@
         app:layout_constraintStart_toStartOf="@+id/valuesBackgroundView"
         app:layout_constraintTop_toTopOf="@+id/operatorBackgroundView" />
 
-    <Button
+    <android.widget.Button
         android:id="@+id/addButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -150,7 +150,7 @@
         app:layout_constraintStart_toEndOf="@+id/valuesBackgroundView"
         app:layout_constraintTop_toTopOf="@+id/sourceBackgroundView" />
 
-    <TextView
+    <android.widget.TextView
         android:id="@+id/barrierConditionsTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -161,7 +161,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/sourceBackgroundView" />
 
-    <TextView
+    <android.widget.TextView
         android:id="@+id/expressionTextView"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -176,7 +176,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/barrierConditionsTextView" />
 
-    <Button
+    <android.widget.Button
         android:id="@+id/traceButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -188,7 +188,7 @@
         app:layout_constraintEnd_toStartOf="@+id/resetButton"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <Button
+    <android.widget.Button
         android:id="@+id/resetButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/kotlin/create-and-save-kml-file/src/main/res/layout/kml_geometry_controls_layout.xml
+++ b/kotlin/create-and-save-kml-file/src/main/res/layout/kml_geometry_controls_layout.xml
@@ -15,7 +15,7 @@
         app:layout_constraintStart_toEndOf="@+id/geometryTextView"
         app:layout_constraintTop_toTopOf="@+id/geometryTextView" />
 
-    <Spinner
+    <android.widget.Spinner
         android:id="@+id/pointSymbolSpinner"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -24,7 +24,7 @@
         app:layout_constraintStart_toEndOf="@+id/pointSymbolTextView"
         app:layout_constraintTop_toTopOf="@+id/pointSymbolTextView" />
 
-    <Spinner
+    <android.widget.Spinner
         android:id="@+id/colorSpinner"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -63,7 +63,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/geometryTextView" />
 
-    <Button
+    <android.widget.Button
         android:id="@+id/completeSketchButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -76,7 +76,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/colorTextView" />
 
-    <Button
+    <android.widget.Button
         android:id="@+id/saveKmlButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/kotlin/display-grid/src/main/AndroidManifest.xml
+++ b/kotlin/display-grid/src/main/AndroidManifest.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.esri.arcgisruntime.sample.displaygrid">
+        package="com.esri.arcgisruntime.sample.displaygrid">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <uses-feature
-        android:glEsVersion="0x00020000"
-        android:required="true" />
+            android:glEsVersion="0x00020000"
+            android:required="true" />
 
     <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+            android:allowBackup="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name"
+            android:roundIcon="@mipmap/ic_launcher_round"
+            android:supportsRtl="true"
+            android:theme="@style/AppTheme">
+        <activity
+                android:name=".MainActivity"
+                android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/kotlin/display-subtype-feature-layer/src/main/res/layout/sublayer_control_layout.xml
+++ b/kotlin/display-subtype-feature-layer/src/main/res/layout/sublayer_control_layout.xml
@@ -14,7 +14,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/rendererRadioGroup" />
 
-    <CheckBox
+    <android.widget.CheckBox
         android:id="@+id/showSubtypeSublayerCheckBox"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -25,7 +25,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <RadioGroup
+    <android.widget.RadioGroup
         android:id="@+id/rendererRadioGroup"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -34,20 +34,20 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/showSubtypeSublayerCheckBox">
 
-        <RadioButton
+        <android.widget.RadioButton
             android:id="@+id/originalRendererButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checked="true"
             android:text="@string/show_original_renderer" />
 
-        <RadioButton
+        <android.widget.RadioButton
             android:id="@+id/alternativeRendererButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/show_alternative_renderer" />
 
-    </RadioGroup>
+    </android.widget.RadioGroup>
 
     <View
         android:layout_width="0dp"
@@ -73,7 +73,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/currentMapScaleTextView" />
 
-    <Button
+    <android.widget.Button
         android:id="@+id/setMinScaleButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/kotlin/generate-geodatabase/src/main/res/layout/activity_main.xml
+++ b/kotlin/generate-geodatabase/src/main/res/layout/activity_main.xml
@@ -4,11 +4,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">
+
     <com.esri.arcgisruntime.mapping.view.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-    <Button
+
+    <android.widget.Button
         android:id="@+id/genGeodatabaseButton"
         android:text="@string/gen_geodatabase_button_text"
         android:layout_width="match_parent"
@@ -16,4 +18,5 @@
         android:layout_alignParentBottom="true"
         android:layout_alignParentStart="true"
         android:onClick="generateGeodatabase"/>
+
 </RelativeLayout>

--- a/kotlin/generate-offline-map/src/main/res/layout/activity_main.xml
+++ b/kotlin/generate-offline-map/src/main/res/layout/activity_main.xml
@@ -11,7 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 
-    <Button
+    <android.widget.Button
         android:id="@+id/takeMapOfflineButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/kotlin/integrated-windows-authentication/src/main/res/layout/portal_info.xml
+++ b/kotlin/integrated-windows-authentication/src/main/res/layout/portal_info.xml
@@ -17,7 +17,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <Button
+    <android.widget.Button
         android:id="@+id/searchPublicButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -32,7 +32,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/portalUrlEditText" />
 
-    <Button
+    <android.widget.Button
         android:id="@+id/searchSecureButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/kotlin/query-with-cql-filters/src/main/res/layout/cql_filters_layout.xml
+++ b/kotlin/query-with-cql-filters/src/main/res/layout/cql_filters_layout.xml
@@ -9,7 +9,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/constraintLayout"
             android:layout_width="match_parent"
@@ -19,7 +18,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-            <TextView
+            <android.widget.TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/cql_filters"
@@ -31,7 +30,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
+            <android.widget.TextView
                 android:id="@+id/applyTv"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -43,7 +42,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
+            <android.widget.TextView
                 android:id="@+id/cancelTv"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -57,7 +56,7 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <LinearLayout
+        <android.widget.LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
@@ -66,7 +65,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/constraintLayout">
 
-            <TextView
+            <android.widget.TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@color/light_grey"
@@ -89,7 +88,7 @@
                 android:paddingTop="10dp"
                 android:paddingBottom="10dp">
 
-                <TextView
+                <android.widget.TextView
                     android:id="@+id/textView"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -100,7 +99,7 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
-                <TextView
+                <android.widget.TextView
                     android:id="@+id/cqlQueryTextView"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
@@ -115,7 +114,7 @@
                     app:layout_constraintStart_toEndOf="@+id/textView"
                     app:layout_constraintTop_toTopOf="parent" />
 
-                <ImageView
+                <android.widget.ImageView
                     android:id="@+id/imageView4"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -143,7 +142,7 @@
                 android:paddingTop="10dp"
                 android:paddingBottom="10dp">
 
-                <TextView
+                <android.widget.TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Max Features"
@@ -153,7 +152,7 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
-                <EditText
+                <android.widget.EditText
                     android:id="@+id/maxFeaturesEditText"
                     android:layout_width="50dp"
                     android:layout_height="wrap_content"
@@ -179,7 +178,7 @@
                 android:paddingTop="10dp"
                 android:paddingBottom="10dp">
 
-                <TextView
+                <android.widget.TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Date Filter"
@@ -200,7 +199,7 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <TextView
+            <android.widget.TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@color/light_grey"
@@ -211,14 +210,14 @@
                 android:textColor="@color/grey"
                 android:textSize="12sp" />
 
-            <DatePicker
+            <android.widget.DatePicker
                 android:id="@+id/fromDatePicker"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:calendarViewShown="false"
                 android:datePickerMode="spinner" />
 
-            <TextView
+            <android.widget.TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@color/light_grey"
@@ -229,15 +228,14 @@
                 android:textColor="@color/grey"
                 android:textSize="12sp" />
 
-            <DatePicker
+            <android.widget.DatePicker
                 android:id="@+id/toDatePicker"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:calendarViewShown="false"
                 android:datePickerMode="spinner" />
 
-        </LinearLayout>
-
+        </android.widget.LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/kotlin/surface-placement/src/main/java/com/esri/arcgisruntime/sample/surfaceplacement/MainActivity.kt
+++ b/kotlin/surface-placement/src/main/java/com/esri/arcgisruntime/sample/surfaceplacement/MainActivity.kt
@@ -42,11 +42,11 @@ class MainActivity : AppCompatActivity() {
     val scene = ArcGISScene(Basemap.Type.IMAGERY).apply {
       // add base surface for elevation data
       baseSurface.elevationSources.add(
-        ArcGISTiledElevationSource(getString(R.string.elevation_image_service))
+        ArcGISTiledElevationSource(getString(R.string.world_elevation_service))
       )
       // create a scene layer from the Brest, France scene server
       operationalLayers.add(
-        ArcGISSceneLayer(getString(R.string.scene_layer_service))
+        ArcGISSceneLayer(getString(R.string.brest_building_scene_service))
       )
     }
 

--- a/kotlin/surface-placement/src/main/res/values/strings.xml
+++ b/kotlin/surface-placement/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Surface placement</string>
-    <string name="elevation_image_service">
+    <string name="world_elevation_service">
         https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer</string>
-    <string name="scene_layer_service">https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer</string>
+    <string name="brest_building_scene_service">https://tiles.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/Buildings_Brest/SceneServer</string>
 </resources>


### PR DESCRIPTION
use android.widget. to keep old UI behaviour where needed. Required because of upgrade to Material

We had to update the sample viewer to Material to get Show Popup working. As a result, the size of some buttons and textviews went a bit funny. This addresses the worst offenders so we can release the sample viewer