### PR TITLE
Viewshed geoprocessing load failure fix

### DIFF
--- a/java/viewshed-geoprocessing/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoprocessing/MainActivity.java
+++ b/java/viewshed-geoprocessing/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoprocessing/MainActivity.java
@@ -163,7 +163,6 @@ public class MainActivity extends AppCompatActivity {
     mFeatureCollectionTable.addDoneLoadingListener(() -> {
       if (mFeatureCollectionTable.getLoadStatus() == LoadStatus.LOADED) {
         performGeoprocessing(mFeatureCollectionTable);
-        mLoadingView.setVisibility(View.GONE);
       }
     });
 
@@ -195,6 +194,7 @@ public class MainActivity extends AppCompatActivity {
         // listen for job success
         mGeoprocessingJob.addJobDoneListener(new Runnable() {
           @Override public void run() {
+            mLoadingView.setVisibility(View.GONE);
             if (mGeoprocessingJob.getStatus() == Job.Status.SUCCEEDED) {
               GeoprocessingResult geoprocessingResult = mGeoprocessingJob.getResult();
               // get the viewshed from geoprocessingResult

--- a/java/viewshed-geoprocessing/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoprocessing/MainActivity.java
+++ b/java/viewshed-geoprocessing/src/main/java/com/esri/arcgisruntime/sample/viewshedgeoprocessing/MainActivity.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutionException;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.view.MotionEvent;
+import android.view.View;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -63,6 +64,7 @@ public class MainActivity extends AppCompatActivity {
   private GraphicsOverlay mResultGraphicsOverlay;
   // objects that implement Loadable must be class fields to prevent being garbage collected before loading
   private FeatureCollectionTable mFeatureCollectionTable;
+  private View mLoadingView;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -73,6 +75,7 @@ public class MainActivity extends AppCompatActivity {
     // location services
     ArcGISRuntimeEnvironment.setApiKey(BuildConfig.API_KEY);
 
+    mLoadingView = findViewById(R.id.loadingView);
     mInputGraphicsOverlay = new GraphicsOverlay();
     mResultGraphicsOverlay = new GraphicsOverlay();
 
@@ -132,6 +135,8 @@ public class MainActivity extends AppCompatActivity {
    * @param point in MapView coordinates.
    */
   private void calculateViewshedAt(Point point) {
+    mLoadingView.setVisibility(View.VISIBLE);
+
     // remove previous graphics
     mResultGraphicsOverlay.getGraphics().clear();
 
@@ -158,6 +163,7 @@ public class MainActivity extends AppCompatActivity {
     mFeatureCollectionTable.addDoneLoadingListener(() -> {
       if (mFeatureCollectionTable.getLoadStatus() == LoadStatus.LOADED) {
         performGeoprocessing(mFeatureCollectionTable);
+        mLoadingView.setVisibility(View.GONE);
       }
     });
 

--- a/java/viewshed-geoprocessing/src/main/res/layout/activity_main.xml
+++ b/java/viewshed-geoprocessing/src/main/res/layout/activity_main.xml
@@ -1,4 +1,4 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
     android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
@@ -12,4 +12,31 @@
         android:layout_height="match_parent">
     </com.esri.arcgisruntime.mapping.view.MapView>
 
-</RelativeLayout>
+    <RelativeLayout
+        android:id="@+id/loadingView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/loading_view_bg"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="gone">
+
+        <ProgressBar
+            android:id="@+id/loadingSpinner"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/loadingSpinner"
+            android:gravity="center"
+            android:text="@string/loading_text"
+            android:textColor="@android:color/white"
+            android:textSize="@dimen/loading_text_size"
+            android:textStyle="bold" />
+
+    </RelativeLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/java/viewshed-geoprocessing/src/main/res/layout/activity_main.xml
+++ b/java/viewshed-geoprocessing/src/main/res/layout/activity_main.xml
@@ -36,7 +36,6 @@
             android:textColor="@android:color/white"
             android:textSize="@dimen/loading_text_size"
             android:textStyle="bold" />
-
     </RelativeLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/java/viewshed-geoprocessing/src/main/res/values/colors.xml
+++ b/java/viewshed-geoprocessing/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#2196F3</color>
     <color name="colorPrimaryDark">#1976D2</color>
     <color name="colorAccent">#4CAF50</color>
+    <color name="loading_view_bg">#40000000</color>
 </resources>

--- a/java/viewshed-geoprocessing/src/main/res/values/dimens.xml
+++ b/java/viewshed-geoprocessing/src/main/res/values/dimens.xml
@@ -2,4 +2,5 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+    <dimen name="loading_text_size">14sp</dimen>
 </resources>

--- a/java/viewshed-geoprocessing/src/main/res/values/strings.xml
+++ b/java/viewshed-geoprocessing/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="viewshed_service">
         https://sampleserver6.arcgisonline.com/arcgis/rest/services/Elevation/ESRI_Elevation_World/GPServer/Viewshed
     </string>
+    <string name="loading_text">Calculating Viewshed...</string>
 </resources>


### PR DESCRIPTION
PR to add a progress bar to Viewshed geoprocessing sample to disable map interaction when the `GeoprocessingJob` is loading. 

Previously, an error is thrown when the map is tapped while the job is loading. The progress bar is similar to the one used in the [Browse WFS layers](https://github.com/Esri/arcgis-runtime-samples-android/blob/main/java/browse-wfs-layers/src/main/res/layout/activity_main.xml) sample. 