### PR TITLE
Update OGC service URL

### DIFF
--- a/kotlin/browse-ogc-api-feature-service/README.md
+++ b/kotlin/browse-ogc-api-feature-service/README.md
@@ -31,7 +31,7 @@ Select a layer to display from the list of layers shown in an OGC API service.
 
 ## About the data
 
-The [Daraa, Syria test data](https://demo.ldproxy.net/daraa) is OpenStreetMap data converted to the Topographic Data Store schema of NGA.
+The [Daraa, Syria test data](https://services.interactive-instruments.de/t15/daraa) is OpenStreetMap data converted to the Topographic Data Store schema of NGA.
 
 ## Additional information
 

--- a/kotlin/browse-ogc-api-feature-service/src/main/java/com/esri/arcgisruntime/sample/browseogcapifeatureservice/MainActivity.kt
+++ b/kotlin/browse-ogc-api-feature-service/src/main/java/com/esri/arcgisruntime/sample/browseogcapifeatureservice/MainActivity.kt
@@ -51,7 +51,7 @@ import com.esri.arcgisruntime.symbology.SimpleRenderer
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 // URL to the OAFeat service
-private const val serviceUrl = "https://demo.ldproxy.net/daraa"
+private const val serviceUrl = "https://services.interactive-instruments.de/t15/daraa"
 
 class MainActivity : AppCompatActivity() {
 

--- a/kotlin/browse-ogc-api-feature-service/src/main/res/values/strings.xml
+++ b/kotlin/browse-ogc-api-feature-service/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Browse OGC API feature service</string>
     <string name="load_service">Load service</string>
-    <string name="daraa_url">https://demo.ldproxy.net/daraa</string>
+    <string name="daraa_url">https://services.interactive-instruments.de/t15/daraa</string>
     <string name="instructions_text">Load the service, then select a layer for display.</string>
     <string name="layers_floating_action_button">layers floating action button</string>
     <string name="url_hint">Enter a URL</string>

--- a/kotlin/display-ogc-api-collection/README.md
+++ b/kotlin/display-ogc-api-collection/README.md
@@ -32,7 +32,7 @@ Pan the map and observe how new features are loaded from the OGC API feature ser
 
 ## About the data
 
-The [Daraa, Syria test data](https://demo.ldproxy.net/daraa) is OpenStreetMap data converted to the Topographic Data Store schema of NGA.
+The [Daraa, Syria test data](https://services.interactive-instruments.de/t15/daraa) is OpenStreetMap data converted to the Topographic Data Store schema of NGA.
 
 ## Additional information
 

--- a/kotlin/display-ogc-api-collection/src/main/java/com/esri/arcgisruntime/sample/displayogcapicollection/MainActivity.kt
+++ b/kotlin/display-ogc-api-collection/src/main/java/com/esri/arcgisruntime/sample/displayogcapicollection/MainActivity.kt
@@ -40,7 +40,7 @@ class MainActivity : AppCompatActivity() {
     // define strings for the service URL and collection id
     // note that the service defines the collection id which can be accessed
     // via OgcFeatureCollectionInfo.getCollectionId()
-    private val serviceUrl = "https://demo.ldproxy.net/daraa"
+    private val serviceUrl = "https://services.interactive-instruments.de/t15/daraa"
     private val collectionId = "TransportationGroundCrv"
 
     // create an OGC feature collection table from the service url and collection id

--- a/kotlin/query-with-cql-filters/README.md
+++ b/kotlin/query-with-cql-filters/README.md
@@ -29,7 +29,7 @@ The sample loads displaying all features within the OGC API feature service. Sel
 
 ## About the data
 
-The [Daraa, Syria test data](https://demo.ldproxy.net/daraa) is OpenStreetMap data converted to the Topographic Data Store schema of NGA.
+The [Daraa, Syria test data](https://services.interactive-instruments.de/t15/daraa) is OpenStreetMap data converted to the Topographic Data Store schema of NGA.
 
 ## Additional information
 

--- a/kotlin/query-with-cql-filters/src/main/AndroidManifest.xml
+++ b/kotlin/query-with-cql-filters/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Kotlin">
+        android:theme="@style/AppTheme">
         <activity
             android:exported="true" 
             android:name=".MainActivity"

--- a/kotlin/query-with-cql-filters/src/main/java/com/esri/arcgisruntime/sample/querywithcqlfilters/MainActivity.kt
+++ b/kotlin/query-with-cql-filters/src/main/java/com/esri/arcgisruntime/sample/querywithcqlfilters/MainActivity.kt
@@ -98,7 +98,7 @@ class MainActivity : AppCompatActivity() {
         // Define strings for the service URL and collection id
         // Note that the service defines the collection id which can be
         // accessed via OgcFeatureCollectionInfo.getCollectionId()
-        val serviceUrl = "https://demo.ldproxy.net/daraa"
+        val serviceUrl = "https://services.interactive-instruments.de/t15/daraa"
         val collectionId = "TransportationGroundCrv"
 
         // Create an OGC feature collection table from the service url and collection ID


### PR DESCRIPTION
## Description
PR to update the service URL used in OGC samples. We use a test URL that has changed causing issues with the CQL filters sample (#3461). Instead we should use the official demo service URL provided by the [official OGC tutorial module](http://opengeospatial.github.io/e-learning/ogcapi-features/text/operations.html).

Affected samples: 
- Query with CQL filters
- Display OGC API collection
- Browse OGC API feature service

## Links and Data

- Old service URL: "https://demo.ldproxy.net/daraa"
- New service URL: "https://services.interactive-instruments.de/t15/daraa"
- Original issue: `runtime/common-samples/issues/3461`

## How to Test

- CQL query of `F_CODE = 'AP010'` should return 75 features with the new service URL.
- Other OGC samples run as expected