### PR TITLE
Add status check to GeotriggerMonitor

### DIFF
--- a/kotlin/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgisruntime/sample/setuplocationdrivengeotriggers/MainActivity.kt
+++ b/kotlin/set-up-location-driven-geotriggers/src/main/java/com/esri/arcgisruntime/sample/setuplocationdrivengeotriggers/MainActivity.kt
@@ -214,12 +214,11 @@ class MainActivity : AppCompatActivity() {
         // check to see if the GeotriggerMonitor failed to start
         future.addDoneListener {
             if (geotriggerMonitor.status == GeotriggerMonitorStatus.FAILED_TO_START) {
-                Log.e(
-                    TAG,
-                    "GeotriggerMonitor failed to load: " +
-                        geotriggerMonitor.warning.message +
-                        geotriggerMonitor.warning.additionalMessage
-                )
+                val message = "GeotriggerMonitor failed to load: " +
+                    geotriggerMonitor.warning.message +
+                    geotriggerMonitor.warning.additionalMessage
+                Log.e(TAG, message)
+                Toast.makeText(this@MainActivity, message, Toast.LENGTH_SHORT).show()
             }
         }
 


### PR DESCRIPTION
## Description
PR to update the sample "Set up location driven Geotriggers" to check the status of the `GeotriggerMonitor` to see if it has started successfully or not using `GeotriggerMonitorStatus.FAILED_TO_START`

## Links and Data
Change made due to the question submitted on [Runtime SDK for Android Questions](https://community.esri.com/t5/arcgis-runtime-sdk-for-android-questions/how-do-i-create-geotriggers-using-polygon-tables/m-p/1187725#M5792)
