### PR TITLE
Unify category names

### DIFF
--- a/kotlin/add-features-with-contingent-values/README.metadata.json
+++ b/kotlin/add-features-with-contingent-values/README.metadata.json
@@ -21,6 +21,9 @@
         "ContingentValuesResult"
     ],
     "language": "kotlin",
+    "redirect_from": [
+        "/android/latest/sample-code/add-features-with-contingent-values.htm"
+    ],
     "provision_from": [
         "https://www.arcgis.com/home/item.html?id=e12b54ea799f4606a2712157cf9f6e41",
         "https://www.arcgis.com/home/item.html?id=b5106355f1634b8996e634c04b6a930a"

--- a/kotlin/add-features-with-contingent-values/README.metadata.json
+++ b/kotlin/add-features-with-contingent-values/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Edit & Manage Data",
+    "category": "Edit and Manage Data",
     "description": "Create and add features whose attribute values satisfy a predefined set of contingencies.",
     "formal_name": "AddFeaturesWithContingentValues",
     "ignore": false,

--- a/kotlin/query-features-with-arcade-expression/README.metadata.json
+++ b/kotlin/query-features-with-arcade-expression/README.metadata.json
@@ -1,5 +1,5 @@
 {
-    "category": "Search and query",
+    "category": "Search and Query",
     "description": "Query features on a map using an Arcade expression.",
     "formal_name": "QueryFeaturesWithArcadeExpression",
     "ignore": false,


### PR DESCRIPTION
## Description

Corrects two additional categories which appear on the site due to case insensitivity or character difference.

<details><summary>See screenshot</summary>

![2022-09-14_17-08-47](https://user-images.githubusercontent.com/25207711/190284672-12cc4915-e79c-42d9-a4d3-216e42250561.png)

</details>