### PR TITLE
Create and Save KML point symbols patch

### DIFF
--- a/kotlin/create-and-save-kml-file/src/main/java/com/esri/arcgisruntime/sample/createandsavekmlfile/MainActivity.kt
+++ b/kotlin/create-and-save-kml-file/src/main/java/com/esri/arcgisruntime/sample/createandsavekmlfile/MainActivity.kt
@@ -267,14 +267,14 @@ class MainActivity : AppCompatActivity() {
                             this -> {
                                 pointSymbolSpinner.visibility = View.VISIBLE
                                 pointSymbolTextView.visibility = View.VISIBLE
-                                colorSpinner.visibility = View.INVISIBLE
-                                colorTextView.visibility = View.INVISIBLE
+                                colorSpinner.visibility = View.GONE
+                                colorTextView.visibility = View.GONE
                             }
                             else -> {
                                 colorSpinner.visibility = View.VISIBLE
                                 colorTextView.visibility = View.VISIBLE
-                                pointSymbolSpinner.visibility = View.INVISIBLE
-                                pointSymbolTextView.visibility = View.INVISIBLE
+                                pointSymbolSpinner.visibility = View.GONE
+                                pointSymbolTextView.visibility = View.GONE
                             }
                         }
                     }

--- a/kotlin/create-and-save-kml-file/src/main/java/com/esri/arcgisruntime/sample/createandsavekmlfile/PointSymbolAdapter.kt
+++ b/kotlin/create-and-save-kml-file/src/main/java/com/esri/arcgisruntime/sample/createandsavekmlfile/PointSymbolAdapter.kt
@@ -11,22 +11,20 @@ import com.esri.arcgisruntime.sample.createandsavekmlfile.databinding.PointSymbo
 class PointSymbolAdapter(context: Context, pointSymbolUrls: List<Int>) :
     ArrayAdapter<Int>(context, R.layout.point_symbol, pointSymbolUrls) {
 
-    private val pointSymbolBinding by lazy {
-        PointSymbolBinding.inflate(LayoutInflater.from(context))
-    }
-
     override fun getView(position: Int, recycledView: View?, parent: ViewGroup): View {
-        return this.createView(position, recycledView, parent)
+        val binding = PointSymbolBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        getItem(position)?.let { binding.pointSymbol.setImageResource(it) }
+        return binding.root
     }
 
-    override fun getDropDownView(position: Int, recycledView: View?, parent: ViewGroup): View {
-        return this.createView(position, recycledView, parent)
-    }
+    override fun getDropDownView(
+        position: Int,
+        convertView: View?,
+        parent: ViewGroup
+    ): View = getView(position, convertView, parent)
 
-    private fun createView(position: Int, recycledView: View?, parent: ViewGroup): View {
-        val pointDrawable = getItem(position)!!
-        val view = recycledView ?: pointSymbolBinding.root
-        pointSymbolBinding.pointSymbol.setImageResource(pointDrawable)
-        return view
-    }
 }

--- a/kotlin/create-and-save-kml-file/src/main/res/layout/activity_main.xml
+++ b/kotlin/create-and-save-kml-file/src/main/res/layout/activity_main.xml
@@ -17,7 +17,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
+        android:layout_marginBottom="32dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/kotlin/create-and-save-kml-file/src/main/res/layout/activity_main.xml
+++ b/kotlin/create-and-save-kml-file/src/main/res/layout/activity_main.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -15,8 +16,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/kotlin/create-and-save-kml-file/src/main/res/layout/kml_geometry_controls_layout.xml
+++ b/kotlin/create-and-save-kml-file/src/main/res/layout/kml_geometry_controls_layout.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/linearLayout"
     android:layout_width="wrap_content"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="12dp"
     android:background="@android:color/background_light">
 
     <Spinner

--- a/kotlin/create-and-save-kml-file/src/main/res/layout/point_symbol.xml
+++ b/kotlin/create-and-save-kml-file/src/main/res/layout/point_symbol.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/pointSymbol"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_gravity="center"
     android:contentDescription="@string/content_description_point_symbols" />
 

--- a/kotlin/perform-valve-isolation-trace/src/main/java/com/esri/arcgisruntime/sample/performvalveisolationtrace/MainActivity.kt
+++ b/kotlin/perform-valve-isolation-trace/src/main/java/com/esri/arcgisruntime/sample/performvalveisolationtrace/MainActivity.kt
@@ -581,7 +581,6 @@ class MainActivity : AppCompatActivity() {
                         false
                     )
 
-                    //val spinnerItem = LayoutInflater.from(this@MainActivity).inflate(R.layout.spinner_text_item, parent, false)
                     binding.textView.text = (getItem(position) as UtilityCategory).name
                     return binding.root
                 }


### PR DESCRIPTION
## Description
`Create and Save KML` sample has an issue with the "Point Symbol" images not loading using a spinner adapter. Fixed by using Viewbinding on `getView()` instead of `createView()` 

## Links and Data
Sample Epic: `runtime/common-samples/issues/3452`

