### PR TITLE
DependencyResolutionManagement and gradle upgrades

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -12,17 +12,6 @@ buildscript {
     }
 }
 
-allprojects {
-
-    final def var = repositories {
-        google()
-        mavenCentral()
-        maven { url 'https://esri.jfrog.io/artifactory/arcgis' }
-        maven { url 'https://olympus.esri.com/artifactory/arcgisruntime-repo/' }
-    }
-    var
-}
-
 subprojects {
     afterEvaluate { project ->
         if (project.hasProperty("dependencies")) {

--- a/java/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -1,3 +1,19 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url 'https://esri.jfrog.io/artifactory/arcgis' }
+        maven { url 'https://olympus.esri.com/artifactory/arcgisruntime-repo/' }
+    }
+}
 include ':add-enc-exchange-set',
         ':add-features-feature-service',
         ':add-graphics-renderer',

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -12,16 +12,6 @@ buildscript {
     }
 }
 
-allprojects {
-    final def var = repositories {
-        google()
-        mavenCentral()
-        maven { url 'https://esri.jfrog.io/artifactory/arcgis' }
-        maven { url 'https://olympus.esri.com/artifactory/arcgisruntime-repo/' }
-    }
-    var
-}
-
 subprojects {
     afterEvaluate { project ->
         if (project.hasProperty("dependencies")) {

--- a/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Dec 13 20:00:18 PST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/kotlin/settings.gradle
+++ b/kotlin/settings.gradle
@@ -1,3 +1,19 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url 'https://esri.jfrog.io/artifactory/arcgis' }
+        maven { url 'https://olympus.esri.com/artifactory/arcgisruntime-repo/' }
+    }
+}
 include ':add-features-feature-service',
         ':add-features-with-contingent-values',
         ':add-graphics-renderer',

--- a/version.gradle
+++ b/version.gradle
@@ -16,7 +16,7 @@ ext {
     materialVersion = '1.5.0'
     recyclerViewVersion = '1.1.0'
     // plugin versions
-    gradleVersion = '7.0.2'
+    gradleVersion = '7.2.1'
     // java version
     javaVersion = 1.11
 }


### PR DESCRIPTION
## Description
PR to support `dependencyResolutionManagement` for Kotlin and Java samples. 
- Updated Gradle version to v7.4.2
- Updated Gradle plugin version to v7.2.1
- The Gradle changes will now be supported in the latest version of Android Studio. 

## Links and Data
Sample Epic: `runtime/common-samples/issues/3509`

## How to Test
Run the sample on the sample viewer and to test if the samples runs as expected
