### PR TITLE
Fix for U13

### DIFF
--- a/kotlin/show-popup/build.gradle
+++ b/kotlin/show-popup/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion


### PR DESCRIPTION
Removed `apply plugin: 'kotlin-kapt'` to work with `arcgisVersion=13` as defined in the `version.gradle` file. 

The show-popup sample was built on version 12, where the toolkit required the sample to use the plugin `apply plugin: 'kotlin-kapt'`. The version upgrade [here](https://github.com/Esri/arcgis-runtime-samples-android/commit/74d900d3e740cce487711898146296928beabf48) no longer the needs the plugin which may have caused the build failures. 