### PR TITLE
correct proper noun exception list

### DIFF
--- a/tools/CI/README_Metadata_StyleCheck/README_style_checker.py
+++ b/tools/CI/README_Metadata_StyleCheck/README_style_checker.py
@@ -8,8 +8,8 @@ import argparse
 
 # region Global sets
 # A set of words that get omitted during letter-case checks.
-exception_proper_nouns = {
-    'Arcade'
+exception_proper_nouns = [
+    'Arcade',
     'WmsLayer',
     'ArcGIS Online',
     'OAuth',
@@ -24,7 +24,7 @@ exception_proper_nouns = {
     'Open Street Map',
     'OpenStreetMap',
     'Play a KML Tour'
-}
+]
 
 # endregion
 


### PR DESCRIPTION
## Description

I noticed that the README styler checker script is causing an error for PR #1014:
```
1. kotlin/query-features-with-arcade-expression - Error title - Wrong letter case for word: "Arcade" in title.
```

This PR converts `exception_proper_nouns` from a dict to a list to make iterating through that list succeed on line 136 further below:
   ```py
   and word not in exception_proper_nouns:
   ```

It also adds a comma after the first list entry to avoid a syntax error.

## How to Test
After merging to `main`, this script should run successfully and allow the checker to complete without errors for #1014.

