### PR TITLE
Samples to viewbinding

### DIFF
--- a/kotlin/arcgis-vector-tiled-layer-custom-style/build.gradle
+++ b/kotlin/arcgis-vector-tiled-layer-custom-style/build.gradle
@@ -21,6 +21,10 @@ android {
         }
     }
 
+    buildFeatures{
+        viewBinding true
+    }
+
 }
 
 dependencies {

--- a/kotlin/arcgis-vector-tiled-layer-custom-style/build.gradle
+++ b/kotlin/arcgis-vector-tiled-layer-custom-style/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
-
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 

--- a/kotlin/arcgis-vector-tiled-layer-custom-style/build.gradle
+++ b/kotlin/arcgis-vector-tiled-layer-custom-style/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/kotlin/arcgis-vector-tiled-layer-custom-style/src/main/java/com/esri/arcgisruntime/sample/arcgisvectortiledlayercustomstyle/MainActivity.kt
+++ b/kotlin/arcgis-vector-tiled-layer-custom-style/src/main/java/com/esri/arcgisruntime/sample/arcgisvectortiledlayercustomstyle/MainActivity.kt
@@ -21,10 +21,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.AdapterView
-import android.widget.BaseAdapter
-import android.widget.TextView
-import android.widget.Toast
+import android.widget.*
 import androidx.appcompat.app.AppCompatActivity
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment
 import com.esri.arcgisruntime.concurrent.Job
@@ -36,10 +33,12 @@ import com.esri.arcgisruntime.loadable.LoadStatus
 import com.esri.arcgisruntime.mapping.ArcGISMap
 import com.esri.arcgisruntime.mapping.ItemResourceCache
 import com.esri.arcgisruntime.mapping.Viewpoint
+import com.esri.arcgisruntime.mapping.view.MapView
 import com.esri.arcgisruntime.portal.Portal
 import com.esri.arcgisruntime.portal.PortalItem
+import com.esri.arcgisruntime.sample.arcgisvectortiledlayercustomstyle.databinding.ActivityMainBinding
+import com.esri.arcgisruntime.sample.arcgisvectortiledlayercustomstyle.databinding.SpinnerItemBinding
 import com.esri.arcgisruntime.tasks.vectortilecache.ExportVectorTilesTask
-import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity() {
 
@@ -65,9 +64,22 @@ class MainActivity : AppCompatActivity() {
     // A dictionary to cache loaded vector tiled layers.
     private var vectorTiledLayersMap: MutableMap<String, ArcGISVectorTiledLayer> = mutableMapOf()
 
+    private val activityMainBinding by lazy {
+        ActivityMainBinding.inflate(layoutInflater)
+    }
+
+    private val spinner: Spinner by lazy {
+        activityMainBinding.spinner
+    }
+
+    private val mapView: MapView by lazy {
+        activityMainBinding.mapView
+    }
+
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContentView(activityMainBinding.root)
 
         // Set the map to be displayed in the layout's MapView
         mapView.map = ArcGISMap()
@@ -277,12 +289,13 @@ class MainActivity : AppCompatActivity() {
             context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
 
         override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
+            val spinnerItemBinding = SpinnerItemBinding.inflate(inflater)
             val view: View
             val itemHolder: ItemHolder
             if (convertView == null) {
-                view = inflater.inflate(R.layout.spinner_item, parent, false)
+                view = spinnerItemBinding.root
                 itemHolder = ItemHolder(view)
-                view?.tag = itemHolder
+                view.tag = itemHolder
             } else {
                 view = convertView
                 itemHolder = view.tag as ItemHolder

--- a/kotlin/browse-ogc-api-feature-service/build.gradle
+++ b/kotlin/browse-ogc-api-feature-service/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -21,6 +20,9 @@ android {
         }
     }
 
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {

--- a/kotlin/browse-ogc-api-feature-service/src/main/java/com/esri/arcgisruntime/sample/browseogcapifeatureservice/MainActivity.kt
+++ b/kotlin/browse-ogc-api-feature-service/src/main/java/com/esri/arcgisruntime/sample/browseogcapifeatureservice/MainActivity.kt
@@ -23,6 +23,8 @@ import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.widget.ArrayAdapter
+import android.widget.EditText
+import android.widget.ListView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -39,12 +41,14 @@ import com.esri.arcgisruntime.loadable.LoadStatus
 import com.esri.arcgisruntime.mapping.ArcGISMap
 import com.esri.arcgisruntime.mapping.BasemapStyle
 import com.esri.arcgisruntime.mapping.view.DefaultMapViewOnTouchListener
+import com.esri.arcgisruntime.mapping.view.MapView
+import com.esri.arcgisruntime.sample.browseogcapifeatureservice.databinding.ActivityMainBinding
 import com.esri.arcgisruntime.symbology.Renderer
 import com.esri.arcgisruntime.symbology.SimpleFillSymbol
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol
 import com.esri.arcgisruntime.symbology.SimpleMarkerSymbol
 import com.esri.arcgisruntime.symbology.SimpleRenderer
-import kotlinx.android.synthetic.main.activity_main.*
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 // URL to the OAFeat service
 private const val serviceUrl = "https://demo.ldproxy.net/daraa"
@@ -53,9 +57,29 @@ class MainActivity : AppCompatActivity() {
 
     private val TAG = this::class.java.simpleName
 
+    private val activityMainBinding by lazy {
+        ActivityMainBinding.inflate(layoutInflater)
+    }
+
+    private val mapView: MapView by lazy {
+        activityMainBinding.mapView
+    }
+
+    private val serviceEditText: EditText by lazy {
+        activityMainBinding.serviceEditText
+    }
+
+    private val featureCollectionTitleListView: ListView by lazy {
+        activityMainBinding.featureCollectionTitleListView
+    }
+
+    private val layerFAB: FloatingActionButton by lazy {
+        activityMainBinding.layerFAB
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContentView(activityMainBinding.root)
 
         // authentication with an API key or named user is required to access basemaps and other
         // location services

--- a/kotlin/create-symbol-styles-from-web-styles/build.gradle
+++ b/kotlin/create-symbol-styles-from-web-styles/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
-
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 

--- a/kotlin/create-symbol-styles-from-web-styles/build.gradle
+++ b/kotlin/create-symbol-styles-from-web-styles/build.gradle
@@ -20,6 +20,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {

--- a/kotlin/create-symbol-styles-from-web-styles/build.gradle
+++ b/kotlin/create-symbol-styles-from-web-styles/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/kotlin/create-symbol-styles-from-web-styles/src/main/java/com/esri/arcgisruntime/sample/createsymbolstylesfromwebstyles/MainActivity.kt
+++ b/kotlin/create-symbol-styles-from-web-styles/src/main/java/com/esri/arcgisruntime/sample/createsymbolstylesfromwebstyles/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.MotionEvent
 import android.view.View
+import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -15,18 +16,37 @@ import com.esri.arcgisruntime.mapping.ArcGISMap
 import com.esri.arcgisruntime.mapping.BasemapStyle
 import com.esri.arcgisruntime.mapping.Viewpoint
 import com.esri.arcgisruntime.mapping.view.DefaultMapViewOnTouchListener
+import com.esri.arcgisruntime.mapping.view.MapView
+import com.esri.arcgisruntime.sample.createsymbolstylesfromwebstyles.databinding.ActivityMainBinding
+import com.esri.arcgisruntime.sample.createsymbolstylesfromwebstyles.databinding.LegendRowBinding
 import com.esri.arcgisruntime.symbology.SymbolStyle
 import com.esri.arcgisruntime.symbology.UniqueValueRenderer
-import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.android.synthetic.main.legend_row.view.*
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import kotlinx.android.synthetic.main.legend_row.*
 
 class MainActivity : AppCompatActivity() {
 
     private val TAG = this::class.java.simpleName
 
+    private val activityMainBinding by lazy {
+        ActivityMainBinding.inflate(layoutInflater)
+    }
+
+    private val mapView: MapView by lazy {
+        activityMainBinding.mapView
+    }
+
+    private val legendFAB: FloatingActionButton by lazy {
+        activityMainBinding.legendFAB
+    }
+
+    private val scrollViewLayout: LinearLayout by lazy {
+        activityMainBinding.scrollViewLayout
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContentView(activityMainBinding.root)
 
         // authentication with an API key or named user is required to access basemaps and other
         // location services
@@ -89,11 +109,11 @@ class MainActivity : AppCompatActivity() {
         symbolNames.forEach { symbolName ->
 
             // create a placeholder legend row
-            val loadingLegendRow = layoutInflater.inflate(R.layout.legend_row, null).apply {
+            val loadingLegendRowBinding = LegendRowBinding.inflate(layoutInflater).apply {
                 symbolTextView.text = getString(R.string.loading)
             }
             // add the placeholder row to the scroll view
-            scrollViewLayout.addView(loadingLegendRow)
+            scrollViewLayout.addView(loadingLegendRowBinding.root)
 
             // search for each symbol in the symbol style
             val searchResult = symbolStyle.getSymbolAsync(listOf(symbolName))
@@ -118,7 +138,7 @@ class MainActivity : AppCompatActivity() {
                     val symbolBitmapFuture = symbol.createSwatchAsync(this, Color.WHITE)
                     symbolBitmapFuture.addDoneListener {
                         // create a legend row
-                        val legendRow = layoutInflater.inflate(R.layout.legend_row, null).apply {
+                        val legendRowBinding = LegendRowBinding.inflate(layoutInflater).apply {
                             // set the symbol to the row's image view
                             symbolImageView.setImageBitmap(symbolBitmapFuture.get())
                             // set the symbol name to the row's text view
@@ -127,7 +147,7 @@ class MainActivity : AppCompatActivity() {
                         // remove the loading row already at this index
                         scrollViewLayout.removeViewAt(symbolNames.indexOf(symbolName))
                         // add the legend row at the correct index
-                        scrollViewLayout.addView(legendRow, symbolNames.indexOf(symbolName))
+                        scrollViewLayout.addView(legendRowBinding.root, symbolNames.indexOf(symbolName))
                     }
                 } catch (e: Exception) {
                     val error = "Error getting symbol: " + e.message

--- a/kotlin/create-symbol-styles-from-web-styles/src/main/java/com/esri/arcgisruntime/sample/createsymbolstylesfromwebstyles/MainActivity.kt
+++ b/kotlin/create-symbol-styles-from-web-styles/src/main/java/com/esri/arcgisruntime/sample/createsymbolstylesfromwebstyles/MainActivity.kt
@@ -22,7 +22,6 @@ import com.esri.arcgisruntime.sample.createsymbolstylesfromwebstyles.databinding
 import com.esri.arcgisruntime.symbology.SymbolStyle
 import com.esri.arcgisruntime.symbology.UniqueValueRenderer
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import kotlinx.android.synthetic.main.legend_row.*
 
 class MainActivity : AppCompatActivity() {
 

--- a/kotlin/display-device-location-with-nmea-data-sources/build.gradle
+++ b/kotlin/display-device-location-with-nmea-data-sources/build.gradle
@@ -20,6 +20,10 @@ android {
         }
     }
 
+    buildFeatures {
+        viewBinding true
+    }
+
 }
 
 dependencies {

--- a/kotlin/display-device-location-with-nmea-data-sources/build.gradle
+++ b/kotlin/display-device-location-with-nmea-data-sources/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 

--- a/kotlin/display-device-location-with-nmea-data-sources/src/main/java/com/esri/arcgisruntime/sample/displaydevicelocationwithnmeadatasources/MainActivity.kt
+++ b/kotlin/display-device-location-with-nmea-data-sources/src/main/java/com/esri/arcgisruntime/sample/displaydevicelocationwithnmeadatasources/MainActivity.kt
@@ -18,6 +18,7 @@ package com.esri.arcgisruntime.sample.displaydevicelocationwithnmeadatasources
 
 import android.os.Bundle
 import android.util.Log
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
@@ -31,7 +32,9 @@ import com.esri.arcgisruntime.mapping.ArcGISMap
 import com.esri.arcgisruntime.mapping.BasemapStyle
 import com.esri.arcgisruntime.mapping.Viewpoint
 import com.esri.arcgisruntime.mapping.view.LocationDisplay
-import kotlinx.android.synthetic.main.activity_main.*
+import com.esri.arcgisruntime.mapping.view.MapView
+import com.esri.arcgisruntime.sample.displaydevicelocationwithnmeadatasources.databinding.ActivityMainBinding
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
@@ -57,9 +60,37 @@ class MainActivity : AppCompatActivity() {
     // Keeps track of the timer during play/pause
     private var count = 0
 
+    private val activityMainBinding by lazy {
+        ActivityMainBinding.inflate(layoutInflater)
+    }
+
+    private val mapView: MapView by lazy {
+        activityMainBinding.mapView
+    }
+
+    private val accuracyTV: TextView by lazy {
+        activityMainBinding.accuracyTV
+    }
+
+    private val satelliteCountTV: TextView by lazy {
+        activityMainBinding.satelliteCountTV
+    }
+
+    private val satelliteIDsTV: TextView by lazy {
+        activityMainBinding.satelliteIDsTV
+    }
+
+    private val systemTypeTV: TextView by lazy {
+        activityMainBinding.systemTypeTV
+    }
+
+    private val playPauseFAB: FloatingActionButton by lazy {
+        activityMainBinding.playPauseFAB
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContentView(activityMainBinding.root)
 
         // Authentication with an API key or named user is required
         // to access basemaps and other location services

--- a/kotlin/display-ogc-api-collection/build.gradle
+++ b/kotlin/display-ogc-api-collection/build.gradle
@@ -21,6 +21,10 @@ android {
         }
     }
 
+    buildFeatures {
+        viewBinding true
+    }
+
 }
 
 dependencies {

--- a/kotlin/display-ogc-api-collection/build.gradle
+++ b/kotlin/display-ogc-api-collection/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
-
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 

--- a/kotlin/display-ogc-api-collection/build.gradle
+++ b/kotlin/display-ogc-api-collection/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/kotlin/display-ogc-api-collection/src/main/java/com/esri/arcgisruntime/sample/displayogcapicollection/MainActivity.kt
+++ b/kotlin/display-ogc-api-collection/src/main/java/com/esri/arcgisruntime/sample/displayogcapicollection/MainActivity.kt
@@ -30,9 +30,10 @@ import com.esri.arcgisruntime.layers.FeatureLayer
 import com.esri.arcgisruntime.loadable.LoadStatus
 import com.esri.arcgisruntime.mapping.ArcGISMap
 import com.esri.arcgisruntime.mapping.BasemapStyle
+import com.esri.arcgisruntime.mapping.view.MapView
+import com.esri.arcgisruntime.sample.displayogcapicollection.databinding.ActivityMainBinding
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol
 import com.esri.arcgisruntime.symbology.SimpleRenderer
-import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity() {
 
@@ -47,9 +48,17 @@ class MainActivity : AppCompatActivity() {
     private var ogcFeatureCollectionTable: OgcFeatureCollectionTable =
         OgcFeatureCollectionTable(serviceUrl, collectionId)
 
+    private val activityMainBinding by lazy {
+        ActivityMainBinding.inflate(layoutInflater)
+    }
+
+    private val mapView: MapView by lazy {
+        activityMainBinding.mapView
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContentView(activityMainBinding.root)
 
         // authentication with an API key or named user is required to access basemaps and other
         // location services

--- a/kotlin/query-with-cql-filters/build.gradle
+++ b/kotlin/query-with-cql-filters/build.gradle
@@ -20,6 +20,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    buildFeatures {
+        viewBinding true
+    }
+
 }
 
 dependencies {

--- a/kotlin/query-with-cql-filters/build.gradle
+++ b/kotlin/query-with-cql-filters/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
-
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 

--- a/kotlin/query-with-cql-filters/build.gradle
+++ b/kotlin/query-with-cql-filters/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/kotlin/query-with-cql-filters/src/main/AndroidManifest.xml
+++ b/kotlin/query-with-cql-filters/src/main/AndroidManifest.xml
@@ -4,13 +4,15 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Kotlin">
+        android:theme="@style/AppTheme">
         <activity
             android:exported="true" 
             android:name=".MainActivity"

--- a/kotlin/query-with-cql-filters/src/main/java/com/esri/arcgisruntime/sample/querywithcqlfilters/MainActivity.kt
+++ b/kotlin/query-with-cql-filters/src/main/java/com/esri/arcgisruntime/sample/querywithcqlfilters/MainActivity.kt
@@ -36,12 +36,13 @@ import com.esri.arcgisruntime.mapping.ArcGISMap
 import com.esri.arcgisruntime.mapping.BasemapStyle
 import com.esri.arcgisruntime.mapping.TimeExtent
 import com.esri.arcgisruntime.mapping.view.MapView
+import com.esri.arcgisruntime.sample.querywithcqlfilters.databinding.ActivityMainBinding
+import com.esri.arcgisruntime.sample.querywithcqlfilters.databinding.CqlFiltersLayoutBinding
 import kotlinx.android.synthetic.main.activity_main.*
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol
 import com.esri.arcgisruntime.symbology.SimpleRenderer
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import kotlinx.android.synthetic.main.cql_filters_layout.view.*
 import java.util.*
 
 
@@ -71,9 +72,21 @@ class MainActivity : AppCompatActivity() {
     private var fromDate = Calendar.getInstance()
     private var toDate = Calendar.getInstance()
 
+    private val activityMainBinding by lazy {
+        ActivityMainBinding.inflate(layoutInflater)
+    }
+
+    private val mapView: MapView by lazy {
+        activityMainBinding.mapView
+    }
+
+    private val fab: FloatingActionButton by lazy {
+        activityMainBinding.fab
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContentView(activityMainBinding.root)
 
         // Authentication with an API key or named user is required to
         // access basemaps and other location services
@@ -189,9 +202,9 @@ class MainActivity : AppCompatActivity() {
         val dialog = BottomSheetDialog(this)
 
         // Inflates layout file
-        val bottomSheetView = LayoutInflater.from(this).inflate(R.layout.cql_filters_layout,null)
+        val bottomSheetBinding = CqlFiltersLayoutBinding.inflate(layoutInflater)
 
-        bottomSheetView.apply {
+        bottomSheetBinding.apply {
             // Set the current selection of CQL query
             cqlQueryTextView.text = cqlQueryList[cqlQueryListPosition]
 
@@ -263,7 +276,7 @@ class MainActivity : AppCompatActivity() {
         dialog.setCancelable(false)
 
         // Sets bottom sheet content view to layout
-        dialog.setContentView(bottomSheetView)
+        dialog.setContentView(bottomSheetBinding.root)
 
         // Displays bottom sheet view
         dialog.show()

--- a/kotlin/query-with-cql-filters/src/main/java/com/esri/arcgisruntime/sample/querywithcqlfilters/MainActivity.kt
+++ b/kotlin/query-with-cql-filters/src/main/java/com/esri/arcgisruntime/sample/querywithcqlfilters/MainActivity.kt
@@ -19,8 +19,6 @@ package com.esri.arcgisruntime.sample.querywithcqlfilters
 import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
-import android.view.LayoutInflater
-import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -38,7 +36,6 @@ import com.esri.arcgisruntime.mapping.TimeExtent
 import com.esri.arcgisruntime.mapping.view.MapView
 import com.esri.arcgisruntime.sample.querywithcqlfilters.databinding.ActivityMainBinding
 import com.esri.arcgisruntime.sample.querywithcqlfilters.databinding.CqlFiltersLayoutBinding
-import kotlinx.android.synthetic.main.activity_main.*
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol
 import com.esri.arcgisruntime.symbology.SimpleRenderer
 import com.google.android.material.bottomsheet.BottomSheetDialog

--- a/kotlin/query-with-cql-filters/src/main/res/values/colors.xml
+++ b/kotlin/query-with-cql-filters/src/main/res/values/colors.xml
@@ -10,4 +10,7 @@
     <color name="grey">#808080</color>
     <color name="light_grey">#EFEFEF</color>
     <color name="divider">#C5C5C5</color>
+    <color name="colorPrimary">#2196F3</color>
+    <color name="colorPrimaryDark">#1976D2</color>
+    <color name="colorAccent">#4CAF50</color>
 </resources>

--- a/kotlin/query-with-cql-filters/src/main/res/values/themes.xml
+++ b/kotlin/query-with-cql-filters/src/main/res/values/themes.xml
@@ -1,16 +1,9 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Kotlin" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
     </style>
 </resources>

--- a/kotlin/set-up-location-driven-geotriggers/build.gradle
+++ b/kotlin/set-up-location-driven-geotriggers/build.gradle
@@ -20,6 +20,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    buildFeatures {
+        viewBinding true
+    }
+
 }
 
 dependencies {

--- a/kotlin/set-up-location-driven-geotriggers/build.gradle
+++ b/kotlin/set-up-location-driven-geotriggers/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
-
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 

--- a/kotlin/set-up-location-driven-geotriggers/build.gradle
+++ b/kotlin/set-up-location-driven-geotriggers/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/kotlin/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgisruntime/sample/setuplocationdrivengeotriggers/GardenDescriptionFragment.kt
+++ b/kotlin/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgisruntime/sample/setuplocationdrivengeotriggers/GardenDescriptionFragment.kt
@@ -7,7 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.DialogFragment
-import kotlinx.android.synthetic.main.dialog_fragment.*
+import com.esri.arcgisruntime.sample.setuplocationdrivengeotriggers.databinding.DialogFragmentBinding
 
 /**
  * Class to display a dialog with the title, image and description of the [GardenSection]
@@ -18,19 +18,23 @@ class GardenDescriptionFragment(
     private val mainActivity: MainActivity
 ) : DialogFragment() {
 
+    private val dialogBinding by lazy {
+        DialogFragmentBinding.inflate(layoutInflater)
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         // Bind inflater to the layout view.
-        return inflater.inflate(R.layout.dialog_fragment, container, false)
+        return dialogBinding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         // Set title, description and image view of the mGardenSection
-        view.apply {
+        dialogBinding.apply {
             gardenContentTitle.text = gardenSection.title
             gardenContentTextView.text =
                 HtmlCompat.fromHtml(gardenSection.description, HtmlCompat.FROM_HTML_MODE_LEGACY)

--- a/kotlin/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgisruntime/sample/setuplocationdrivengeotriggers/ListAdapter.kt
+++ b/kotlin/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgisruntime/sample/setuplocationdrivengeotriggers/ListAdapter.kt
@@ -20,10 +20,6 @@ internal class ListAdapter(
 ) :
     BaseAdapter() {
 
-    /*private val listItemBinding by lazy {
-        ListItemBinding.inflate(LayoutInflater.from(context))
-    }*/
-
     private val mLayoutInflater: LayoutInflater =
         context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
 

--- a/kotlin/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgisruntime/sample/setuplocationdrivengeotriggers/ListAdapter.kt
+++ b/kotlin/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgisruntime/sample/setuplocationdrivengeotriggers/ListAdapter.kt
@@ -6,19 +6,23 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.BaseAdapter
 import androidx.fragment.app.FragmentManager
-import kotlinx.android.synthetic.main.list_item.view.*
+import com.esri.arcgisruntime.sample.setuplocationdrivengeotriggers.databinding.ListItemBinding
 
 /**
  * Adapter to display the list of point of interests
  */
 internal class ListAdapter(
-    context: MainActivity,
+    private val context: MainActivity,
     //List of garden sections as POIs
     private val gardenSections: MutableList<GardenSection>,
     // Fragment manager to display description dialog on click.
     private val supportFragmentManager: FragmentManager
 ) :
     BaseAdapter() {
+
+    /*private val listItemBinding by lazy {
+        ListItemBinding.inflate(LayoutInflater.from(context))
+    }*/
 
     private val mLayoutInflater: LayoutInflater =
         context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
@@ -37,9 +41,9 @@ internal class ListAdapter(
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
         // Bind the view to the layout inflater
-        val itemView = mLayoutInflater.inflate(R.layout.list_item,null,true)
+        val listItemBinding = ListItemBinding.inflate(this.mLayoutInflater)
 
-        itemView.apply {
+        listItemBinding.apply {
             itemButton.text = gardenSections[position].title
             //Display description dialog on button click
             itemButton.setOnClickListener {
@@ -49,8 +53,6 @@ internal class ListAdapter(
                 )
             }
         }
-
-        return itemView
+        return listItemBinding.root
     }
-
 }

--- a/kotlin/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgisruntime/sample/setuplocationdrivengeotriggers/MainActivity.kt
+++ b/kotlin/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgisruntime/sample/setuplocationdrivengeotriggers/MainActivity.kt
@@ -21,6 +21,9 @@ import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import android.widget.Button
+import android.widget.ListView
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.esri.arcgisruntime.ArcGISRuntimeEnvironment
@@ -35,9 +38,11 @@ import com.esri.arcgisruntime.location.SimulatedLocationDataSource
 import com.esri.arcgisruntime.location.SimulationParameters
 import com.esri.arcgisruntime.mapping.ArcGISMap
 import com.esri.arcgisruntime.mapping.view.LocationDisplay
+import com.esri.arcgisruntime.mapping.view.MapView
 import com.esri.arcgisruntime.portal.Portal
 import com.esri.arcgisruntime.portal.PortalItem
-import kotlinx.android.synthetic.main.activity_main.*
+import com.esri.arcgisruntime.sample.setuplocationdrivengeotriggers.databinding.ActivityMainBinding
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -70,9 +75,33 @@ class MainActivity : AppCompatActivity() {
 
     private val TAG: String = MainActivity::class.java.simpleName
 
+    private val activityMainBinding by lazy {
+        ActivityMainBinding.inflate(layoutInflater)
+    }
+
+    private val mapView: MapView by lazy {
+        activityMainBinding.mapView
+    }
+
+    private val playPauseFAB: FloatingActionButton by lazy {
+        activityMainBinding.playPauseFAB
+    }
+
+    private val sectionButton: Button by lazy {
+        activityMainBinding.sectionButton
+    }
+
+    private val listAvailable: TextView by lazy {
+        activityMainBinding.listAvailable
+    }
+
+    private val poiListView: ListView by lazy {
+        activityMainBinding.poiListView
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContentView(activityMainBinding.root)
 
         // Authentication with an API key or named user is required to access basemaps and other
         // location services

--- a/kotlin/show-labels-on-layer-in-3d/build.gradle
+++ b/kotlin/show-labels-on-layer-in-3d/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -19,6 +18,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    buildFeatures {
+        viewBinding true
     }
 }
 

--- a/kotlin/show-labels-on-layer-in-3d/src/main/java/com/esri/arcgisruntime/showlabelsonlayerin3d/MainActivity.kt
+++ b/kotlin/show-labels-on-layer-in-3d/src/main/java/com/esri/arcgisruntime/showlabelsonlayerin3d/MainActivity.kt
@@ -26,16 +26,25 @@ import com.esri.arcgisruntime.arcgisservices.LabelingPlacement
 import com.esri.arcgisruntime.layers.FeatureLayer
 import com.esri.arcgisruntime.mapping.ArcGISScene
 import com.esri.arcgisruntime.mapping.labeling.ArcadeLabelExpression
+import com.esri.arcgisruntime.mapping.view.SceneView
 import com.esri.arcgisruntime.portal.Portal
 import com.esri.arcgisruntime.portal.PortalItem
+import com.esri.arcgisruntime.showlabelsonlayerin3d.databinding.ActivityMainBinding
 import com.esri.arcgisruntime.symbology.TextSymbol
-import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity() {
 
+    private val activityMainBinding by lazy {
+        ActivityMainBinding.inflate(layoutInflater)
+    }
+
+    private val sceneView: SceneView by lazy {
+        activityMainBinding.sceneView
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContentView(activityMainBinding.root)
 
         ArcGISRuntimeEnvironment.setApiKey(BuildConfig.API_KEY)
 

--- a/kotlin/show-location-history/build.gradle
+++ b/kotlin/show-location-history/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+
 
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion

--- a/kotlin/show-location-history/build.gradle
+++ b/kotlin/show-location-history/build.gradle
@@ -19,6 +19,10 @@ android {
           proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
       }
   }
+
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {

--- a/kotlin/show-location-history/build.gradle
+++ b/kotlin/show-location-history/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
-
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion
 

--- a/kotlin/show-location-history/src/main/java/com/esri/arcgisruntime/sample/showlocationhistory/MainActivity.kt
+++ b/kotlin/show-location-history/src/main/java/com/esri/arcgisruntime/sample/showlocationhistory/MainActivity.kt
@@ -33,19 +33,34 @@ import com.esri.arcgisruntime.mapping.Viewpoint
 import com.esri.arcgisruntime.mapping.view.Graphic
 import com.esri.arcgisruntime.mapping.view.GraphicsOverlay
 import com.esri.arcgisruntime.mapping.view.LocationDisplay
+import com.esri.arcgisruntime.mapping.view.MapView
+import com.esri.arcgisruntime.sample.showlocationhistory.databinding.ActivityMainBinding
 import com.esri.arcgisruntime.symbology.SimpleLineSymbol
 import com.esri.arcgisruntime.symbology.SimpleMarkerSymbol
 import com.esri.arcgisruntime.symbology.SimpleRenderer
-import kotlinx.android.synthetic.main.activity_main.*
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 import java.util.Calendar
 
 class MainActivity : AppCompatActivity() {
 
   var isTrackLocation: Boolean = false
 
+  private val activityMainBinding by lazy {
+    ActivityMainBinding.inflate(layoutInflater)
+  }
+
+  private val mapView: MapView by lazy {
+    activityMainBinding.mapView
+  }
+
+  private val button: FloatingActionButton by lazy {
+    activityMainBinding.button
+  }
+
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentView(R.layout.activity_main)
+    setContentView(activityMainBinding.root)
 
     // create a center point for the data in Redlands, California
     val center = Point(-13185535.98, 4037766.28, SpatialReference.create(102100))

--- a/kotlin/show-popup/build.gradle
+++ b/kotlin/show-popup/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
-
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 

--- a/kotlin/show-popup/build.gradle
+++ b/kotlin/show-popup/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion


### PR DESCRIPTION
PR to update the following samples to use Android Viewbinding:

- [x] Browse OGC API feature service
- [x] Display OGC API Collection
- [x] Display device location with nmea data sources
- [x] Setup location driven geotriggers
- [x] Show location history
- [x] Query with CQL filter
- [x] ArcGIS vector tiled layer (custom style)
- [x] Create symbol styles from web styles
- [x] Show labels on layer in 3D
- [x] animate-images-with-image-overlay
- [x] configure-subnetwork-trace
- [x] display-utility-associations
- [x] edit-with-branch-versioning
- [x] offline-geocode
- [x] perform-valve-isolation-trace
- [x] trace-utility-network
- [x] viewshed-geoprocessing



