### PR TITLE
Update minSdkVersion to 24

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -1,7 +1,7 @@
 ext {
     // sdk versions
     compileSdkVersion = 31
-    minSdkVersion = 23
+    minSdkVersion = 24
     targetSdkVersion = 31
     versionCode = 100130
     versionName = '100.13.0'


### PR DESCRIPTION
PR to upgrade Android runtime samples min SDK to version from 23 to 24. This will allow us to use `List.stream()` for samples! 

Tested by running couple sample on sample viewer with the change and everything seems to be working fine! 

Issue explained here: https://devtopia.esri.com/runtime/common-samples/issues/3310