### PR TITLE
Gradle and JDK upgrade

### DIFF
--- a/java/add-enc-exchange-set/src/main/AndroidManifest.xml
+++ b/java/add-enc-exchange-set/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/add-features-feature-service/src/main/AndroidManifest.xml
+++ b/java/add-features-feature-service/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/add-graphics-renderer/src/main/AndroidManifest.xml
+++ b/java/add-graphics-renderer/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/add-graphics-with-symbols/src/main/AndroidManifest.xml
+++ b/java/add-graphics-with-symbols/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/add-point-scene-layer/src/main/AndroidManifest.xml
+++ b/java/add-point-scene-layer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/analyze-hotspots/src/main/AndroidManifest.xml
+++ b/java/analyze-hotspots/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:label="@string/app_name">

--- a/java/animate-3d-graphic/src/main/AndroidManifest.xml
+++ b/java/animate-3d-graphic/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/apply-scheduled-updates-to-preplanned-map-area/src/main/AndroidManifest.xml
+++ b/java/apply-scheduled-updates-to-preplanned-map-area/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/arcgis-map-image-layer-url/src/main/AndroidManifest.xml
+++ b/java/arcgis-map-image-layer-url/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name" >
             <intent-filter>

--- a/java/arcgis-tiled-layer-url/src/main/AndroidManifest.xml
+++ b/java/arcgis-tiled-layer-url/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/arcgis-vector-tiled-layer-url/src/main/AndroidManifest.xml
+++ b/java/arcgis-vector-tiled-layer-url/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/attribution-view-change/src/main/AndroidManifest.xml
+++ b/java/attribution-view-change/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
             android:theme="@style/AppTheme" >
 
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>

--- a/java/authenticate-with-oauth/src/main/AndroidManifest.xml
+++ b/java/authenticate-with-oauth/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
@@ -27,6 +28,7 @@
 
         <!-- You must declare this activity, an intent receiver, to display the OAuth login -->
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.security.DefaultOAuthIntentReceiver"
             android:launchMode="singleTask">
             <intent-filter>

--- a/java/blend-renderer/src/main/AndroidManifest.xml
+++ b/java/blend-renderer/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup,GoogleAppIndexingWarning">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/browse-wfs-layers/src/main/AndroidManifest.xml
+++ b/java/browse-wfs-layers/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/buffer/src/main/AndroidManifest.xml
+++ b/java/buffer/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
             android:theme="@style/AppTheme" >
 
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>

--- a/java/change-atmosphere-effect/src/main/AndroidManifest.xml
+++ b/java/change-atmosphere-effect/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/change-basemaps/src/main/AndroidManifest.xml
+++ b/java/change-basemaps/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/change-feature-layer-renderer/src/main/AndroidManifest.xml
+++ b/java/change-feature-layer-renderer/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/change-sublayer-renderer/src/main/AndroidManifest.xml
+++ b/java/change-sublayer-renderer/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
             android:label="@string/app_name"
             android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>

--- a/java/change-sublayer-visibility/src/main/AndroidManifest.xml
+++ b/java/change-sublayer-visibility/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/change-viewpoint/src/main/AndroidManifest.xml
+++ b/java/change-viewpoint/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/choose-camera-controller/src/main/AndroidManifest.xml
+++ b/java/choose-camera-controller/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name"
             android:theme="@style/NoBarTheme">

--- a/java/clip-geometry/src/main/AndroidManifest.xml
+++ b/java/clip-geometry/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/colormap-renderer/src/main/AndroidManifest.xml
+++ b/java/colormap-renderer/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup,GoogleAppIndexingWarning">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/control-annotation-sublayer-visibility/src/main/AndroidManifest.xml
+++ b/java/control-annotation-sublayer-visibility/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/create-and-save-map/src/main/AndroidManifest.xml
+++ b/java/create-and-save-map/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/create-geometries/src/main/AndroidManifest.xml
+++ b/java/create-geometries/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name" >
             <intent-filter>

--- a/java/create-terrain-from-a-local-raster/src/main/AndroidManifest.xml
+++ b/java/create-terrain-from-a-local-raster/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/create-terrain-from-a-local-tile-package/src/main/AndroidManifest.xml
+++ b/java/create-terrain-from-a-local-tile-package/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/cut-geometry/src/main/AndroidManifest.xml
+++ b/java/cut-geometry/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
             android:theme="@style/AppTheme" >
 
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>

--- a/java/delete-features-feature-service/src/main/AndroidManifest.xml
+++ b/java/delete-features-feature-service/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/densify-and-generalize/src/main/AndroidManifest.xml
+++ b/java/densify-and-generalize/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
             android:theme="@style/AppTheme" >
 
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>

--- a/java/dictionary-renderer-graphics-overlay/src/main/AndroidManifest.xml
+++ b/java/dictionary-renderer-graphics-overlay/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/display-device-location/src/main/AndroidManifest.xml
+++ b/java/display-device-location/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/display-drawing-status/src/main/AndroidManifest.xml
+++ b/java/display-drawing-status/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme" >
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/display-grid/src/main/AndroidManifest.xml
+++ b/java/display-grid/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
             android:theme="@style/AppTheme" >
 
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>

--- a/java/display-kml-network-links/src/main/AndroidManifest.xml
+++ b/java/display-kml-network-links/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/display-kml/src/main/AndroidManifest.xml
+++ b/java/display-kml/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/display-layer-view-state/src/main/AndroidManifest.xml
+++ b/java/display-layer-view-state/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/display-map/src/main/AndroidManifest.xml
+++ b/java/display-map/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/display-scene-in-tabletop-ar/src/main/AndroidManifest.xml
+++ b/java/display-scene-in-tabletop-ar/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/display-scene/src/main/AndroidManifest.xml
+++ b/java/display-scene/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/display-wfs-layer/src/main/AndroidManifest.xml
+++ b/java/display-wfs-layer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/distance-composite-symbol/src/main/AndroidManifest.xml
+++ b/java/distance-composite-symbol/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/distance-measurement-analysis/src/main/AndroidManifest.xml
+++ b/java/distance-measurement-analysis/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/download-preplanned-map-area/src/main/AndroidManifest.xml
+++ b/java/download-preplanned-map-area/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name">

--- a/java/edit-and-sync-features/src/main/AndroidManifest.xml
+++ b/java/edit-and-sync-features/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/edit-feature-attachments/src/main/AndroidManifest.xml
+++ b/java/edit-feature-attachments/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
         </provider>
 
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>
@@ -35,6 +36,7 @@
             </intent-filter>
         </activity>
         <activity
+            android:exported="true"
                 android:name=".EditAttachmentActivity"
                 android:label="@string/edit_attachments" />
     </application>

--- a/java/explore-scene-in-flyover-ar/src/main/AndroidManifest.xml
+++ b/java/explore-scene-in-flyover-ar/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.exploresceneinflyoverar.MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/export-tiles/src/main/AndroidManifest.xml
+++ b/java/export-tiles/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:label="@string/app_name">

--- a/java/feature-collection-layer-query/src/main/AndroidManifest.xml
+++ b/java/feature-collection-layer-query/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/feature-collection-layer/src/main/AndroidManifest.xml
+++ b/java/feature-collection-layer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/feature-layer-definition-expression/src/main/AndroidManifest.xml
+++ b/java/feature-layer-definition-expression/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/feature-layer-dictionary-renderer/src/main/AndroidManifest.xml
+++ b/java/feature-layer-dictionary-renderer/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/feature-layer-extrusion/src/main/AndroidManifest.xml
+++ b/java/feature-layer-extrusion/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/feature-layer-feature-service/src/main/AndroidManifest.xml
+++ b/java/feature-layer-feature-service/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name" >
             <intent-filter>

--- a/java/feature-layer-geodatabase/src/main/AndroidManifest.xml
+++ b/java/feature-layer-geodatabase/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/feature-layer-geopackage/src/main/AndroidManifest.xml
+++ b/java/feature-layer-geopackage/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/feature-layer-query/src/main/AndroidManifest.xml
+++ b/java/feature-layer-query/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name"
             android:launchMode="singleTop">

--- a/java/feature-layer-rendering-mode-map/src/main/AndroidManifest.xml
+++ b/java/feature-layer-rendering-mode-map/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
             android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>

--- a/java/feature-layer-rendering-mode-scene/src/main/AndroidManifest.xml
+++ b/java/feature-layer-rendering-mode-scene/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme" >
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/feature-layer-selection/src/main/AndroidManifest.xml
+++ b/java/feature-layer-selection/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name" >
             <intent-filter>

--- a/java/feature-layer-shapefile/src/main/AndroidManifest.xml
+++ b/java/feature-layer-shapefile/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/feature-layer-show-attributes/src/main/AndroidManifest.xml
+++ b/java/feature-layer-show-attributes/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/feature-layer-update-attributes/src/main/AndroidManifest.xml
+++ b/java/feature-layer-update-attributes/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
@@ -24,6 +25,7 @@
             </intent-filter>
         </activity>
         <activity
+            android:exported="true"
             android:name=".DamageTypesListActivity"
             android:label="@string/select_damage_Type"></activity>
     </application>

--- a/java/feature-layer-update-geometry/src/main/AndroidManifest.xml
+++ b/java/feature-layer-update-geometry/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/find-address/src/main/AndroidManifest.xml
+++ b/java/find-address/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/find-closest-facility-to-an-incident-interactive/src/main/AndroidManifest.xml
+++ b/java/find-closest-facility-to-an-incident-interactive/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/find-closest-facility-to-multiple-incidents-service/src/main/AndroidManifest.xml
+++ b/java/find-closest-facility-to-multiple-incidents-service/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/find-place/src/main/AndroidManifest.xml
+++ b/java/find-place/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/find-route/src/main/AndroidManifest.xml
+++ b/java/find-route/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.findroute.MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/find-service-area-interactive/src/main/AndroidManifest.xml
+++ b/java/find-service-area-interactive/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/format-coordinates/src/main/AndroidManifest.xml
+++ b/java/format-coordinates/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/generate-geodatabase/src/main/AndroidManifest.xml
+++ b/java/generate-geodatabase/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/generate-offline-map-overrides/src/main/AndroidManifest.xml
+++ b/java/generate-offline-map-overrides/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/generate-offline-map-with-local-basemap/src/main/AndroidManifest.xml
+++ b/java/generate-offline-map-with-local-basemap/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/generate-offline-map/src/main/AndroidManifest.xml
+++ b/java/generate-offline-map/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/geodesic-operations/src/main/AndroidManifest.xml
+++ b/java/geodesic-operations/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/get-elevation-at-point/src/main/AndroidManifest.xml
+++ b/java/get-elevation-at-point/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/group-layers/src/main/AndroidManifest.xml
+++ b/java/group-layers/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.grouplayers.MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/hillshade-renderer/src/main/AndroidManifest.xml
+++ b/java/hillshade-renderer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup,GoogleAppIndexingWarning">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/honor-mobile-map-package-expiration-date/src/main/AndroidManifest.xml
+++ b/java/honor-mobile-map-package-expiration-date/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/identify-graphics/src/main/AndroidManifest.xml
+++ b/java/identify-graphics/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/identify-kml-features/src/main/AndroidManifest.xml
+++ b/java/identify-kml-features/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/identify-layers/src/main/AndroidManifest.xml
+++ b/java/identify-layers/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/integrated-mesh-layer/src/main/AndroidManifest.xml
+++ b/java/integrated-mesh-layer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/integrated-windows-authentication/src/main/AndroidManifest.xml
+++ b/java/integrated-windows-authentication/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/line-of-sight-geoelement/src/main/AndroidManifest.xml
+++ b/java/line-of-sight-geoelement/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/list-kml-contents/src/main/AndroidManifest.xml
+++ b/java/list-kml-contents/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/list-related-features/src/main/AndroidManifest.xml
+++ b/java/list-related-features/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/location-line-of-sight/src/main/AndroidManifest.xml
+++ b/java/location-line-of-sight/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/manage-bookmarks/src/main/AndroidManifest.xml
+++ b/java/manage-bookmarks/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/manage-operational-layers/src/main/AndroidManifest.xml
+++ b/java/manage-operational-layers/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name" >
             <intent-filter>
@@ -23,6 +24,7 @@
             </intent-filter>
         </activity>
         <activity
+            android:exported="true"
             android:name=".OperationalLayers">
         </activity>
     </application>

--- a/java/map-image-layer-tables/src/main/AndroidManifest.xml
+++ b/java/map-image-layer-tables/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/map-load-status/src/main/AndroidManifest.xml
+++ b/java/map-load-status/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/map-reference-scale/src/main/AndroidManifest.xml
+++ b/java/map-reference-scale/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/java/map-reference-scale/src/main/AndroidManifest.xml
+++ b/java/map-reference-scale/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/java/map-rotation/src/main/AndroidManifest.xml
+++ b/java/map-rotation/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/mobile-map-search-and-route/src/main/AndroidManifest.xml
+++ b/java/mobile-map-search-and-route/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
@@ -25,6 +26,7 @@
             </intent-filter>
         </activity>
         <activity
+            android:exported="true"
             android:name=".MapChooserActivity"
             android:label="@string/chooseMap">
             <intent-filter tools:ignore="GoogleAppIndexingWarning">

--- a/java/navigate-in-ar/src/main/AndroidManifest.xml
+++ b/java/navigate-in-ar/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="Navigate in AR"
             android:theme="@style/AppTheme.NoActionBar">
@@ -29,6 +30,7 @@
             </intent-filter>
         </activity>
         <activity
+            android:exported="true"
             android:name=".ARNavigateActivity"
             android:label="@string/app_name">
         </activity>

--- a/java/navigate-route/src/main/AndroidManifest.xml
+++ b/java/navigate-route/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/offline-geocode/src/main/AndroidManifest.xml
+++ b/java/offline-geocode/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/open-existing-map/src/main/AndroidManifest.xml
+++ b/java/open-existing-map/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/open-mobile-map-package/src/main/AndroidManifest.xml
+++ b/java/open-mobile-map-package/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/open-mobile-scene-package/src/main/AndroidManifest.xml
+++ b/java/open-mobile-scene-package/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/open-scene-portal-item/src/main/AndroidManifest.xml
+++ b/java/open-scene-portal-item/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.opensceneportalitem.MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/openstreetmap-layer/src/main/AndroidManifest.xml
+++ b/java/openstreetmap-layer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/perform-spatial-operations/src/main/AndroidManifest.xml
+++ b/java/perform-spatial-operations/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/picture-marker-symbols/src/main/AndroidManifest.xml
+++ b/java/picture-marker-symbols/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/play-kml-tour/src/main/AndroidManifest.xml
+++ b/java/play-kml-tour/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/portal-user-info/src/main/AndroidManifest.xml
+++ b/java/portal-user-info/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:label="@string/app_name">

--- a/java/project/src/main/AndroidManifest.xml
+++ b/java/project/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/query-map-image-sublayer/src/main/AndroidManifest.xml
+++ b/java/query-map-image-sublayer/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/raster-function-service/src/main/AndroidManifest.xml
+++ b/java/raster-function-service/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.rasterfunctionservice.MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/raster-layer-file/src/main/AndroidManifest.xml
+++ b/java/raster-layer-file/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/raster-layer-geopackage/src/main/AndroidManifest.xml
+++ b/java/raster-layer-geopackage/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/raster-layer-service/src/main/AndroidManifest.xml
+++ b/java/raster-layer-service/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/raster-rendering-rule/src/main/AndroidManifest.xml
+++ b/java/raster-rendering-rule/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/read-geopackage/src/main/AndroidManifest.xml
+++ b/java/read-geopackage/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/read-symbols-mobile-style-file/src/main/AndroidManifest.xml
+++ b/java/read-symbols-mobile-style-file/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/rgb-renderer/src/main/AndroidManifest.xml
+++ b/java/rgb-renderer/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/scene-layer-selection/src/main/AndroidManifest.xml
+++ b/java/scene-layer-selection/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/scene-layer/src/main/AndroidManifest.xml
+++ b/java/scene-layer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/scene-property-expressions/src/main/AndroidManifest.xml
+++ b/java/scene-property-expressions/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/scene-symbols/src/main/AndroidManifest.xml
+++ b/java/scene-symbols/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/search-for-webmap/src/main/AndroidManifest.xml
+++ b/java/search-for-webmap/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/service-feature-table-cache/src/main/AndroidManifest.xml
+++ b/java/service-feature-table-cache/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.servicefeaturetablecache.MainActivity"
             android:label="@string/app_name" >
             <intent-filter>

--- a/java/service-feature-table-manual-cache/src/main/AndroidManifest.xml
+++ b/java/service-feature-table-manual-cache/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/service-feature-table-no-cache/src/main/AndroidManifest.xml
+++ b/java/service-feature-table-no-cache/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/set-initial-map-area/src/main/AndroidManifest.xml
+++ b/java/set-initial-map-area/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.setinitialmaparea.MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/set-initial-map-location/src/main/AndroidManifest.xml
+++ b/java/set-initial-map-location/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/set-map-spatial-reference/src/main/AndroidManifest.xml
+++ b/java/set-map-spatial-reference/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/set-min-max-scale/src/main/AndroidManifest.xml
+++ b/java/set-min-max-scale/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name="com.esri.arcgisruntime.samples.setminxmaxscale.MainActivity">
+            android:exported="true" 
+            android:name="com.esri.arcgisruntime.samples.setminxmaxscale.MainActivity">
             <intent-filter>
                 <action
                     android:name="android.intent.action.MAIN"

--- a/java/set-min-max-scale/src/main/AndroidManifest.xml
+++ b/java/set-min-max-scale/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.esri.arcgisruntime.samples.setminxmaxscale.MainActivity">
+        <activity
+            android:exported="true" android:name="com.esri.arcgisruntime.samples.setminxmaxscale.MainActivity">
             <intent-filter>
                 <action
                     android:name="android.intent.action.MAIN"

--- a/java/show-callout/src/main/AndroidManifest.xml
+++ b/java/show-callout/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/show-labels-on-layer/src/main/AndroidManifest.xml
+++ b/java/show-labels-on-layer/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/show-magnifier/src/main/AndroidManifest.xml
+++ b/java/show-magnifier/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/simple-marker-symbol/src/main/AndroidManifest.xml
+++ b/java/simple-marker-symbol/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/simple-renderer/src/main/AndroidManifest.xml
+++ b/java/simple-renderer/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/sketch-editor/src/main/AndroidManifest.xml
+++ b/java/sketch-editor/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/spatial-relationships/src/main/AndroidManifest.xml
+++ b/java/spatial-relationships/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.spatialrelationships.MainActivity"
             android:label="@string/app_name">
             <intent-filter>
@@ -23,6 +24,7 @@
             </intent-filter>
         </activity>
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.spatialrelationships.ResultsActivity"
             android:label="@string/Relationships" />
     </application>

--- a/java/statistical-query-group-and-sort/src/main/AndroidManifest.xml
+++ b/java/statistical-query-group-and-sort/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.statisticalquerygroupandsort.MainActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait">
@@ -21,6 +22,7 @@
             </intent-filter>
         </activity>
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.statisticalquerygroupandsort.ResultsActivity"
             android:label="Statistical Query - results"
             android:screenOrientation="portrait" />

--- a/java/statistical-query/src/main/AndroidManifest.xml
+++ b/java/statistical-query/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/stretch-renderer/src/main/AndroidManifest.xml
+++ b/java/stretch-renderer/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/style-wms-layer/src/main/AndroidManifest.xml
+++ b/java/style-wms-layer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/surface-placement/src/main/AndroidManifest.xml
+++ b/java/surface-placement/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.surfaceplacement.MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/symbolize-shapefile/src/main/AndroidManifest.xml
+++ b/java/symbolize-shapefile/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/sync-map-and-scene-viewpoints/src/main/AndroidManifest.xml
+++ b/java/sync-map-and-scene-viewpoints/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/take-screenshot/src/main/AndroidManifest.xml
+++ b/java/take-screenshot/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
                   android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/java/take-screenshot/src/main/AndroidManifest.xml
+++ b/java/take-screenshot/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
                   android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/java/terrain-exaggeration/src/main/AndroidManifest.xml
+++ b/java/terrain-exaggeration/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/time-based-query/src/main/AndroidManifest.xml
+++ b/java/time-based-query/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/token-authentication/src/main/AndroidManifest.xml
+++ b/java/token-authentication/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/transforms-by-suitability/src/main/AndroidManifest.xml
+++ b/java/transforms-by-suitability/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">

--- a/java/unique-value-renderer/src/main/AndroidManifest.xml
+++ b/java/unique-value-renderer/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/update-related-features/src/main/AndroidManifest.xml
+++ b/java/update-related-features/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/view-content-beneath-the-terrain-surface/src/main/AndroidManifest.xml
+++ b/java/view-content-beneath-the-terrain-surface/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/view-point-cloud-data-offline/src/main/AndroidManifest.xml
+++ b/java/view-point-cloud-data-offline/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/viewshed-camera/src/main/AndroidManifest.xml
+++ b/java/viewshed-camera/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/viewshed-geoelement/src/main/AndroidManifest.xml
+++ b/java/viewshed-geoelement/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/viewshed-geoprocessing/src/main/AndroidManifest.xml
+++ b/java/viewshed-geoprocessing/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme" >
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/viewshed-location/src/main/AndroidManifest.xml
+++ b/java/viewshed-location/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/web-tiled-layer/src/main/AndroidManifest.xml
+++ b/java/web-tiled-layer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/wfs-xml-query/src/main/AndroidManifest.xml
+++ b/java/wfs-xml-query/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.wfsxmlquery.MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/wms-layer-url/src/main/AndroidManifest.xml
+++ b/java/wms-layer-url/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/java/wmts-layer/src/main/AndroidManifest.xml
+++ b/java/wmts-layer/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.wmtslayer.MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/add-features-feature-service/src/main/AndroidManifest.xml
+++ b/kotlin/add-features-feature-service/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/add-graphics-renderer/src/main/AndroidManifest.xml
+++ b/kotlin/add-graphics-renderer/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/add-graphics-renderer/src/main/AndroidManifest.xml
+++ b/kotlin/add-graphics-renderer/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/add-graphics-with-symbols/src/main/AndroidManifest.xml
+++ b/kotlin/add-graphics-with-symbols/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/add-graphics-with-symbols/src/main/AndroidManifest.xml
+++ b/kotlin/add-graphics-with-symbols/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/analyze-hotspots/src/main/AndroidManifest.xml
+++ b/kotlin/analyze-hotspots/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme" >
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/animate-images-with-image-overlay/src/main/AndroidManifest.xml
+++ b/kotlin/animate-images-with-image-overlay/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/apply-mosaic-rule-to-rasters/src/main/AndroidManifest.xml
+++ b/kotlin/apply-mosaic-rule-to-rasters/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/apply-mosaic-rule-to-rasters/src/main/AndroidManifest.xml
+++ b/kotlin/apply-mosaic-rule-to-rasters/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/arcgis-vector-tiled-layer-custom-style/src/main/AndroidManifest.xml
+++ b/kotlin/arcgis-vector-tiled-layer-custom-style/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/attribution-view-change/src/main/AndroidManifest.xml
+++ b/kotlin/attribution-view-change/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/authenticate-with-oauth/src/main/AndroidManifest.xml
+++ b/kotlin/authenticate-with-oauth/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
@@ -27,6 +28,7 @@
 
         <!-- You must declare this activity, an intent receiver, to display the OAuth login -->
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.security.DefaultOAuthIntentReceiver"
             android:launchMode="singleTask">
             <intent-filter>

--- a/kotlin/browse-ogc-api-feature-service/src/main/AndroidManifest.xml
+++ b/kotlin/browse-ogc-api-feature-service/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/buffer/src/main/AndroidManifest.xml
+++ b/kotlin/buffer/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/change-atmosphere-effect/src/main/AndroidManifest.xml
+++ b/kotlin/change-atmosphere-effect/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/change-basemaps/src/main/AndroidManifest.xml
+++ b/kotlin/change-basemaps/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/AppTheme"
         android:supportsRtl="true">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/change-viewpoint/src/main/AndroidManifest.xml
+++ b/kotlin/change-viewpoint/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/choose-camera-controller/src/main/AndroidManifest.xml
+++ b/kotlin/choose-camera-controller/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name"
             android:theme="@style/NoBarTheme">

--- a/kotlin/configure-subnetwork-trace/src/main/AndroidManifest.xml
+++ b/kotlin/configure-subnetwork-trace/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/convex-hull/src/main/AndroidManifest.xml
+++ b/kotlin/convex-hull/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/convex-hull/src/main/AndroidManifest.xml
+++ b/kotlin/convex-hull/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/create-and-save-kml-file/src/main/AndroidManifest.xml
+++ b/kotlin/create-and-save-kml-file/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/create-symbol-styles-from-web-styles/src/main/AndroidManifest.xml
+++ b/kotlin/create-symbol-styles-from-web-styles/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/create-terrain-from-a-local-raster/src/main/AndroidManifest.xml
+++ b/kotlin/create-terrain-from-a-local-raster/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/create-terrain-from-a-local-tile-package/src/main/AndroidManifest.xml
+++ b/kotlin/create-terrain-from-a-local-tile-package/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/custom-dictionary-style/src/main/AndroidManifest.xml
+++ b/kotlin/custom-dictionary-style/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/delete-features-feature-service/src/main/AndroidManifest.xml
+++ b/kotlin/delete-features-feature-service/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/display-annotation/src/main/AndroidManifest.xml
+++ b/kotlin/display-annotation/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/display-device-location-with-nmea-data-sources/src/main/AndroidManifest.xml
+++ b/kotlin/display-device-location-with-nmea-data-sources/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/display-device-location/src/main/AndroidManifest.xml
+++ b/kotlin/display-device-location/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/display-device-location/src/main/AndroidManifest.xml
+++ b/kotlin/display-device-location/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/display-grid/src/main/AndroidManifest.xml
+++ b/kotlin/display-grid/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/display-kml/src/main/AndroidManifest.xml
+++ b/kotlin/display-kml/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/display-layer-view-state/src/main/AndroidManifest.xml
+++ b/kotlin/display-layer-view-state/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/display-layer-view-state/src/main/AndroidManifest.xml
+++ b/kotlin/display-layer-view-state/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/display-map/src/main/AndroidManifest.xml
+++ b/kotlin/display-map/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/display-ogc-api-collection/src/main/AndroidManifest.xml
+++ b/kotlin/display-ogc-api-collection/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/display-ogc-api-collection/src/main/AndroidManifest.xml
+++ b/kotlin/display-ogc-api-collection/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/display-subtype-feature-layer/src/main/AndroidManifest.xml
+++ b/kotlin/display-subtype-feature-layer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/display-utility-associations/src/main/AndroidManifest.xml
+++ b/kotlin/display-utility-associations/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/download-preplanned-map-area/src/main/AndroidManifest.xml
+++ b/kotlin/download-preplanned-map-area/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name">

--- a/kotlin/edit-and-sync-features/src/main/AndroidManifest.xml
+++ b/kotlin/edit-and-sync-features/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/edit-features-with-feature-linked-annotation/src/main/AndroidManifest.xml
+++ b/kotlin/edit-features-with-feature-linked-annotation/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/edit-with-branch-versioning/src/main/AndroidManifest.xml
+++ b/kotlin/edit-with-branch-versioning/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/edit-with-branch-versioning/src/main/AndroidManifest.xml
+++ b/kotlin/edit-with-branch-versioning/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/export-tiles/src/main/AndroidManifest.xml
+++ b/kotlin/export-tiles/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     android:supportsRtl="true"
     android:theme="@style/AppTheme">
     <activity
+            android:exported="true"
       android:name=".MainActivity"
       android:label="@string/app_name">
       <intent-filter>

--- a/kotlin/feature-collection-layer-portal-item/src/main/AndroidManifest.xml
+++ b/kotlin/feature-collection-layer-portal-item/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/feature-collection-layer-portal-item/src/main/AndroidManifest.xml
+++ b/kotlin/feature-collection-layer-portal-item/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/feature-layer-definition-expression/src/main/AndroidManifest.xml
+++ b/kotlin/feature-layer-definition-expression/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/feature-layer-extrusion/src/main/AndroidManifest.xml
+++ b/kotlin/feature-layer-extrusion/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/feature-layer-feature-service/src/main/AndroidManifest.xml
+++ b/kotlin/feature-layer-feature-service/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/feature-layer-feature-service/src/main/AndroidManifest.xml
+++ b/kotlin/feature-layer-feature-service/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/feature-layer-geodatabase/src/main/AndroidManifest.xml
+++ b/kotlin/feature-layer-geodatabase/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/feature-layer-query/src/main/AndroidManifest.xml
+++ b/kotlin/feature-layer-query/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name"
             android:launchMode="singleTop">

--- a/kotlin/feature-layer-selection/src/main/AndroidManifest.xml
+++ b/kotlin/feature-layer-selection/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/find-address/src/main/AndroidManifest.xml
+++ b/kotlin/find-address/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/find-route/src/main/AndroidManifest.xml
+++ b/kotlin/find-route/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/find-route/src/main/AndroidManifest.xml
+++ b/kotlin/find-route/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/generate-geodatabase/src/main/AndroidManifest.xml
+++ b/kotlin/generate-geodatabase/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/generate-offline-map/src/main/AndroidManifest.xml
+++ b/kotlin/generate-offline-map/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/generate-offline-map/src/main/AndroidManifest.xml
+++ b/kotlin/generate-offline-map/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/geodesic-operations/src/main/AndroidManifest.xml
+++ b/kotlin/geodesic-operations/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Dec 13 20:00:18 PST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/kotlin/group-layers/src/main/AndroidManifest.xml
+++ b/kotlin/group-layers/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/group-layers/src/main/AndroidManifest.xml
+++ b/kotlin/group-layers/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/identify-layers/src/main/AndroidManifest.xml
+++ b/kotlin/identify-layers/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/identify-raster-cell/src/main/AndroidManifest.xml
+++ b/kotlin/identify-raster-cell/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/integrated-mesh-layer/src/main/AndroidManifest.xml
+++ b/kotlin/integrated-mesh-layer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/integrated-windows-authentication/src/main/AndroidManifest.xml
+++ b/kotlin/integrated-windows-authentication/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/manage-operational-layers/src/main/AndroidManifest.xml
+++ b/kotlin/manage-operational-layers/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/manage-operational-layers/src/main/AndroidManifest.xml
+++ b/kotlin/manage-operational-layers/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/map-rotation/src/main/AndroidManifest.xml
+++ b/kotlin/map-rotation/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/navigate-route/src/main/AndroidManifest.xml
+++ b/kotlin/navigate-route/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/nearest-vertex/src/main/AndroidManifest.xml
+++ b/kotlin/nearest-vertex/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/offline-geocode/src/main/AndroidManifest.xml
+++ b/kotlin/offline-geocode/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/offline-routing/src/main/AndroidManifest.xml
+++ b/kotlin/offline-routing/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
         android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/offline-routing/src/main/AndroidManifest.xml
+++ b/kotlin/offline-routing/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
         android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/open-mobile-map-package/src/main/AndroidManifest.xml
+++ b/kotlin/open-mobile-map-package/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/perform-spatial-operations/src/main/AndroidManifest.xml
+++ b/kotlin/perform-spatial-operations/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/perform-valve-isolation-trace/src/main/AndroidManifest.xml
+++ b/kotlin/perform-valve-isolation-trace/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/perform-valve-isolation-trace/src/main/AndroidManifest.xml
+++ b/kotlin/perform-valve-isolation-trace/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/portal-user-info/src/main/AndroidManifest.xml
+++ b/kotlin/portal-user-info/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/query-with-cql-filters/src/main/AndroidManifest.xml
+++ b/kotlin/query-with-cql-filters/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Kotlin">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/query-with-cql-filters/src/main/AndroidManifest.xml
+++ b/kotlin/query-with-cql-filters/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Kotlin">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/raster-function-service/src/main/AndroidManifest.xml
+++ b/kotlin/raster-function-service/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/raster-layer-file/src/main/AndroidManifest.xml
+++ b/kotlin/raster-layer-file/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/raster-rendering-rule/src/main/AndroidManifest.xml
+++ b/kotlin/raster-rendering-rule/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/realistic-lighting-and-shadows/src/main/AndroidManifest.xml
+++ b/kotlin/realistic-lighting-and-shadows/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/realistic-lighting-and-shadows/src/main/AndroidManifest.xml
+++ b/kotlin/realistic-lighting-and-shadows/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/route-around-barriers/src/main/AndroidManifest.xml
+++ b/kotlin/route-around-barriers/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/scene-layer/src/main/AndroidManifest.xml
+++ b/kotlin/scene-layer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/set-initial-map-area/src/main/AndroidManifest.xml
+++ b/kotlin/set-initial-map-area/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.setinitialmaparea.MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/set-min-max-scale/src/main/AndroidManifest.xml
+++ b/kotlin/set-min-max-scale/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/set-up-location-driven-geotriggers/src/main/AndroidManifest.xml
+++ b/kotlin/set-up-location-driven-geotriggers/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
                 android:name=".MainActivity"
                 android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/show-callout/src/main/AndroidManifest.xml
+++ b/kotlin/show-callout/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name="com.esri.arcgisruntime.sample.showcallout.MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/show-labels-on-layer-in-3d/src/main/AndroidManifest.xml
+++ b/kotlin/show-labels-on-layer-in-3d/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/show-labels-on-layer/src/main/AndroidManifest.xml
+++ b/kotlin/show-labels-on-layer/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/show-location-history/src/main/AndroidManifest.xml
+++ b/kotlin/show-location-history/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup">
-        <activity android:name=".MainActivity"
+        <activity
+            android:exported="true" android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/show-location-history/src/main/AndroidManifest.xml
+++ b/kotlin/show-location-history/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup">
         <activity
-            android:exported="true" android:name=".MainActivity"
+            android:exported="true" 
+            android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/kotlin/show-popup/src/main/AndroidManifest.xml
+++ b/kotlin/show-popup/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/surface-placement/src/main/AndroidManifest.xml
+++ b/kotlin/surface-placement/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/token-authentication/src/main/AndroidManifest.xml
+++ b/kotlin/token-authentication/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/trace-utility-network/src/main/AndroidManifest.xml
+++ b/kotlin/trace-utility-network/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/view-point-cloud-data-offline/src/main/AndroidManifest.xml
+++ b/kotlin/view-point-cloud-data-offline/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/viewshed-geoprocessing/src/main/AndroidManifest.xml
+++ b/kotlin/viewshed-geoprocessing/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         tools:ignore="GoogleAppIndexingWarning">
 
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/viewshed-location/src/main/AndroidManifest.xml
+++ b/kotlin/viewshed-location/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/kotlin/wmts-layer/src/main/AndroidManifest.xml
+++ b/kotlin/wmts-layer/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:label="@string/app_name">
             <intent-filter>

--- a/version.gradle
+++ b/version.gradle
@@ -16,7 +16,7 @@ ext {
     materialVersion = '1.4.0'
     recyclerViewVersion = '1.1.0'
     // plugin versions
-    gradleVersion = '4.1.2'
+    gradleVersion = '7.0.4'
     // java version
-    javaVersion = 1.8
+    javaVersion = 1.11
 }


### PR DESCRIPTION
Changes made: 

- Upgrade change was made in the versions.gradle changes: `javaVersion = 1.11` and `kotlinVersion = '1.5.20'`
- Since gradle 7.+ requires `android:exported`  to be defined in every sample


This PR is to address Android Toolkit support for version 13. 